### PR TITLE
Enable strict validation for the gradle plugin

### DIFF
--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -76,6 +76,10 @@ kotlin {
     explicitApi()
 }
 
+tasks.withType(ValidatePlugins).configureEach {
+    it.enableStricterValidation = true
+}
+
 tasks.withType(io.gitlab.arturbosch.detekt.Detekt).configureEach {
     it.jvmTarget = libs.versions.jvm.compatibility.get()
     it.setSource(layout.files("src"))

--- a/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/ModuleStructureDependencyCheckTask.kt
+++ b/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/ModuleStructureDependencyCheckTask.kt
@@ -7,12 +7,14 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ExternalDependency
 import org.gradle.api.artifacts.ProjectDependency
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
 /** Checks that our module structure dependency rules are followed. */
+@CacheableTask
 public abstract class ModuleStructureDependencyCheckTask : DefaultTask() {
 
   /** The path of this module, e.g. `:presenter:public`. */


### PR DESCRIPTION
This also fixes the existing issue flagged by this validation of missing @CacheableTask on ModuleStructureDependencyCheckTask.

Test: ./gradlew gradle-plugin:check

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
