### PR TITLE
Upgrade KSP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,8 +100,15 @@ jobs:
           path: ./**/build/reports/
 
   test-jvm-modules:
+    name: test-jvm-modules (KSP2=${{ matrix.use-ksp2 }})
+
     runs-on: ubuntu-latest
     timeout-minutes: 25
+
+    strategy:
+      fail-fast: false
+      matrix:
+        use-ksp2: [ true, false ]
 
     steps:
       - uses: actions/checkout@v4
@@ -112,13 +119,13 @@ jobs:
           gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Test
-        run: ./gradlew :kotlin-inject-extensions:contribute:impl-code-generators:test --stacktrace --show-version --continue
+        run: ./gradlew :kotlin-inject-extensions:contribute:impl-code-generators:test --stacktrace --show-version --continue -Pksp.useKSP2=${{ matrix.use-ksp2 }}
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
-          name: test-results-${{ github.job }}
+          name: test-results-${{ github.job }}-${{ matrix.use-ksp2 }}
           path: ./**/build/reports/
 
   test-emulator-renderer-android-view:

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -78,7 +78,6 @@ dependencies {
     implementation libs.ktfmt.gradle.plugin
     implementation libs.maven.publish.gradle.plugin
     implementation libs.detekt.gradle.plugin
-    implementation libs.build.config.gradle.plugin
     implementation "$GROUP:gradle-plugin:$VERSION_NAME"
 }
 

--- a/buildSrc/src/main/kotlin/software/amazon/app/platform/gradle/buildsrc/KmpPlugin.kt
+++ b/buildSrc/src/main/kotlin/software/amazon/app/platform/gradle/buildsrc/KmpPlugin.kt
@@ -1,6 +1,5 @@
 package software.amazon.app.platform.gradle.buildsrc
 
-import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.gradle.KspExtension
 import com.google.devtools.ksp.gradle.KspTask
 import com.ncorti.ktfmt.gradle.KtfmtExtension
@@ -179,8 +178,6 @@ public open class KmpPlugin : Plugin<Project> {
         "software.amazon.lastmile.kotlin.inject.anvil.processor." + "ContributesBindingProcessor",
         "disabled",
       )
