### PR TITLE
Verify fullscreen profile picture

### DIFF
--- a/sample/app/src/androidInstrumentedTest/kotlin/software/amazon/app/platform/sample/AndroidLoginUiTest.kt
+++ b/sample/app/src/androidInstrumentedTest/kotlin/software/amazon/app/platform/sample/AndroidLoginUiTest.kt
@@ -50,14 +50,28 @@ class AndroidLoginUiTest : ComposeInteractionsProvider {
   }
 
   @Test
-  fun a_user_logs_in() {
+  fun a_user_logs_in_and_opens_the_profile_picture() {
     composeRobot<LoginRobot> {
       seeLoginButton()
       clickLoginButton()
     }
 
     waitUntilCatching("login finished", timeout = 4.seconds) {
-      composeRobot<UserPageRobot> { seeUserId() }
+      composeRobot<UserPageRobot> {
+        seeUserId()
+        seeProfilePicture(fullScreen = false)
+      }
+    }
+
+    // Note that this code doesn't run within the `waitUntilCatching` on purpose. The code
+    // above waits until we're logged in and retries the operation until the UI displayed. The
+    // operations below should not be retried.
+    composeRobot<UserPageRobot> {
+      clickProfilePicture()
+      seeProfilePicture(fullScreen = true)
+
+      clickProfilePicture()
+      seeProfilePicture(fullScreen = false)
     }
   }
 

--- a/sample/app/src/desktopTest/kotlin/software/amazon/app/platform/sample/LoginUiTest.kt
+++ b/sample/app/src/desktopTest/kotlin/software/amazon/app/platform/sample/LoginUiTest.kt
@@ -40,14 +40,28 @@ class LoginUiTest {
   }
 
   @Test
-  fun `a user logs in`(): Unit = runRobotTest {
+  fun `a user logs in and opens the profile picture`(): Unit = runRobotTest {
     composeRobot<LoginRobot> {
       seeLoginButton()
       clickLoginButton()
     }
 
     waitUntilCatching("login finished", timeout = 2.seconds) {
-      composeRobot<UserPageRobot> { seeUserId() }
+      composeRobot<UserPageRobot> {
+        seeUserId()
+        seeProfilePicture(fullScreen = false)
+      }
+    }
+
+    // Note that this code doesn't run within the `waitUntilCatching` on purpose. The code
+    // above waits until we're logged in and retries the operation until the UI displayed. The
+    // operations below should not be retried.
+    composeRobot<UserPageRobot> {
+      clickProfilePicture()
+      seeProfilePicture(fullScreen = true)
+
+      clickProfilePicture()
+      seeProfilePicture(fullScreen = false)
     }
   }
 

--- a/sample/user/impl-robots/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserPageRobot.kt
+++ b/sample/user/impl-robots/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserPageRobot.kt
@@ -3,6 +3,7 @@ package software.amazon.app.platform.sample.user
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
 import me.tatarka.inject.annotations.Inject
 import software.amazon.app.platform.inject.robot.ContributesRobot
 import software.amazon.app.platform.robot.ComposeRobot
@@ -22,6 +23,9 @@ class UserPageRobot(private val userManager: UserManager) : ComposeRobot() {
   private val userIdTextNode
     get() = compose.onNodeWithTag("userIdText")
 
+  private val profilePictureNode
+    get() = compose.onNodeWithTag("profilePicture")
+
   /**
    * Verify that the user ID is displayed. The [userId] can be changed, but uses by default the ID
    * of the logged in user if present.
@@ -29,5 +33,24 @@ class UserPageRobot(private val userManager: UserManager) : ComposeRobot() {
   fun seeUserId(userId: Long = userManager.user.value?.userId ?: -1L) {
     userIdTextNode.assertIsDisplayed()
     userIdTextNode.assertTextEquals("User: $userId")
+  }
+
+  /**
+   * Verify that the profile picture is displayed. If [fullScreen] is `true`, then only the picture
+   * should be shown and other elements like the user ID [seeUserId] are gone.
+   */
+  fun seeProfilePicture(fullScreen: Boolean = false) {
+    profilePictureNode.assertIsDisplayed()
+
+    if (fullScreen) {
+      userIdTextNode.assertDoesNotExist()
+    } else {
+      userIdTextNode.assertIsDisplayed()
+    }
+  }
+
+  /** Click on the profile picture. This works in the detail page and fullscreen mode. */
+  fun clickProfilePicture() {
+    profilePictureNode.performClick()
   }
 }

--- a/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserPageDetailRenderer.kt
+++ b/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserPageDetailRenderer.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import app_platform.sample.user.impl.generated.resources.Res
@@ -59,6 +60,7 @@ class UserPageDetailRenderer : ComposeRenderer<Model>() {
           contentDescription = "Profile picture",
           modifier =
             Modifier.padding(start = 64.dp, top = 16.dp, end = 64.dp)
+              .testTag("profilePicture")
               .sharedElement(
                 rememberSharedContentState(key = PROFILE_PICTURE_KEY),
                 animatedVisibilityScope = checkNotNull(LocalAnimatedVisibilityScope.current),
@@ -97,6 +99,7 @@ class UserPageDetailRenderer : ComposeRenderer<Model>() {
           contentDescription = "Profile picture",
           modifier =
             Modifier.clickable { model.onEvent(UserPageDetailPresenter.Event.ProfilePictureClick) }
+              .testTag("profilePicture")
               .align(Alignment.CenterVertically)
               .sharedElement(
                 rememberSharedContentState(key = PROFILE_PICTURE_KEY),


### PR DESCRIPTION
Verify the fullscreen profile picture in UI tests on Android and desktop. The test opens the fullscreen profile picture and closes it again.

See #37 for more details.