### PR TITLE
Add backstack recipe

### DIFF
--- a/kotlin-js-store/wasm/yarn.lock
+++ b/kotlin-js-store/wasm/yarn.lock
@@ -52,6 +52,11 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@js-joda/core@3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@js-joda/core/-/core-3.2.0.tgz#3e61e21b7b2b8a6be746df1335cf91d70db2a273"
+  integrity sha512-PMqgJ0sw5B7FKb2d5bWYIoxjri+QlW/Pys7+Rw82jSH0QN3rB05jZ/VrrsUdh1w4+i2kw9JOejXGq/KhDOX7Kg==
+
 "@jsonjoy.com/base64@^1.1.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@jsonjoy.com/base64/-/base64-1.1.2.tgz#cf8ea9dcb849b81c95f14fc0aaa151c6b54d2578"

--- a/recipes/common/impl/build.gradle
+++ b/recipes/common/impl/build.gradle
@@ -17,6 +17,9 @@ appPlatform {
 compose {
     dependencies {
         commonMainImplementation dependencies.components.resources
-        commonMainImplementation dependencies.material
+        commonMainImplementation dependencies.material3
+        commonMainImplementation dependencies.materialIconsExtended
+        commonMainImplementation dependencies.runtimeSaveable
+        commonMainImplementation dependencies.ui
     }
 }

--- a/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/appbar/AppBarConfig.kt
+++ b/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/appbar/AppBarConfig.kt
@@ -1,0 +1,16 @@
+package software.amazon.app.platform.recipes.appbar
+
+/** Configures the look of the App Bar for the recipe app. */
+data class AppBarConfig(
+  /** The title shown in the center of the App Bar. */
+  val title: String,
+  /**
+   * If not null, then the back arrow will be shown and the lambda invoked when there's an action.
+   */
+  val backArrowAction: (() -> Unit)? = null,
+) {
+  companion object {
+    /** The default configuration used when no presenter overrides the config. */
+    val DEFAULT = AppBarConfig(title = "Recipes App")
+  }
+}

--- a/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/appbar/AppBarConfigModel.kt
+++ b/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/appbar/AppBarConfigModel.kt
@@ -1,0 +1,9 @@
+package software.amazon.app.platform.recipes.appbar
+
+import software.amazon.app.platform.presenter.BaseModel
+
+/** Can be implemented by a [BaseModel] class to change the configuration of the App Bar. */
+interface AppBarConfigModel {
+  /** Returns the config that should be rendered. */
+  fun appBarConfig(): AppBarConfig
+}

--- a/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/backstack/CrossSlideBackstackPresenter.kt
+++ b/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/backstack/CrossSlideBackstackPresenter.kt
@@ -1,0 +1,40 @@
+package software.amazon.app.platform.recipes.backstack
+
+import androidx.compose.runtime.Composable
+import software.amazon.app.platform.presenter.BaseModel
+import software.amazon.app.platform.presenter.molecule.MoleculePresenter
+import software.amazon.app.platform.recipes.appbar.AppBarConfig
+import software.amazon.app.platform.recipes.appbar.AppBarConfigModel
+import software.amazon.app.platform.recipes.backstack.CrossSlideBackstackPresenter.Model
+
+/**
+ * A generic presenter that wraps a presenter backstack to play a cross-fade animation whenever a
+ * presenter is pushed to the stack or popped from the stack. A backstack always contains
+ * [initialPresenter] as an element.
+ */
+class CrossSlideBackstackPresenter(
+  private val initialPresenter: MoleculePresenter<Unit, out BaseModel>
+) : MoleculePresenter<Unit, Model> {
+  @Composable
+  override fun present(input: Unit): Model {
+    return presenterBackstack(initialPresenter) { model ->
+      Model(delegate = model, backstackScope = this)
+    }
+  }
+
+  /**
+   * The model containing all information about the backstack to play a cross-slide animation in the
+   * renderer. [delegate] refers to the model of the top most presenter in the stack.
+   * [backstackScope] contains the backstack and allows you to modify the stack.
+   */
+  data class Model(val delegate: BaseModel, val backstackScope: PresenterBackstackScope) :
+    BaseModel, AppBarConfigModel {
+    override fun appBarConfig(): AppBarConfig {
+      return if (delegate is AppBarConfigModel) {
+        delegate.appBarConfig()
+      } else {
+        AppBarConfig.DEFAULT
+      }
+    }
+  }
+}

--- a/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/backstack/CrossSlideBackstackRenderer.kt
+++ b/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/backstack/CrossSlideBackstackRenderer.kt
@@ -1,0 +1,144 @@
+package software.amazon.app.platform.recipes.backstack
+
+import androidx.compose.animation.core.FiniteAnimationSpec
+import androidx.compose.animation.core.MutableTransitionState
+import androidx.compose.animation.core.Transition
+import androidx.compose.animation.core.animateOffset
+import androidx.compose.animation.core.rememberTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalWindowInfo
+import me.tatarka.inject.annotations.Inject
+import software.amazon.app.platform.inject.ContributesRenderer
+import software.amazon.app.platform.recipes.backstack.CrossSlideBackstackPresenter.Model
+import software.amazon.app.platform.renderer.ComposeRenderer
+import software.amazon.app.platform.renderer.RendererFactory
+import software.amazon.app.platform.renderer.getComposeRenderer
+
+/**
+ * Plays a cross-slide animation whenever the backstack provided [CrossSlideBackstackPresenter]
+ * changes.
+ */
+@Inject
+@ContributesRenderer
+class CrossSlideBackstackRenderer(private val rendererFactory: RendererFactory) :
+  ComposeRenderer<Model>() {
+
+  @Composable
+  override fun Compose(model: Model) {
+    Column(modifier = Modifier.fillMaxSize()) {
+      CrossSlide(
+        targetState = model.delegate,
+        reverseAnimation =
+          model.backstackScope.lastBackstackChange.value.action ==
+            PresenterBackstackScope.BackstackChange.Action.POP,
+        contentKey = {
+          // Include size of the backstack in the key in case the model type is the same but the
+          // position in the stack differs.
+          it::class.hashCode() + model.backstackScope.lastBackstackChange.value.backstack.size
+        },
+      ) { screen ->
+        rendererFactory.getComposeRenderer(screen).renderCompose(screen)
+      }
+    }
+  }
+
+  // https://gist.github.com/DavidIbrahim/5f4c0387b571f657f4de976822c2a225
+  //
+  // This animation implementation comes from the link above, but was modified with the
+  // `contentKey` parameter to allows updates of the `targetState` without playing another
+  // cross slide animation.
+  //
+  // Further the distance was adjusted to the screen size.
+  @Composable
+  @Suppress("LongMethod", "MagicNumber")
+  private fun <T : Any> CrossSlide(
+    targetState: T,
+    contentKey: (targetState: T) -> Any = { it },
+    modifier: Modifier = Modifier,
+    animationSpec: FiniteAnimationSpec<Offset> = tween(500),
+    reverseAnimation: Boolean = false,
+    content: @Composable (T) -> Unit,
+  ) {
+    data class SlideInOutAnimationState<T>(
+      val key: Any,
+      val state: T,
+      val content: @Composable () -> Unit,
+    )
+
+    val direction: Int = if (reverseAnimation) -1 else 1
+    val items = remember { mutableStateListOf<SlideInOutAnimationState<T>>() }
+
+    val targetKey = contentKey(targetState)
+
+    // We only play a cross slide animation / transition, if the key has changed. If the state has
+    // changed, but the key didn't, then we only need to update the rendered target state in the
+    // same item.
+    val transitionState = remember { MutableTransitionState(targetKey) }
+    transitionState.targetState = targetKey
+    val transition: Transition<Any> = rememberTransition(transitionState)
+
+    val targetContentChanged = items.firstOrNull { it.key == targetKey }?.state != targetState
+
+    if (targetContentChanged || items.isEmpty()) {
+      // Only manipulate the list when the state is changed, or in the first run.
+      items
+        .map {
+          if (it.key == targetKey) {
+            // Change the old state remembered in the list to the new state.
+            it.key to targetState
+          } else {
+            it.key to it.state
+          }
+        }
+        .let {
+          if (it.none { (key, _) -> key == targetKey }) {
+            it + Pair(targetKey, targetState)
+          } else {
+            it
+          }
+        }
+        .also { items.clear() }
+        .mapTo(items) { (key, state) ->
+          SlideInOutAnimationState(key, state) {
+            val xTransition by
+              transition.animateOffset(transitionSpec = { animationSpec }, label = "") {
+                val containerSize = LocalWindowInfo.current.containerSize
+                if (it == key) {
+                  Offset(0f, 0f)
+                } else {
+                  Offset(containerSize.width.toFloat(), containerSize.height.toFloat())
+                }
+              }
+            Box(
+              modifier.graphicsLayer {
+                this.translationX =
+                  if (transition.targetState == key) {
+                    direction * xTransition.x
+                  } else {
+                    direction * -xTransition.x
+                  }
+              }
+            ) {
+              content(state)
+            }
+          }
+        }
+    } else if (transitionState.isIdle) {
+      // Remove all the intermediate items from the list once the animation is finished.
+      items.removeAll { it.key != transitionState.targetState }
+    }
+
+    Box(modifier) { items.forEach { key(it.key) { it.content() } } }
+  }
+}

--- a/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/backstack/PresenterBackstackScope.kt
+++ b/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/backstack/PresenterBackstackScope.kt
@@ -1,0 +1,152 @@
+package software.amazon.app.platform.recipes.backstack
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import software.amazon.app.platform.presenter.BaseModel
+import software.amazon.app.platform.presenter.molecule.MoleculePresenter
+import software.amazon.app.platform.presenter.molecule.returningCompositionLocalProvider
+import software.amazon.app.platform.recipes.backstack.PresenterBackstackScope.BackstackChange
+import software.amazon.app.platform.recipes.backstack.PresenterBackstackScope.BackstackChange.Action
+
+/**
+ * Receiver scope for content lambda for [presenterBackstack]. In this scope, [lastBackstackChange]
+ * can be used to observe the state of the backstack, or to [push] and [pop] presenters.
+ */
+interface PresenterBackstackScope {
+
+  /** Provides the last change made to the backstack. */
+  val lastBackstackChange: State<BackstackChange>
+
+  /** Pushes a new presenter to the top of the backstack. This will update [lastBackstackChange]. */
+  fun push(presenter: MoleculePresenter<Unit, out BaseModel>)
+
+  /**
+   * Removes the top presenter from the backstack. This will update [lastBackstackChange]. Note that
+   * the stack will always contain the initial presenter provided in [presenterBackstack] and this
+   * presenter cannot be popped.
+   */
+  fun pop()
+
+  /** Describes the current state of the backstack with the last change. */
+  interface BackstackChange {
+
+    /**
+     * The stack of presenters. This list will always contain at least one element, which is the
+     * initial presenter provided in [presenterBackstack].
+     */
+    val backstack: List<MoleculePresenter<Unit, out BaseModel>>
+
+    /**
+     * The last executed for the backstack. Knowing what kind of change was made is helpful to
+     * animate changes in the UI.
+     */
+    val action: Action
+
+    /** Describes all actions that can be applied to the backstack. */
+    enum class Action {
+      /** A new presenter was added to the top of the backstack. */
+      PUSH,
+
+      /** The last top presenter in the stack was removed. */
+      POP,
+    }
+  }
+}
+
+private class PresenterBackstackScopeImpl(initial: MoleculePresenter<Unit, out BaseModel>) :
+  PresenterBackstackScope {
+  private var _lastBackstackChange =
+    mutableStateOf(BackstackChangeImpl(listOf(initial), Action.PUSH))
+  override val lastBackstackChange: State<BackstackChange> = _lastBackstackChange
+
+  override fun push(presenter: MoleculePresenter<Unit, out BaseModel>) {
+    _lastBackstackChange.value =
+      BackstackChangeImpl(
+        backstack = _lastBackstackChange.value.backstack + presenter,
+        action = Action.PUSH,
+      )
+  }
+
+  override fun pop() {
+    val oldStack = _lastBackstackChange.value.backstack
+    if (oldStack.size > 1) {
+      _lastBackstackChange.value =
+        BackstackChangeImpl(backstack = oldStack.subList(0, oldStack.size - 1), action = Action.POP)
+    }
+  }
+
+  private class BackstackChangeImpl(
+    override val backstack: List<MoleculePresenter<Unit, out BaseModel>>,
+    override val action: Action,
+  ) : BackstackChange
+}
+
+/**
+ * Provides the backstack closest to this presenter or `null` if there's none. Presenters build a
+ * tree. When the backstack is queried, then the backstack first found while walking the tree to the
+ * root is returned. In the tree there can be multiple backstacks.
+ *
+ * ```
+ * @Composable
+ * override fun present(input: Unit): Model {
+ *   val backstack = checkNotNull(LocalBackstackScope.current)
+ *   ...
+ * }
+ * ```
+ */
+val LocalBackstackScope = compositionLocalOf<PresenterBackstackScope?> { null }
+
+/**
+ * Creates a new backstack for presenters. A backstack always contains [initialPresenter] as an
+ * element.
+ *
+ * [content] is invoked with the [BaseModel] of the top presenter in the stack. The lambda returns
+ * the model of the presenter this function [presenterBackstack] is called in. The receiver type
+ * [PresenterBackstackScope] allows you to modify the backstack or get information about changes.
+ *
+ * ```
+ * class SomePresenter : MoleculePresenter<Unit, SomeModel> {
+ *   @Composable
+ *   override fun present(input: Unit): SomeModel {
+ *     val initialPresenter = ...
+ *     return presenterBackstack(initialPresenter) { model ->
+ *       SomeModel(...)
+ *     }
+ *   }
+ *
+ *   data class SomeModel(...) : BaseModel
+ * }
+ *
+ * ```
+ *
+ * Child presenters get access to the backstack through [LocalBackstackScope], e.g.
+ *
+ * ```
+ * @Composable
+ * override fun present(input: Unit): Model {
+ *   val backstack = checkNotNull(LocalBackstackScope.current)
+ *   ...
+ * }
+ * ```
+ *
+ * To use a cross-slide animation by default for backstack changes, consider using
+ * [CrossSlideBackstackPresenter].
+ */
+@Composable
+fun <ModelT : BaseModel> presenterBackstack(
+  initialPresenter: MoleculePresenter<Unit, out BaseModel>,
+  content: PresenterBackstackScope.(model: BaseModel) -> ModelT,
+): ModelT {
+  val scope = remember { PresenterBackstackScopeImpl(initialPresenter) }
+
+  return returningCompositionLocalProvider(LocalBackstackScope provides scope) {
+    val presenter = scope.lastBackstackChange.value.backstack.last()
+    val backstackModel = key(presenter) { presenter.present(Unit) }
+
+    content.invoke(scope, backstackModel)
+  }
+}

--- a/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/backstack/presenter/BackstackChildPresenter.kt
+++ b/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/backstack/presenter/BackstackChildPresenter.kt
@@ -1,0 +1,76 @@
+@file:Suppress("UndocumentedPublicProperty", "UndocumentedPublicClass")
+
+package software.amazon.app.platform.recipes.backstack.presenter
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import software.amazon.app.platform.inject.ContributesRenderer
+import software.amazon.app.platform.presenter.BaseModel
+import software.amazon.app.platform.presenter.molecule.MoleculePresenter
+import software.amazon.app.platform.recipes.appbar.AppBarConfig
+import software.amazon.app.platform.recipes.appbar.AppBarConfigModel
+import software.amazon.app.platform.recipes.backstack.LocalBackstackScope
+import software.amazon.app.platform.recipes.backstack.presenter.BackstackChildPresenter.Model
+import software.amazon.app.platform.renderer.ComposeRenderer
+
+class BackstackChildPresenter(private val index: Int) : MoleculePresenter<Unit, Model> {
+  @Composable
+  override fun present(input: Unit): Model {
+    val backstack = checkNotNull(LocalBackstackScope.current)
+
+    val counter by
+      produceState(0) {
+        while (isActive) {
+          delay(1.seconds)
+          value += 1
+        }
+      }
+
+    return Model(index = index, counter = counter) {
+      when (it) {
+        Event.AddPresenterToBackstack -> backstack.push(BackstackChildPresenter(index = index + 1))
+      }
+    }
+  }
+
+  data class Model(val index: Int, val counter: Int, val onEvent: (Event) -> Unit) :
+    BaseModel, AppBarConfigModel {
+    override fun appBarConfig(): AppBarConfig {
+      return AppBarConfig(title = "Backstack")
+    }
+  }
+
+  sealed interface Event {
+    data object AddPresenterToBackstack : Event
+  }
+}
+
+@ContributesRenderer
+class BackstackChildRenderer : ComposeRenderer<Model>() {
+  @Composable
+  override fun Compose(model: Model) {
+    Column(
+      modifier = Modifier.fillMaxSize().padding(top = 12.dp),
+      horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+      Text("Index: ${model.index}")
+      Text("Counter: ${model.counter}")
+
+      Button(onClick = { model.onEvent(BackstackChildPresenter.Event.AddPresenterToBackstack) }) {
+        Text("Add presenter to backstack")
+      }
+    }
+  }
+}

--- a/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/landing/LandingPresenter.kt
+++ b/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/landing/LandingPresenter.kt
@@ -4,6 +4,8 @@ import androidx.compose.runtime.Composable
 import me.tatarka.inject.annotations.Inject
 import software.amazon.app.platform.presenter.BaseModel
 import software.amazon.app.platform.presenter.molecule.MoleculePresenter
+import software.amazon.app.platform.recipes.backstack.LocalBackstackScope
+import software.amazon.app.platform.recipes.backstack.presenter.BackstackChildPresenter
 import software.amazon.app.platform.recipes.landing.LandingPresenter.Model
 
 /** The presenter that is responsible to show the content of the landing page in the Recipes app. */
@@ -11,7 +13,15 @@ import software.amazon.app.platform.recipes.landing.LandingPresenter.Model
 class LandingPresenter : MoleculePresenter<Unit, Model> {
   @Composable
   override fun present(input: Unit): Model {
-    return Model {}
+    val backstack = checkNotNull(LocalBackstackScope.current)
+
+    return Model {
+      when (it) {
+        Event.AddPresenterToBackstack -> {
+          backstack.push(BackstackChildPresenter(0))
+        }
+      }
+    }
   }
 
   /** The state of the landing screen. */
@@ -21,5 +31,8 @@ class LandingPresenter : MoleculePresenter<Unit, Model> {
   ) : BaseModel
 
   /** All events that [LandingPresenter] can process. */
-  sealed interface Event
+  sealed interface Event {
+    /** Add a new presenter to the backstack. */
+    data object AddPresenterToBackstack : Event
+  }
 }

--- a/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/landing/LandingRenderer.kt
+++ b/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/landing/LandingRenderer.kt
@@ -1,7 +1,14 @@
 package software.amazon.app.platform.recipes.landing
 
-import androidx.compose.material.Text
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import software.amazon.app.platform.inject.ContributesRenderer
 import software.amazon.app.platform.recipes.landing.LandingPresenter.Model
 import software.amazon.app.platform.renderer.ComposeRenderer
@@ -11,6 +18,13 @@ import software.amazon.app.platform.renderer.ComposeRenderer
 class LandingRenderer : ComposeRenderer<Model>() {
   @Composable
   override fun Compose(model: Model) {
-    Text("Hello")
+    Column(
+      modifier = Modifier.fillMaxSize().padding(top = 12.dp),
+      horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+      Button(onClick = { model.onEvent(LandingPresenter.Event.AddPresenterToBackstack) }) {
+        Text("Add presenter to backstack")
+      }
+    }
   }
 }

--- a/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/template/RecipesAppTemplate.kt
+++ b/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/template/RecipesAppTemplate.kt
@@ -2,12 +2,15 @@ package software.amazon.app.platform.recipes.template
 
 import software.amazon.app.platform.presenter.BaseModel
 import software.amazon.app.platform.presenter.template.Template
+import software.amazon.app.platform.recipes.appbar.AppBarConfig
 
 /** All [Template]s implemented in the recipes application. */
 sealed interface RecipesAppTemplate : Template {
   /** A template that hosts a single model, which should rendered as full-screen element. */
   data class FullScreenTemplate(
     /** The model to be rendered fullscreen. */
-    val model: BaseModel
+    val model: BaseModel,
+    /** The configuration for the app bar of the recipe app. */
+    val appBarConfig: AppBarConfig,
   ) : RecipesAppTemplate
 }

--- a/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/template/RootPresenterRenderer.kt
+++ b/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/template/RootPresenterRenderer.kt
@@ -1,9 +1,29 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
 package software.amazon.app.platform.recipes.template
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.text.style.TextOverflow
 import me.tatarka.inject.annotations.Inject
 import software.amazon.app.platform.inject.ContributesRenderer
 import software.amazon.app.platform.presenter.BaseModel
+import software.amazon.app.platform.recipes.appbar.AppBarConfig
 import software.amazon.app.platform.renderer.ComposeRenderer
 import software.amazon.app.platform.renderer.Renderer
 import software.amazon.app.platform.renderer.RendererFactory
@@ -27,7 +47,54 @@ class RootPresenterRenderer(private val rendererFactory: RendererFactory) :
 
   @Composable
   private fun FullScreen(template: RecipesAppTemplate.FullScreenTemplate) {
-    val renderer = rendererFactory.getComposeRenderer(template.model)
-    renderer.renderCompose(template.model)
+    CenterAlignedTopAppBar(template.appBarConfig) {
+      Box(modifier = Modifier.padding(it)) {
+        val renderer = rendererFactory.getComposeRenderer(template.model)
+        renderer.renderCompose(template.model)
+      }
+    }
+  }
+
+  @Composable
+  private fun CenterAlignedTopAppBar(
+    appBarConfig: AppBarConfig,
+    content: @Composable (PaddingValues) -> Unit,
+  ) {
+    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
+
+    Scaffold(
+      modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+      topBar = {
+        CenterAlignedTopAppBar(
+          colors =
+            TopAppBarDefaults.centerAlignedTopAppBarColors(
+              containerColor = MaterialTheme.colorScheme.primaryContainer,
+              titleContentColor = MaterialTheme.colorScheme.primary,
+            ),
+          title = { Text(appBarConfig.title, maxLines = 1, overflow = TextOverflow.Ellipsis) },
+          navigationIcon = {
+            if (appBarConfig.backArrowAction != null) {
+              IconButton(onClick = appBarConfig.backArrowAction) {
+                Icon(
+                  imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                  contentDescription = "Localized description",
+                )
+              }
+            }
+          },
+          //          actions = {
+          //            IconButton(onClick = { /* do something */ }) {
+          //              Icon(
+          //                imageVector = Icons.Filled.Menu,
+          //                contentDescription = "Localized description"
+          //              )
+          //            }
+          //          },
+          scrollBehavior = scrollBehavior,
+        )
+      },
+    ) { innerPadding ->
+      content(innerPadding)
+    }
   }
 }


### PR DESCRIPTION
Add a recipe to highlight how a Presenter backstack can be implemented including animations. The recipe implementation includes an App Bar as well to implement navigation. Proper back press support will be provided later.

See #69

Note that there is still one more missing feature to highlight and this is how presenters can restore their state when they come back into the foreground. This will be implemented separately. 

https://github.com/user-attachments/assets/5de4b41c-5bcd-4035-bd4d-8a157b777c29

