### PR TITLE
Make `exportedDependencies()` easier accessible

### DIFF
--- a/gradle-plugin/api/gradle-plugin.api
+++ b/gradle-plugin/api/gradle-plugin.api
@@ -13,6 +13,7 @@ public class software/amazon/app/platform/gradle/AppPlatformPlugin : org/gradle/
 	public fun <init> ()V
 	public synthetic fun apply (Ljava/lang/Object;)V
 	public fun apply (Lorg/gradle/api/Project;)V
+	public static final fun exportedDependencies ()Ljava/util/Set;
 }
 
 public final class software/amazon/app/platform/gradle/AppPlatformPlugin$Companion {

--- a/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/AppPlatformPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/AppPlatformPlugin.kt
@@ -103,6 +103,7 @@ public open class AppPlatformPlugin : Plugin<Project> {
      * Returns the set of dependencies that need to be exported in a Framework for native targets in
      * order to make App Platform work.
      */
+    @JvmStatic
     public fun exportedDependencies(): Set<String> =
       setOf(
           "kotlin-inject-contribute-public",


### PR DESCRIPTION
Make `exportedDependencies()` easier accessible for Groovy build scripts by annotating the function with `@JvmStatic`.

