### PR TITLE
Fix status bar overdraw

### DIFF
--- a/sample/app/src/androidMain/kotlin/software/amazon/app/platform/sample/MainActivity.kt
+++ b/sample/app/src/androidMain/kotlin/software/amazon/app/platform/sample/MainActivity.kt
@@ -2,6 +2,7 @@ package software.amazon.app.platform.sample
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -25,6 +26,8 @@ class MainActivity : ComponentActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    enableEdgeToEdge()
+
     setContentView(R.layout.activity_main)
 
     val rendererFactory =

--- a/sample/templates/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/template/ComposeSampleAppTemplateRenderer.kt
+++ b/sample/templates/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/template/ComposeSampleAppTemplateRenderer.kt
@@ -1,7 +1,11 @@
 package software.amazon.app.platform.sample.template
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import me.tatarka.inject.annotations.Inject
@@ -24,9 +28,11 @@ class ComposeSampleAppTemplateRenderer(private val rendererFactory: RendererFact
 
   @Composable
   override fun Compose(model: SampleAppTemplate) {
-    when (model) {
-      is SampleAppTemplate.FullScreenTemplate -> FullScreen(model)
-      is SampleAppTemplate.ListDetailTemplate -> ListDetail(model)
+    Box(Modifier.windowInsetsPadding(WindowInsets.safeDrawing)) {
+      when (model) {
+        is SampleAppTemplate.FullScreenTemplate -> FullScreen(model)
+        is SampleAppTemplate.ListDetailTemplate -> ListDetail(model)
+      }
     }
   }
 


### PR DESCRIPTION
Starting with Android API 35, [edge-to-edge is enforced](https://developer.android.com/about/versions/15/behavior-changes-15#edge-to-edge) and content is drawn behind system bars. This looks broken in the sample application.

| Broken    | Fixed |
| -------- | ------- |
| ![Broken](https://github.com/user-attachments/assets/44294a01-8509-4d28-8e64-b6a7685ea2d0)    | ![Fixed](https://github.com/user-attachments/assets/a7e0fdf9-2b5a-4680-8b5f-4a1c483c4175)    |