-
-      @OptIn(KspExperimental::class) kspExtension.useKsp2.set(false)
 
       tasks.withType(KspTask::class.java).configureEach { kspTask ->
         if (kspTask is KotlinCompile) {

--- a/buildSrc/src/main/kotlin/software/amazon/app/platform/gradle/buildsrc/Plugins.kt
+++ b/buildSrc/src/main/kotlin/software/amazon/app/platform/gradle/buildsrc/Plugins.kt
@@ -5,7 +5,6 @@ internal object Plugins {
   const val ANDROID_LIBRARY = "com.android.library"
   const val APP_PLATFORM = "software.amazon.app.platform"
   const val BINARY_COMPAT_VALIDATOR = "org.jetbrains.kotlinx.binary-compatibility-validator"
-  const val BUILD_CONFIG = "com.github.gmazzo.buildconfig"
   const val COMPOSE_COMPILER = "org.jetbrains.kotlin.plugin.compose"
   const val COMPOSE_MULTIPLATFORM = "org.jetbrains.compose"
   const val DETEKT = "io.gitlab.arturbosch.detekt"

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ kotlin.mpp.enableCInteropCommonization=true
 kotlin.native.distribution.downloadFromMaven=true
 kotlin.native.enableKlibsCrossCompilation=true
 
-ksp.useKSP2=false
+ksp.useKSP2=true
 
 org.jetbrains.compose.experimental.uikit.enabled=true
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,11 +31,11 @@ kotlin-atomicfu = "0.27.0"
 kotlin-compile-testing = "0.7.0"
 kotlin-hierarchy = "1.1"
 kotlin-inject = "0.7.2"
-kotlin-inject-anvil = "0.1.3"
+kotlin-inject-anvil = "0.1.4"
 kotlin-poet = "2.1.0"
 kotlinx-binaryCompatibilityValidator = "0.17.0"
 ktfmt-gradle = "0.22.0"
-ksp = "2.1.20-1.0.32"
+ksp = "2.1.20-2.0.0"
 maven-publish = "0.31.0"
 molecule = "2.0.0"
 recyclerView = "1.2.1"
@@ -72,6 +72,7 @@ kotlin-atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "ko
 kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
 kotlin-compile-testing-core = { module = "dev.zacsweers.kctfork:core", version.ref = "kotlin-compile-testing" }
 kotlin-compile-testing-ksp = { module = "dev.zacsweers.kctfork:ksp", version.ref = "kotlin-compile-testing" }
+kotlin-compiler-embeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
 kotlin-compose-gradle-plugin = { module = "org.jetbrains.kotlin.plugin.compose:org.jetbrains.kotlin.plugin.compose.gradle.plugin", version.ref = "kotlin" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-gradle-plugin-api = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin" }
@@ -90,6 +91,7 @@ kotlin-poet-ksp = { module = "com.squareup:kotlinpoet-ksp", version.ref = "kotli
 ktfmt-gradle-plugin = { module = "com.ncorti.ktfmt.gradle:plugin", version.ref = "ktfmt-gradle" }
 ksp = { module = "com.google.devtools.ksp:symbol-processing", version.ref = "ksp" }
 ksp-api = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
+ksp-embeddable = { module = "com.google.devtools.ksp:symbol-processing-aa-embeddable", version.ref = "ksp" }
 ksp-gradle-plugin = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin", version.ref = "ksp" }
 maven-publish-gradle-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "maven-publish" }
 molecule-runtime = { module = "app.cash.molecule:molecule-runtime", version.ref = "molecule" }
@@ -107,7 +109,7 @@ app-platform = { id = "software.amazon.app.platform" }
 build-config = { id = "com.github.gmazzo.buildconfig", version.ref = "build-config" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 kotlin-atomicfu = { id = "org.jetbrains.kotlinx.atomicfu", version.ref = "kotlin-atomicfu" }
-#kotlin-hierarchy = { id = "io.github.terrakok.kmp-hierarchy", version.ref = "kotlin-hierarchy" }
+kotlin-hierarchy = { id = "io.github.terrakok.kmp-hierarchy", version.ref = "kotlin-hierarchy" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlinx-binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "kotlinx-binaryCompatibilityValidator" }
 ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt-gradle" }

--- a/kotlin-inject-extensions/contribute/impl-code-generators/build.gradle
+++ b/kotlin-inject-extensions/contribute/impl-code-generators/build.gradle
@@ -1,6 +1,8 @@
 plugins {
     id 'software.amazon.app.platform.lib.jvm'
     id 'com.google.devtools.ksp'
+
+    alias(libs.plugins.build.config)
 }
 
 appPlatformBuildSrc {
@@ -41,7 +43,19 @@ dependencies {
     testImplementation libs.kotlin.inject.anvil.compiler
 
     // Bump transitive dependency.
+    testImplementation libs.kotlin.compiler.embeddable
     testImplementation libs.ksp
+    testImplementation libs.ksp.embeddable
+}
+
+buildConfig {
+    useKotlinOutput {
+        internalVisibility = false
+    }
+
+    sourceSets.named("test") {
+        buildConfigField(boolean, 'USE_KSP_2', providers.gradleProperty('ksp.useKSP2').get().toBoolean())
+    }
 }
 
 // We don't need the apiCheck in this module.

--- a/kotlin-inject-extensions/contribute/impl-code-generators/src/main/kotlin/software/amazon/app/platform/inject/processor/ContributesRendererProcessor.kt
+++ b/kotlin-inject-extensions/contribute/impl-code-generators/src/main/kotlin/software/amazon/app/platform/inject/processor/ContributesRendererProcessor.kt
@@ -116,7 +116,21 @@ internal class ContributesRendererProcessor(
     }
 
     val includeSealedSubtypes =
-      clazz.getAnnotationsByType(ContributesRenderer::class).single().includeSealedSubtypes
+      try {
+        clazz.getAnnotationsByType(ContributesRenderer::class).single().includeSealedSubtypes
+      } catch (_: NoSuchElementException) {
+        /*
+        Caused by: java.util.NoSuchElementException: Collection contains no element matching the predicate.
+          at com.google.devtools.ksp.UtilsKt.createInvocationHandler$lambda$8(utils.kt:591)
+          at jdk.proxy105/jdk.proxy105.$Proxy1029.includeSealedSubtypes(Unknown Source)
+          at software.amazon.app.platform.inject.processor.ContributesRendererProcessor.generateComponentInterface(ContributesRendererProcessor.kt:120)
+
+        We're seeing this exception when trying to read 'includeSealedSubtypes' for an annotation
+        where the value is not declared, e.g. '@ContributesRenderer' (without any arguments).
+        This happens only on iOS for some reason. Fallback to the default value 'true'.
+         */
+        true
+      }
 
     val allModels =
       if (includeSealedSubtypes) {

--- a/kotlin-inject-extensions/contribute/impl-code-generators/src/test/kotlin/software/amazon/app/platform/inject/Compilation.kt
+++ b/kotlin-inject-extensions/contribute/impl-code-generators/src/test/kotlin/software/amazon/app/platform/inject/Compilation.kt
@@ -2,6 +2,7 @@
 
 package software.amazon.app.platform.inject
 
+import app_platform.kotlin_inject_extensions.contribute.impl_code_generators.TestBuildConfig.USE_KSP_2
 import assertk.assertThat
 import com.google.devtools.ksp.processing.SymbolProcessorProvider
 import com.tschuchort.compiletesting.JvmCompilationResult
@@ -32,7 +33,7 @@ class Compilation internal constructor(val kotlinCompilation: KotlinCompilation)
 
     processorsConfigured = true
 
-    val useKsp2 = false
+    val useKsp2 = USE_KSP_2
 
     if (!useKsp2) {
       kotlinCompilation.languageVersion = "1.9"

--- a/presenter-molecule/impl/build.gradle
+++ b/presenter-molecule/impl/build.gradle
@@ -14,3 +14,22 @@ dependencies {
     commonTestImplementation project(':kotlin-inject:impl')
     commonTestImplementation libs.kotlin.inject.runtime.kmp
 }
+
+ksp {
+    // Caused by: ksp.org.jetbrains.kotlin.analysis.api.lifetime.KaInvalidLifetimeOwnerAccessException: Access to invalid ksp.org.jetbrains.kotlin.analysis.api.platform.lifetime.KotlinAlwaysAccessibleLifetimeToken@33adf999: PSI has changed since creation
+    //        at ksp.org.jetbrains.kotlin.analysis.api.fir.symbols.KaFirNamedFunctionSymbol.getPsi(KaFirNamedFunctionSymbol.kt:247)
+    //        at com.google.devtools.ksp.impl.symbol.kotlin.UtilKt.toContainingFile(util.kt:237)
+    //        at com.google.devtools.ksp.impl.symbol.kotlin.AbstractKSDeclarationImpl$containingFile$2.invoke(AbstractKSDeclarationImpl.kt:79)
+    //        at com.google.devtools.ksp.impl.symbol.kotlin.AbstractKSDeclarationImpl$containingFile$2.invoke(AbstractKSDeclarationImpl.kt:78)
+    //        at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:83)
+    //        at com.google.devtools.ksp.impl.symbol.kotlin.AbstractKSDeclarationImpl.getContainingFile(AbstractKSDeclarationImpl.kt:78)
+    //        at me.tatarka.kotlin.ast.KSAstProvider.addOriginatingElement(KSAst.kt:94)
+    //        at me.tatarka.inject.compiler.KmpComponentCreateGenerator.generate(KmpComponentCreateGenerator.kt:27)
+    //        at me.tatarka.inject.compiler.ksp.ProcessKmpComponentCreateKt.generateKmpComponentCreateFiles(ProcessKmpComponentCreate.kt:40)
+    //        at me.tatarka.inject.compiler.ksp.InjectProcessor.finish(InjectProcessor.kt:113)
+    //
+    // Unfortunately, for this module KSP2 needs to be disabled due to this crash.
+    //
+    // TODO: Resolve the bug in kotlin-inject.
+    useKsp2.set(false)
+}


### PR DESCRIPTION
Upgrade KSP to the latest stable build, which turns on KSP2 by default. Therefore, turn on KSP2 by default for App Platform as well.

