### PR TITLE
Update publishing to Sonatype Central Portal

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -9,7 +9,7 @@ jobs:
   publish-release:
     runs-on: macos-latest-xlarge
     if: github.repository == 'amzn/app-platform'
-    timeout-minutes: 25
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@v4
@@ -24,8 +24,8 @@ jobs:
           ./gradlew clean publishAndReleaseToMavenCentral -PRELEASE_SIGNING_ENABLED=true --no-build-cache --stacktrace --show-version --no-configuration-cache
           ./gradlew -p gradle-plugin clean publishAndReleaseToMavenCentral -PRELEASE_SIGNING_ENABLED=true --no-build-cache --stacktrace --show-version --no-configuration-cache
         env:
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_PORTAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PORTAL_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY_PASSWORD }}
 

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -11,7 +11,7 @@ jobs:
   publish-snapshot:
     runs-on: macos-latest-xlarge
     if: github.repository == 'amzn/app-platform'
-    timeout-minutes: 25
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@v4
@@ -26,7 +26,7 @@ jobs:
           ./gradlew clean publish -PRELEASE_SIGNING_ENABLED=true --no-build-cache --stacktrace --show-version --no-configuration-cache
           ./gradlew -p gradle-plugin clean publish -PRELEASE_SIGNING_ENABLED=true --no-build-cache --stacktrace --show-version --no-configuration-cache
         env:
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_PORTAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PORTAL_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY_PASSWORD }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+* Snapshots are now published to the Central Portal Snapshots repository at https://central.sonatype.com/repository/maven-snapshots/.
+
 ### Deprecated
 
 ### Removed
@@ -15,6 +17,7 @@
 ### Security
 
 ### Other Notes & Contributions
+
 
 ## [0.0.2] - 2025-05-02
 

--- a/buildSrc/settings.gradle
+++ b/buildSrc/settings.gradle
@@ -11,7 +11,7 @@ dependencyResolutionManagement {
         gradlePluginPortal()
 
         maven {
-            url = "https://oss.sonatype.org/content/repositories/snapshots/"
+            url = "https://central.sonatype.com/repository/maven-snapshots/"
         }
     }
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -43,7 +43,7 @@ To import snapshot builds use following repository:
 
 ```gradle
 maven {
-  url = 'https://aws.oss.sonatype.org/content/repositories/snapshots/'
+  url = 'https://central.sonatype.com/repository/maven-snapshots/'
 }
 ```
 

--- a/gradle-plugin/settings.gradle
+++ b/gradle-plugin/settings.gradle
@@ -12,7 +12,7 @@ dependencyResolutionManagement {
         gradlePluginPortal()
 
         maven {
-            url = "https://oss.sonatype.org/content/repositories/snapshots/"
+            url = "https://central.sonatype.com/repository/maven-snapshots/"
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ org.jetbrains.compose.experimental.uikit.enabled=true
 
 # This property does not work when setting up publishing through the DSL as we do.
 # SONATYPE_AUTOMATIC_RELEASE=true
-SONATYPE_HOST=https://aws.oss.sonatype.org
+SONATYPE_HOST=CENTRAL_PORTAL
 # Keep this set to false by default, otherwise publishing to Maven local is extremely slow. There is a bug:
 # https://github.com/gradle/gradle/issues/26256
 RELEASE_SIGNING_ENABLED=false

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,7 +15,7 @@ dependencyResolutionManagement {
         gradlePluginPortal()
 
         maven {
-            url = "https://oss.sonatype.org/content/repositories/snapshots/"
+            url = "https://central.sonatype.com/repository/maven-snapshots/"
         }
     }
 }


### PR DESCRIPTION
The old OSSRH repository is deprecated and will stop working end of June.

