### PR TITLE
Set the POM name

### DIFF
--- a/buildSrc/src/main/kotlin/software/amazon/app/platform/gradle/buildsrc/SdkPlugin.kt
+++ b/buildSrc/src/main/kotlin/software/amazon/app/platform/gradle/buildsrc/SdkPlugin.kt
@@ -31,6 +31,14 @@ internal object SdkPlugin {
         artifactId()
       }
     mavenPublish.coordinates(artifactId = artifactId)
+    mavenPublish.pom { pom ->
+      pom.name.set(
+        "App Platform ${
+        artifactId.split('-')
+          .joinToString(separator = " ", prefix = "", postfix = "") { it.capitalize() }
+      }"
+      )
+    }
   }
 
   private fun Project.configureBinaryCompatibility() {

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -15,6 +15,12 @@ ktfmt {
     removeUnusedImports.set(true)
 }
 
+mavenPublishing {
+    pom {
+        name = "App Platform Gradle Plugin"
+    }
+}
+
 gradlePlugin {
     plugins {
         appPlatformPlugin {


### PR DESCRIPTION
Set the POM name for all published artifacts. This was missing and is required for publishing.

