### PR TITLE
Update Compose UI / Android interop `RendererFactory`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ android-compose-version = "1.8.0"
 android-minSdk = "21"
 android-targetSdk = "36"
 #noinspection GradleDependency
-androidx-activity = "1.8.0"
+androidx-activity = "1.8.2"
 #noinspection GradleDependency
 androidx-constraintlayout = "2.1.4"
 #noinspection GradleDependency
@@ -53,7 +53,7 @@ viewbinding = "7.0.0"
 [libraries]
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 android-gradle-plugin-api = { module = "com.android.tools.build:gradle-api", version.ref = "agp" }
-androidx-activity = { module = "androidx.activity:activity-ktx", version.ref = "androidx-activity" }
+androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-lint-gradle = {  module = "androidx.lint:lint-gradle", version.ref = "androidx-lint-gradle" }

--- a/renderer-compose-multiplatform/public/api/android/public.api
+++ b/renderer-compose-multiplatform/public/api/android/public.api
@@ -2,10 +2,13 @@ public abstract interface class software/amazon/app/platform/renderer/BaseCompos
 	public abstract fun renderCompose (Lsoftware/amazon/app/platform/presenter/BaseModel;Landroidx/compose/runtime/Composer;I)V
 }
 
-public final class software/amazon/app/platform/renderer/ComposeAndroidRendererFactory : software/amazon/app/platform/renderer/AndroidRendererFactory {
-	public static final field $stable I
-	public fun <init> (Lsoftware/amazon/app/platform/scope/RootScopeProvider;Landroid/app/Activity;Landroid/view/ViewGroup;)V
-	public fun createRenderer (Lkotlin/reflect/KClass;)Lsoftware/amazon/app/platform/renderer/Renderer;
+public abstract interface class software/amazon/app/platform/renderer/ComposeAndroidRendererFactory : software/amazon/app/platform/renderer/RendererFactory {
+	public static final field Companion Lsoftware/amazon/app/platform/renderer/ComposeAndroidRendererFactory$Companion;
+}
+
+public final class software/amazon/app/platform/renderer/ComposeAndroidRendererFactory$Companion {
+	public final fun createForAndroidViews (Lsoftware/amazon/app/platform/scope/RootScopeProvider;Landroid/app/Activity;Landroid/view/ViewGroup;)Lsoftware/amazon/app/platform/renderer/ComposeAndroidRendererFactory;
+	public final fun createForComposeUi (Lsoftware/amazon/app/platform/scope/RootScopeProvider;)Lsoftware/amazon/app/platform/renderer/ComposeAndroidRendererFactory;
 }
 
 public abstract class software/amazon/app/platform/renderer/ComposeRenderer : software/amazon/app/platform/renderer/BaseComposeRenderer, software/amazon/app/platform/renderer/Renderer {

--- a/renderer-compose-multiplatform/public/build.gradle
+++ b/renderer-compose-multiplatform/public/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 
     commonTestImplementation project(':scope:testing')
 
+    androidTestImplementation libs.androidx.activity.compose
     androidTestImplementation libs.compose.ui.test.junit4
     androidTestImplementation libs.compose.ui.test.junit4.android
     androidTestImplementation libs.compose.ui.test.manifest

--- a/renderer-compose-multiplatform/public/src/androidMain/kotlin/software/amazon/app/platform/renderer/AndroidViewWithinComposeRenderer.kt
+++ b/renderer-compose-multiplatform/public/src/androidMain/kotlin/software/amazon/app/platform/renderer/AndroidViewWithinComposeRenderer.kt
@@ -27,7 +27,16 @@ internal class AndroidViewWithinComposeRenderer<in ModelT : BaseModel>(
   }
 
   override fun render(model: ModelT) {
-    androidRenderer.render(model)
+    try {
+      androidRenderer.render(model)
+    } catch (e: UninitializedPropertyAccessException) {
+      throw IllegalStateException(
+        "Tried to call render() on an AndroidViewRenderer without a parent view. This usually " +
+          "only happens when an AndroidViewRenderer is embedded in Compose UI. Call " +
+          "renderCompose() instead.",
+        e,
+      )
+    }
   }
 
   @Suppress("ComposableNaming")

--- a/renderer-compose-multiplatform/public/src/androidMain/kotlin/software/amazon/app/platform/renderer/ComposeAndroidRendererFactory.kt
+++ b/renderer-compose-multiplatform/public/src/androidMain/kotlin/software/amazon/app/platform/renderer/ComposeAndroidRendererFactory.kt
@@ -11,34 +11,123 @@ import software.amazon.app.platform.scope.RootScopeProvider
  * Android, unlike [ComposeRendererFactory] which only handles [ComposeRenderer] and unlike
  * [AndroidRendererFactory] which only handles [ViewRenderer]. Further, this implementation provides
  * adapters for renderers for a seamless interop between Compose UI and Android Views.
+ *
+ * Call either [createForComposeUi] or [createForAndroidViews] to create a new instance.
  */
-public class ComposeAndroidRendererFactory(
-  rootScopeProvider: RootScopeProvider,
-  activity: Activity,
-  parent: ViewGroup,
-) : AndroidRendererFactory(rootScopeProvider, activity, parent) {
-  override fun <T : BaseModel> createRenderer(modelType: KClass<out T>): Renderer<T> {
-    val renderer = super.createRenderer(modelType)
+public sealed interface ComposeAndroidRendererFactory : RendererFactory {
 
-    check(renderer !is ComposeWithinAndroidViewRenderer) {
-      "Trying to wrap a render that has been wrapped already for model $modelType."
+  private class ComposeAndroidRendererFactoryComposeUi(rootScopeProvider: RootScopeProvider) :
+    BaseRendererFactory(rootScopeProvider), ComposeAndroidRendererFactory {
+    override fun <T : BaseModel> createRenderer(modelType: KClass<out T>): Renderer<T> {
+      return wrapRenderer(super.createRenderer(modelType), modelType)
     }
+  }
 
-    check(renderer !is AndroidViewWithinComposeRenderer) {
-      "Trying to wrap a render that has been wrapped already for model $modelType."
+  private class ComposeAndroidRendererFactoryAndroidView(
+    rootScopeProvider: RootScopeProvider,
+    activity: Activity,
+    parent: ViewGroup,
+  ) : AndroidRendererFactory(rootScopeProvider, activity, parent), ComposeAndroidRendererFactory {
+    override fun <T : BaseModel> createRenderer(modelType: KClass<out T>): Renderer<T> {
+      return wrapRenderer(super.createRenderer(modelType), modelType)
     }
+  }
 
-    return when (renderer) {
-      // Wrap a ComposeRenderer to support embedding it in an Android View hierarchy.
-      is BaseComposeRenderer<*> ->
-        @Suppress("UNCHECKED_CAST")
-        ComposeWithinAndroidViewRenderer(renderer as BaseComposeRenderer<T>)
+  public companion object {
+    /**
+     * Creates a new [RendererFactory] that implements interop for Compose UI and Android Views.
+     *
+     * Use this function only when you know that `Renderers` returned by this factory are instances
+     * of [ComposeRenderer]. This avoids unnecessary wrapping of root `Renderers` and allows you to
+     * embed them into a Compose UI hierarchy. Unlike [createForAndroidViews] it's not necessary to
+     * provide a parent view.
+     *
+     * This constraint only applies to root `Renderers`. Child `Renderers` can still be instances of
+     * [ViewRenderer] and are wrapped for interop when necessary.
+     *
+     * A typical pattern looks like this:
+     * ```
+     * override fun onCreate(savedInstanceState: Bundle?) {
+     *     super.onCreate(savedInstanceState)
+     *
+     *     val rendererFactory =
+     *         ComposeAndroidRendererFactory.createForComposeUi(rootScopeProvider = ...)
+     *
+     *     setContent {
+     *         val model by models.collectAsState()
+     *
+     *         val renderer = rendererFactory.getComposeRenderer(model)
+     *         renderer.renderCompose(model)
+     *     }
+     * }
+     * ```
+     */
+    public fun createForComposeUi(
+      rootScopeProvider: RootScopeProvider
+    ): ComposeAndroidRendererFactory = ComposeAndroidRendererFactoryComposeUi(rootScopeProvider)
 
-      // Wrap a ViewRenderer to support embedding it in a Compose UI hierarchy.
-      is BaseAndroidViewRenderer -> AndroidViewWithinComposeRenderer(renderer)
+    /**
+     * Creates a new [RendererFactory] that implements interop for Compose UI and Android Views.
+     *
+     * Use this function when `Renderers` returned by this factory are instances of
+     * [ComposeRenderer] or [ViewRenderer]. `Renderers` are wrapped for interop when necessary and
+     * embedded as children in [parent].
+     *
+     * A typical pattern looks like this:
+     * ```
+     * override fun onCreate(savedInstanceState: Bundle?) {
+     *     super.onCreate(savedInstanceState)
+     *     setContentView(R.layout.activity_main)
+     *
+     *     val rendererFactory =
+     *         ComposeAndroidRendererFactory(
+     *             rootScopeProvider = ...,
+     *             activity = this,
+     *             parent = findViewById(R.id.main_container),
+     *         )
+     *
+     *     lifecycleScope.launch {
+     *         repeatOnLifecycle(Lifecycle.State.STARTED) {
+     *             models.collect { model ->
+     *                val renderer = rendererFactory.getRenderer(model)
+     *                renderer.render(model)
+     *             }
+     *         }
+     *     }
+     * }
+     * ```
+     */
+    public fun createForAndroidViews(
+      rootScopeProvider: RootScopeProvider,
+      activity: Activity,
+      parent: ViewGroup,
+    ): ComposeAndroidRendererFactory =
+      ComposeAndroidRendererFactoryAndroidView(rootScopeProvider, activity, parent)
 
-      // Should not happen, each original Renderer is wrapped.
-      else -> error("Unsupported renderer type ${renderer::class} for model $modelType.")
+    private fun <T : BaseModel> wrapRenderer(
+      renderer: Renderer<T>,
+      modelType: KClass<out T>,
+    ): Renderer<T> {
+      check(renderer !is ComposeWithinAndroidViewRenderer) {
+        "Trying to wrap a render that has been wrapped already for model $modelType."
+      }
+
+      check(renderer !is AndroidViewWithinComposeRenderer) {
+        "Trying to wrap a render that has been wrapped already for model $modelType."
+      }
+
+      return when (renderer) {
+        // Wrap a ComposeRenderer to support embedding it in an Android View hierarchy.
+        is BaseComposeRenderer<*> ->
+          @Suppress("UNCHECKED_CAST")
+          ComposeWithinAndroidViewRenderer(renderer as BaseComposeRenderer<T>)
+
+        // Wrap a ViewRenderer to support embedding it in a Compose UI hierarchy.
+        is BaseAndroidViewRenderer -> AndroidViewWithinComposeRenderer(renderer)
+
+        // Should not happen, each original Renderer is wrapped.
+        else -> error("Unsupported renderer type ${renderer::class} for model $modelType.")
+      }
     }
   }
 }

--- a/renderer-compose-multiplatform/public/src/androidUnitTest/kotlin/software/amazon/app/platform/renderer/ComposeAndroidRendererFactoryTest.kt
+++ b/renderer-compose-multiplatform/public/src/androidUnitTest/kotlin/software/amazon/app/platform/renderer/ComposeAndroidRendererFactoryTest.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.FrameLayout
 import androidx.compose.runtime.Composable
 import assertk.assertFailure
 import assertk.assertThat
@@ -48,10 +47,7 @@ class ComposeAndroidRendererFactoryTest {
   }
 
   private fun TestScope.factory(): ComposeAndroidRendererFactory {
-    val activity = Activity()
-    val viewGroup = FrameLayout(activity)
-
-    return ComposeAndroidRendererFactory(rootScopeProvider(), activity, viewGroup)
+    return ComposeAndroidRendererFactory.createForComposeUi(rootScopeProvider())
   }
 
   private fun TestScope.rootScopeProvider(): RootScopeProvider {

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     commonMainImplementation project(':sample:templates:impl')
     commonMainImplementation project(':sample:user:impl')
 
-    androidMainImplementation libs.androidx.activity
+    androidMainImplementation libs.androidx.activity.compose
 
     desktopTestImplementation project(':robot-compose-multiplatform:public')
     desktopTestImplementation project(':sample:login:impl-robots')

--- a/sample/app/src/androidMain/kotlin/software/amazon/app/platform/sample/MainActivity.kt
+++ b/sample/app/src/androidMain/kotlin/software/amazon/app/platform/sample/MainActivity.kt
@@ -2,15 +2,13 @@ package software.amazon.app.platform.sample
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
-import kotlinx.coroutines.launch
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import software.amazon.app.platform.renderer.ComposeAndroidRendererFactory
-import software.amazon.app.platform.renderer.getRenderer
-import software.amazon.app.platform.sample.app.R
+import software.amazon.app.platform.renderer.getComposeRenderer
 import software.amazon.app.platform.scope.RootScopeProvider
 
 /**
@@ -28,22 +26,14 @@ class MainActivity : ComponentActivity() {
     super.onCreate(savedInstanceState)
     enableEdgeToEdge()
 
-    setContentView(R.layout.activity_main)
-
     val rendererFactory =
-      ComposeAndroidRendererFactory(
-        rootScopeProvider = rootScopeProvider,
-        activity = this,
-        parent = findViewById(R.id.main_container),
-      )
+      ComposeAndroidRendererFactory.createForComposeUi(rootScopeProvider = rootScopeProvider)
 
-    lifecycleScope.launch {
-      repeatOnLifecycle(Lifecycle.State.STARTED) {
-        viewModel.templates.collect { template ->
-          val renderer = rendererFactory.getRenderer(template)
-          renderer.render(template)
-        }
-      }
+    setContent {
+      val template by viewModel.templates.collectAsState()
+
+      val renderer = rendererFactory.getComposeRenderer(template)
+      renderer.renderCompose(template)
     }
   }
 }

--- a/sample/app/src/androidMain/res/layout/activity_main.xml
+++ b/sample/app/src/androidMain/res/layout/activity_main.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<FrameLayout android:id="@+id/main_container"
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:ignore="MergeRootFrame" />


### PR DESCRIPTION
Until now it was required to provide a parent Android View to `ComposeAndroidRendererFactory` even though this view is not needed for applications where the root renderers use Compose UI and only some child renderers use Android Views. This change introduces two factory functions to distinguish between these two scenarios.

The sample application demos this change and gets rid of the redundant parent view.

