### PR TITLE
Deprecate `onEvent`

### DIFF
--- a/docs/presenter.md
+++ b/docs/presenter.md
@@ -109,15 +109,12 @@ class AmazonLoginPresenter : LoginPresenter {
   fun present(input: Unit): Model {
     ..
     return if (user != null) {
-      LoggedIn(
-        user = user,
-        onEvent = onEvent { event ->
-          when(event) {
-            is Logout -> ..
-            is ChangeName -> ..
-          }
+      LoggedIn(user = user) { event ->
+        when (event) {
+          is Logout -> ..
+          is ChangeName -> ..
         }
-      )
+      }
     } else {
       LoggedOut
     }
@@ -131,23 +128,6 @@ class AmazonLoginPresenter : LoginPresenter {
     automatically bind the concrete implementation to an API using `@ContributesBinding`, they don't use the
     `@SingleIn` annotation. `MoleculePresenters` manage their state in the `@Composable` function with the Compose
     runtime. Therefore, it's strongly discouraged to have any class properties.
-
-!!! warning
-
-    Notice that the lambda for `onEvent` is wrapped in the [`onEvent` function](https://github.com/amzn/app-platform/blob/main/presenter-molecule/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/OnEvent.kt).
-
-    ```kotlin hl_lines="1"
-    onEvent = onEvent { event ->
-      when(event) {
-        is Logout -> ..
-        is ChangeName -> ..
-      }
-    }
-    ```
-
-    This is important for `data classes` in order to preserve equality. Internally, the `onEvent` function creates
-    and reuses a separate lambda to ensure that `BaseModel` instances holding the same data are still considered
-    equal although the `onEvent` lambda has changed between compositions.
 
 ## Model driven navigation
 
@@ -470,12 +450,11 @@ fun present(input: Unit): Model {
 
   return Model(
     text = if (toggled) "toggled" else "not toggled",
-    onEvent = onEvent {
-      when(it) {
-        is ToggleClicked -> toggled = !toggled
-      }
+  ) {
+    when (it) {
+      is ToggleClicked -> toggled = !toggled
     }
-  )
+  }
 }
 ```
 
@@ -533,13 +512,11 @@ This is an example for how one would use `rememberCoroutineScope()`:
 fun present(input: Unit): Model {
   val coroutineScope = rememberCoroutineScope()
 
-  return Model(
-    onEvent = onEvent {
-      when(it) {
-        is OnClick -> coroutineScope.launch { ... }
-      }
+  return Model() {
+    when (it) {
+      is OnClick -> coroutineScope.launch { ... }
     }
-  )
+  }
 }
 ```
 

--- a/docs/renderer.md
+++ b/docs/renderer.md
@@ -350,7 +350,7 @@ class LoginRendererTest {
     runComposeUiTest {
       setContent {
         val renderer = LoginRenderer()
-        renderer.renderCompose(LoginPresenter.Model(loginInProgress = false, onEvent = {}))
+        renderer.renderCompose(LoginPresenter.Model(loginInProgress = false) {})
       }
 
       onNodeWithTag("loginProgress").assertDoesNotExist()

--- a/presenter-molecule/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/MoleculePresenter.kt
+++ b/presenter-molecule/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/MoleculePresenter.kt
@@ -37,9 +37,7 @@ import software.amazon.app.platform.presenter.Presenter
  * ```
  *
  * If a consumer like the UI layer should be able to send events back to the presenter, then the
- * [BaseModel] implementation typically has an `onEvent` callback lambda as last parameter. To
- * preserve equality checks of [BaseModel] instances, it's strongly recommended to wrap the lambda
- * with [onEvent]:
+ * [BaseModel] implementation typically has an `onEvent` callback lambda as last parameter:
  * ```
  * @Inject
  * class MyPresenter : MoleculePresenter<Unit, Model> {
@@ -49,17 +47,14 @@ import software.amazon.app.platform.presenter.Presenter
  *         var myData by remember { mutableStateOf("") }
  *
  *         ...
- *         return Model(
- *             ...,
- *             onEvent = onEvent { event ->
- *                 when (event) {
- *                     is MyEvent -> {
- *                         // This will trigger recomposition and a new Model will be produced.
- *                         myData = event.moreData
- *                     }
+ *         return Model(...) { event ->
+ *             when (event) {
+ *                 is MyEvent -> {
+ *                     // This will trigger recomposition and a new Model will be produced.
+ *                     myData = event.moreData
  *                 }
  *             }
- *         )
+ *         }
  *     }
  *
  *     data class Model(

--- a/presenter-molecule/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/OnEvent.kt
+++ b/presenter-molecule/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/OnEvent.kt
@@ -53,6 +53,7 @@ import software.amazon.app.platform.presenter.BaseModel
  */
 @Suppress("unused", "UnusedReceiverParameter")
 @Composable
+@Deprecated("This function isn't needed anymore and can be removed")
 public fun <EventT : Any> MoleculePresenter<*, *>.onEvent(
   handler: @DisallowComposableCalls suspend (EventT) -> Unit
 ): (EventT) -> Unit {

--- a/presenter-molecule/public/src/commonTest/kotlin/software/amazon/app/platform/presenter/molecule/OnEventMemoizationTest.kt
+++ b/presenter-molecule/public/src/commonTest/kotlin/software/amazon/app/platform/presenter/molecule/OnEventMemoizationTest.kt
@@ -1,0 +1,203 @@
+package software.amazon.app.platform.presenter.molecule
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DontMemoize
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import software.amazon.app.platform.presenter.BaseModel
+
+class OnEventMemoizationTest {
+
+  @Test
+  fun `onEvent lambda is memoized for different inputs`() = runTest {
+    var presentCalls = 0
+
+    val presenter =
+      object : MoleculePresenter<Int, Model> {
+        @Composable
+        override fun present(input: Int): Model {
+          presentCalls++
+
+          return Model(string = if (input == 0) "A" else "B") {}
+        }
+      }
+
+    val inputs = MutableStateFlow(0)
+
+    presenter.test(this, inputs) {
+      assertThat(awaitItem().string).isEqualTo("A")
+      assertThat(presentCalls).isEqualTo(1)
+
+      inputs.value = 1
+      assertThat(awaitItem().string).isEqualTo("B")
+      assertThat(presentCalls).isEqualTo(2)
+
+      inputs.value = 2
+      runCurrent()
+      expectNoEvents()
+      assertThat(presentCalls).isEqualTo(3)
+
+      inputs.value = 3
+      runCurrent()
+      expectNoEvents()
+      assertThat(presentCalls).isEqualTo(4)
+
+      // This verifies that the presenter recomposes and a new Model is returned. But due to the
+      // strong skipping mode and lambda memoization the new model is equal and no update emitted.
+      inputs.value = 0
+      assertThat(awaitItem().string).isEqualTo("A")
+      assertThat(presentCalls).isEqualTo(5)
+    }
+  }
+
+  @Test
+  fun `onEvent lambda is memoized for state changes`() = runTest {
+    var presentCalls = 0
+
+    var state by mutableIntStateOf(0)
+
+    val presenter =
+      object : MoleculePresenter<Unit, Model> {
+        @Composable
+        override fun present(input: Unit): Model {
+          presentCalls++
+
+          return Model(string = if (state == 0) "A" else "B") {}
+        }
+      }
+
+    presenter.test(this) {
+      assertThat(awaitItem().string).isEqualTo("A")
+      assertThat(presentCalls).isEqualTo(1)
+
+      state = 1
+      assertThat(awaitItem().string).isEqualTo("B")
+      assertThat(presentCalls).isEqualTo(2)
+
+      state = 2
+      runCurrent()
+      expectNoEvents()
+      assertThat(presentCalls).isEqualTo(3)
+
+      state = 3
+      runCurrent()
+      expectNoEvents()
+      assertThat(presentCalls).isEqualTo(4)
+
+      // This verifies that the presenter recomposes and a new Model is returned. But due to the
+      // strong skipping mode and lambda memoization the new model is equal and no update emitted.
+      state = 0
+      assertThat(awaitItem().string).isEqualTo("A")
+      assertThat(presentCalls).isEqualTo(5)
+    }
+  }
+
+  @Test
+  fun `onEvent lambda is memoized for onEvent callbacks`() = runTest {
+    var presentCalls = 0
+
+    val presenter =
+      object : MoleculePresenter<Unit, Model> {
+        @Composable
+        override fun present(input: Unit): Model {
+          presentCalls++
+
+          var state by remember { mutableIntStateOf(0) }
+
+          return Model(string = if (state == 0) "A" else "B") { state = it.value }
+        }
+      }
+
+    presenter.test(this) {
+      var model = awaitItem()
+      assertThat(model.string).isEqualTo("A")
+      assertThat(presentCalls).isEqualTo(1)
+
+      model.onEvent(Event(1))
+
+      model = awaitItem()
+      assertThat(model.string).isEqualTo("B")
+      assertThat(presentCalls).isEqualTo(2)
+
+      model.onEvent(Event(2))
+      runCurrent()
+      expectNoEvents()
+      assertThat(presentCalls).isEqualTo(3)
+
+      model.onEvent(Event(3))
+      runCurrent()
+      expectNoEvents()
+      assertThat(presentCalls).isEqualTo(4)
+
+      // This verifies that the presenter recomposes and a new Model is returned. But due to the
+      // strong skipping mode and lambda memoization the new model is equal and no update emitted.
+      model.onEvent(Event(0))
+      assertThat(awaitItem().string).isEqualTo("A")
+      assertThat(presentCalls).isEqualTo(5)
+    }
+  }
+
+  @Test
+  fun `a new model is produced when memoization is disabled`() = runTest {
+    var presentCalls = 0
+
+    val presenter =
+      object : MoleculePresenter<Unit, Model> {
+        @Composable
+        override fun present(input: Unit): Model {
+          presentCalls++
+
+          var state by remember { mutableIntStateOf(0) }
+
+          return Model(
+            string = if (state == 0) "A" else "B",
+            onEvent = @DontMemoize { state = it.value },
+          )
+        }
+      }
+
+    presenter.test(this) {
+      var model = awaitItem()
+      assertThat(model.string).isEqualTo("A")
+      assertThat(presentCalls).isEqualTo(1)
+
+      model.onEvent(Event(1))
+
+      model = awaitItem()
+      assertThat(model.string).isEqualTo("B")
+      assertThat(presentCalls).isEqualTo(2)
+
+      model.onEvent(Event(2))
+
+      runCurrent()
+      model = awaitItem()
+      assertThat(model.string).isEqualTo("B")
+      assertThat(presentCalls).isEqualTo(3)
+
+      model.onEvent(Event(3))
+
+      runCurrent()
+      model = awaitItem()
+      assertThat(model.string).isEqualTo("B")
+      assertThat(presentCalls).isEqualTo(4)
+
+      // This verifies that the presenter recomposes and a new Model is returned. But due to the
+      // strong skipping mode and lambda memoization the new model is equal and no update emitted.
+      model.onEvent(Event(0))
+      assertThat(awaitItem().string).isEqualTo("A")
+      assertThat(presentCalls).isEqualTo(5)
+    }
+  }
+
+  private data class Event(val value: Int)
+
+  private data class Model(val string: String, val onEvent: (Event) -> Unit) : BaseModel
+}

--- a/presenter-molecule/public/src/commonTest/kotlin/software/amazon/app/platform/presenter/molecule/OnEventTest.kt
+++ b/presenter-molecule/public/src/commonTest/kotlin/software/amazon/app/platform/presenter/molecule/OnEventTest.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import software.amazon.app.platform.presenter.BaseModel
 
+@Suppress("DEPRECATION")
 @OptIn(ExperimentalCoroutinesApi::class)
 class OnEventTest {
 
@@ -325,7 +326,7 @@ class OnEventTest {
       BaseModel
 
     sealed interface Event {
-      object AnyEvent : Event
+      data object AnyEvent : Event
     }
   }
 
@@ -347,7 +348,7 @@ class OnEventTest {
     data class Model(val onEventInvoked: Int, val onEvent: (Event) -> Unit) : BaseModel
 
     sealed interface Event {
-      object AnyEvent : Event
+      data object AnyEvent : Event
     }
   }
 

--- a/sample/login/impl/src/appleAndDesktopTest/kotlin/software/amazon/app/platform/sample/login/LoginRendererTest.kt
+++ b/sample/login/impl/src/appleAndDesktopTest/kotlin/software/amazon/app/platform/sample/login/LoginRendererTest.kt
@@ -20,7 +20,7 @@ class LoginRendererTest {
     runComposeUiTest {
       setContent {
         val renderer = LoginRenderer()
-        renderer.renderCompose(LoginPresenter.Model(loginInProgress = false, onEvent = {}))
+        renderer.renderCompose(LoginPresenter.Model(loginInProgress = false) {})
       }
 
       onNodeWithTag("loginProgress").assertDoesNotExist()
@@ -33,7 +33,7 @@ class LoginRendererTest {
     runComposeUiTest {
       setContent {
         val renderer = LoginRenderer()
-        renderer.renderCompose(LoginPresenter.Model(loginInProgress = true, onEvent = {}))
+        renderer.renderCompose(LoginPresenter.Model(loginInProgress = true) {})
       }
 
       onNodeWithTag("loginProgress").assertIsDisplayed()

--- a/sample/login/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/login/LoginPresenterImpl.kt
+++ b/sample/login/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/login/LoginPresenterImpl.kt
@@ -10,7 +10,6 @@ import kotlin.random.Random
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
 import me.tatarka.inject.annotations.Inject
-import software.amazon.app.platform.presenter.molecule.onEvent
 import software.amazon.app.platform.sample.login.LoginPresenter.Model
 import software.amazon.app.platform.sample.user.UserManager
 import software.amazon.lastmile.kotlin.inject.anvil.AppScope
@@ -33,16 +32,12 @@ class LoginPresenterImpl(private val userManager: UserManager) : LoginPresenter 
       }
     }
 
-    return Model(
-      loginInProgress = loginInProgress,
-      onEvent =
-        onEvent {
-          when (it) {
-            is LoginPresenter.Event.Login -> {
-              loginInProgress = true
-            }
-          }
-        },
-    )
+    return Model(loginInProgress = loginInProgress) {
+      when (it) {
+        is LoginPresenter.Event.Login -> {
+          loginInProgress = true
+        }
+      }
+    }
   }
 }

--- a/sample/navigation/impl/src/commonTest/kotlin/software/amazon/app/platform/sample/navigation/NavigationPresenterImplTest.kt
+++ b/sample/navigation/impl/src/commonTest/kotlin/software/amazon/app/platform/sample/navigation/NavigationPresenterImplTest.kt
@@ -6,7 +6,6 @@ import assertk.assertions.isInstanceOf
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
 import software.amazon.app.platform.presenter.BaseModel
-import software.amazon.app.platform.presenter.molecule.onEvent
 import software.amazon.app.platform.presenter.molecule.test
 import software.amazon.app.platform.sample.login.LoginPresenter
 import software.amazon.app.platform.sample.user.FakeUserManager
@@ -45,7 +44,7 @@ class NavigationPresenterImplTest {
   private class FakeLoginPresenter : LoginPresenter {
     @Composable
     override fun present(input: Unit): LoginPresenter.Model =
-      LoginPresenter.Model(loginInProgress = false, onEvent = onEvent {})
+      LoginPresenter.Model(loginInProgress = false) {}
   }
 
   private class FakeUserPagePresenter : UserPagePresenter {

--- a/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserPageListPresenter.kt
+++ b/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserPageListPresenter.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.setValue
 import me.tatarka.inject.annotations.Inject
 import software.amazon.app.platform.presenter.BaseModel
 import software.amazon.app.platform.presenter.molecule.MoleculePresenter
-import software.amazon.app.platform.presenter.molecule.onEvent
 import software.amazon.app.platform.sample.user.UserPageListPresenter.Input
 import software.amazon.app.platform.sample.user.UserPageListPresenter.Model
 
@@ -26,16 +25,14 @@ class UserPageListPresenter(private val sessionTimeout: SessionTimeout) :
       userId = user.userId,
       attributeKeys = user.attributes.map { it.key },
       selectedIndex = selectedIndex,
-      onEvent =
-        onEvent {
-          when (it) {
-            is Event.ItemSelected -> {
-              sessionTimeout.resetTimeout()
-              selectedIndex = it.index
-            }
-          }
-        },
-    )
+    ) {
+      when (it) {
+        is Event.ItemSelected -> {
+          sessionTimeout.resetTimeout()
+          selectedIndex = it.index
+        }
+      }
+    }
   }
 
   /** The state of the list pane. */


### PR DESCRIPTION
With lambda memoization and the Strong Skipping mode becoming the default in Kotlin 2.0.20 our workaround to memoize lambdas through the `onEvent` function is no longer needed. This change deprecates the function and removes it from the documentation.

Fixes #28
