### PR TITLE
Fullscreen profile picture

### DIFF
--- a/sample/navigation/impl/src/commonTest/kotlin/software/amazon/app/platform/sample/navigation/NavigationPresenterImplTest.kt
+++ b/sample/navigation/impl/src/commonTest/kotlin/software/amazon/app/platform/sample/navigation/NavigationPresenterImplTest.kt
@@ -50,9 +50,9 @@ class NavigationPresenterImplTest {
   private class FakeUserPagePresenter : UserPagePresenter {
     @Composable
     override fun present(input: Unit): UserPagePresenter.Model =
-      UserPagePresenter.Model(
-        listModel = object : BaseModel {},
-        detailModel = object : BaseModel {},
-      )
+      object : UserPagePresenter.Model {
+        override val listModel: BaseModel = object : BaseModel {}
+        override val detailModel: BaseModel = object : BaseModel {}
+      }
   }
 }

--- a/sample/user/impl/build.gradle
+++ b/sample/user/impl/build.gradle
@@ -15,6 +15,7 @@ appPlatform {
 }
 
 dependencies {
+    commonMainImplementation project(':sample:templates:public')
     commonTestImplementation project(':sample:user:testing')
 }
 

--- a/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserPageDetailPresenter.kt
+++ b/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserPageDetailPresenter.kt
@@ -3,6 +3,9 @@ package software.amazon.app.platform.sample.user
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import me.tatarka.inject.annotations.Inject
 import software.amazon.app.platform.presenter.BaseModel
 import software.amazon.app.platform.presenter.molecule.MoleculePresenter
@@ -18,11 +21,20 @@ class UserPageDetailPresenter(private val sessionTimeout: SessionTimeout) :
   override fun present(input: Input): Model {
     val timeout by sessionTimeout.sessionTimeout.collectAsState()
 
+    var showPictureFullscreen by remember { mutableStateOf(false) }
+
     return Model(
       text = input.user.attributes[input.selectedAttribute].value,
       pictureKey = input.user.attributes.single { it.key == User.Attribute.PICTURE_KEY }.value,
       timeoutProgress = (timeout / SessionTimeout.initialTimeout).toFloat(),
-    )
+      showPictureFullscreen = showPictureFullscreen,
+    ) {
+      when (it) {
+        Event.ProfilePictureClick -> {
+          showPictureFullscreen = !showPictureFullscreen
+        }
+      }
+    }
   }
 
   /** The state of the detail pane. */
@@ -33,7 +45,17 @@ class UserPageDetailPresenter(private val sessionTimeout: SessionTimeout) :
     val pictureKey: String,
     /** The progress until when current user is logged out. The value is between [0, 1]. */
     val timeoutProgress: Float,
+    /** If this value is true, then the profile picture is shown in full screen. */
+    val showPictureFullscreen: Boolean,
+    /** Callback to send events back to the presenter. */
+    val onEvent: (Event) -> Unit,
   ) : BaseModel
+
+  /** All events that [UserPageDetailPresenter] can process. */
+  sealed interface Event {
+    /** Sent when the user taps on the profile picture. */
+    data object ProfilePictureClick : Event
+  }
 
   /**
    * The input type of the presenter. [user] is the currently logged in user. [selectedAttribute] is

--- a/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserPageDetailRenderer.kt
+++ b/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserPageDetailRenderer.kt
@@ -2,9 +2,13 @@ package software.amazon.app.platform.sample.user
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.CircleShape
@@ -12,9 +16,11 @@ import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import app_platform.sample.user.impl.generated.resources.Res
@@ -26,12 +32,21 @@ import software.amazon.app.platform.renderer.ComposeRenderer
 import software.amazon.app.platform.sample.user.UserPageDetailPresenter.Model
 
 /** Renders the content for [UserPageDetailPresenter] on screen using Compose Multiplatform. */
+@OptIn(ExperimentalResourceApi::class)
 @ContributesRenderer
 class UserPageDetailRenderer : ComposeRenderer<Model>() {
 
-  @OptIn(ExperimentalResourceApi::class)
   @Composable
   override fun Compose(model: Model) {
+    if (model.showPictureFullscreen) {
+      ProfilePicture(model)
+    } else {
+      ProfileDetails(model)
+    }
+  }
+
+  @Composable
+  private fun ProfileDetails(model: Model) {
     Column(modifier = Modifier.fillMaxWidth().fillMaxHeight()) {
       LinearProgressIndicator(progress = model.timeoutProgress, modifier = Modifier.fillMaxWidth())
 
@@ -48,7 +63,8 @@ class UserPageDetailRenderer : ComposeRenderer<Model>() {
               spotColor = MaterialTheme.colors.primary,
             )
             .clip(CircleShape) // clip to the circle shape
-            .border(2.dp, MaterialTheme.colors.primary, CircleShape),
+            .clickable { model.onEvent(UserPageDetailPresenter.Event.ProfilePictureClick) }
+            .border(2.dp, MaterialTheme.colors.primary, shape = CircleShape),
       )
 
       AnimatedContent(targetState = model.text) { text ->
@@ -59,6 +75,20 @@ class UserPageDetailRenderer : ComposeRenderer<Model>() {
           modifier = Modifier.fillMaxWidth().padding(16.dp),
         )
       }
+    }
+  }
+
+  @Composable
+  private fun ProfilePicture(model: Model) {
+    Row(Modifier.background(Color.Black).fillMaxSize()) {
+      Image(
+        painter = painterResource(Res.allDrawableResources.getValue(model.pictureKey)),
+        contentDescription = "Profile picture",
+        modifier =
+          Modifier.clickable { model.onEvent(UserPageDetailPresenter.Event.ProfilePictureClick) }
+            .align(Alignment.CenterVertically)
+            .clip(CircleShape),
+      )
     }
   }
 }

--- a/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserPagePresenterImpl.kt
+++ b/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserPagePresenterImpl.kt
@@ -2,7 +2,10 @@ package software.amazon.app.platform.sample.user
 
 import androidx.compose.runtime.Composable
 import me.tatarka.inject.annotations.Inject
+import software.amazon.app.platform.presenter.BaseModel
+import software.amazon.app.platform.presenter.template.ModelDelegate
 import software.amazon.app.platform.renderer.Renderer
+import software.amazon.app.platform.sample.template.SampleAppTemplate
 import software.amazon.app.platform.sample.user.UserPagePresenter.Model
 import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
 
@@ -27,12 +30,29 @@ class UserPagePresenterImpl(
   override fun present(input: Unit): Model {
     // Note that listModel provides further input for the detail presenter.
     val listModel = userPageListPresenter.present(UserPageListPresenter.Input(user))
-    return Model(
-      listModel = listModel,
-      detailModel =
-        userPageDetailPresenter.present(
-          UserPageDetailPresenter.Input(user, selectedAttribute = listModel.selectedIndex)
-        ),
-    )
+    val detailModel =
+      userPageDetailPresenter.present(
+        UserPageDetailPresenter.Input(user, selectedAttribute = listModel.selectedIndex)
+      )
+
+    return ModelImpl(listModel = listModel, detailModel = detailModel)
+  }
+
+  /**
+   * This class implements [ModelDelegate] to override which [SampleAppTemplate] to use. This Model
+   * hosts to other models [listModel] and [detailModel], which will be produced by child
+   * presenters.
+   */
+  private data class ModelImpl(
+    override val listModel: UserPageListPresenter.Model,
+    override val detailModel: UserPageDetailPresenter.Model,
+  ) : Model, ModelDelegate {
+    override fun delegate(): BaseModel {
+      return if (detailModel.showPictureFullscreen) {
+        SampleAppTemplate.FullScreenTemplate(detailModel)
+      } else {
+        SampleAppTemplate.ListDetailTemplate(listModel, detailModel)
+      }
+    }
   }
 }

--- a/sample/user/public/build.gradle
+++ b/sample/user/public/build.gradle
@@ -12,7 +12,3 @@ appPlatform {
     enableModuleStructure true
     enableMoleculePresenters true
 }
-
-dependencies {
-    commonMainImplementation project(':sample:templates:public')
-}

--- a/sample/user/public/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserPagePresenter.kt
+++ b/sample/user/public/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserPagePresenter.kt
@@ -3,21 +3,21 @@ package software.amazon.app.platform.sample.user
 import software.amazon.app.platform.presenter.BaseModel
 import software.amazon.app.platform.presenter.molecule.MoleculePresenter
 import software.amazon.app.platform.presenter.template.ModelDelegate
-import software.amazon.app.platform.sample.template.SampleAppTemplate
 import software.amazon.app.platform.sample.user.UserPagePresenter.Model
 
 /** Presenter to render user details on screen. */
 interface UserPagePresenter : MoleculePresenter<Unit, Model> {
 
   /**
-   * The state of the user page. Note that this class implements [ModelDelegate] to override which
-   * [SampleAppTemplate] to use. This Model hosts to other models [listModel] and [detailModel],
-   * which will be produced by child presenters.
+   * The state of the user page. Note that the actual implementation class implements
+   * [ModelDelegate] to override which `SampleAppTemplate` to use. This Model hosts to other models
+   * [listModel] and [detailModel], which will be produced by child presenters.
+   *
+   * This class is an interface and not the final `data class`, because the actual implementation
+   * contains more logic, which was moved therefore into the :impl module.
    */
-  data class Model(val listModel: BaseModel, val detailModel: BaseModel) :
-    BaseModel, ModelDelegate {
-    override fun delegate(): BaseModel {
-      return SampleAppTemplate.ListDetailTemplate(listModel, detailModel)
-    }
+  interface Model : BaseModel {
+    val listModel: BaseModel
+    val detailModel: BaseModel
   }
 }


### PR DESCRIPTION
Allow the user to tap on the profile picture to open it in a fullscreen page. This sample highlights how navigation could be implemented and in a following PR how animations could be implemented.

| Before    | After |
| -------- | ------- |
| ![Screen1](https://github.com/user-attachments/assets/34af25ac-dbcf-4b0b-bc8d-e26e71e7c994)    | ![Screen2](https://github.com/user-attachments/assets/f1ddfaf7-7744-421c-8874-14c83324ea75)    |


