### PR TITLE
Restore the state of presenters in the backstack

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ android-minSdk = "21"
 android-targetSdk = "36"
 #noinspection GradleDependency
 androidx-activity = "1.8.2"
+androidx-collection = "1.5.0"
 #noinspection GradleDependency
 androidx-constraintlayout = "2.1.4"
 #noinspection GradleDependency
@@ -57,6 +58,7 @@ android-gradle-plugin-api = { module = "com.android.tools.build:gradle-api", ver
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
+androidx-collection = { module = "androidx.collection:collection", version.ref = "androidx-collection" }
 androidx-lint-gradle = {  module = "androidx.lint:lint-gradle", version.ref = "androidx-lint-gradle" }
 androidx-test-espresso = { module = "androidx.test.espresso:espresso-core", version.ref = "androidx-test-espresso" }
 androidx-test-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-test-junit" }

--- a/recipes/common/impl/build.gradle
+++ b/recipes/common/impl/build.gradle
@@ -23,3 +23,7 @@ compose {
         commonMainImplementation dependencies.ui
     }
 }
+
+dependencies {
+    commonMainImplementation libs.androidx.collection
+}

--- a/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/backstack/presenter/BackstackChildPresenter.kt
+++ b/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/backstack/presenter/BackstackChildPresenter.kt
@@ -8,8 +8,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.produceState
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -34,13 +37,14 @@ class BackstackChildPresenter(private val index: Int) : MoleculePresenter<Unit, 
   override fun present(input: Unit): Model {
     val backstack = checkNotNull(LocalBackstackScope.current)
 
-    val counter by
-      produceState(0) {
-        while (isActive) {
-          delay(1.seconds)
-          value += 1
-        }
+    var counter by rememberSaveable { mutableIntStateOf(0) }
+
+    LaunchedEffect(Unit) {
+      while (isActive) {
+        delay(1.seconds)
+        counter += 1
       }
+    }
 
     return Model(index = index, counter = counter) {
       when (it) {

--- a/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/saveable/ReturningSaveableStateHolder.kt
+++ b/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/saveable/ReturningSaveableStateHolder.kt
@@ -1,0 +1,140 @@
+package software.amazon.app.platform.recipes.saveable
+
+import androidx.collection.mutableScatterMapOf
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.ReusableContent
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.LocalSaveableStateRegistry
+import androidx.compose.runtime.saveable.SaveableStateHolder
+import androidx.compose.runtime.saveable.SaveableStateRegistry
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.saveable.rememberSaveableStateHolder
+import software.amazon.app.platform.presenter.BaseModel
+import software.amazon.app.platform.presenter.molecule.returningCompositionLocalProvider
+
+/**
+ * Allows to save the state defined with [rememberSaveable] for the subtree before disposing it to
+ * make it possible to compose it back next time with the restored state. It allows different
+ * navigation patterns to keep the ui state like scroll position for the currently not composed
+ * screens from the backstack.
+ *
+ * The content should be composed using [SaveableStateProvider] while providing a key representing
+ * this content. Next time [SaveableStateProvider] will be used with the same key its state will be
+ * restored.
+ *
+ * This implementation is similar to [SaveableStateHolder] with the only difference that
+ * [ReturningSaveableStateHolder] returns a result and doesn't have `Unit` as return type.
+ */
+interface ReturningSaveableStateHolder {
+  /**
+   * Put your content associated with a [key] inside the [content]. This will automatically save all
+   * the states defined with [rememberSaveable] before disposing the content and will restore the
+   * states when you compose with this key again.
+   *
+   * @param key to be used for saving and restoring the states for the subtree. Note that on Android
+   *   you can only use types which can be stored inside the Bundle.
+   * @param content the content for which [key] is associated.
+   */
+  @Suppress("ComposableNaming")
+  @Composable
+  fun <ModelT : BaseModel> SaveableStateProvider(
+    key: Any,
+    content: @Composable () -> ModelT,
+  ): ModelT
+
+  /** Removes the saved state associated with the passed [key]. */
+  fun removeState(key: Any)
+}
+
+/**
+ * Creates and remembers the instance of [ReturningSaveableStateHolder].
+ *
+ * This implementation is similar to [rememberSaveableStateHolder] with the only difference that
+ * [ReturningSaveableStateHolder] returns a result and doesn't have `Unit` as return type.
+ */
+@Composable
+fun rememberReturningSaveableStateHolder(): ReturningSaveableStateHolder =
+  rememberSaveable(saver = CustomSaveableStateHolderImpl.Saver) { CustomSaveableStateHolderImpl() }
+    .apply { parentSaveableStateRegistry = LocalSaveableStateRegistry.current }
+
+private class CustomSaveableStateHolderImpl(
+  private val savedStates: MutableMap<Any, Map<String, List<Any?>>> = mutableMapOf()
+) : ReturningSaveableStateHolder {
+  private val registries = mutableScatterMapOf<Any, SaveableStateRegistry>()
+  var parentSaveableStateRegistry: SaveableStateRegistry? = null
+  private val canBeSaved: (Any) -> Boolean = { parentSaveableStateRegistry?.canBeSaved(it) ?: true }
+
+  @Composable
+  override fun <ModelT : BaseModel> SaveableStateProvider(
+    key: Any,
+    content: @Composable () -> ModelT,
+  ): ModelT {
+    return returningReusableContent(key) {
+      val registry = remember {
+        require(canBeSaved(key)) {
+          "Type of the key $key is not supported. On Android you can only use types " +
+            "which can be stored inside the Bundle."
+        }
+        SaveableStateRegistry(savedStates[key], canBeSaved)
+      }
+      val model =
+        returningCompositionLocalProvider(
+          LocalSaveableStateRegistry provides registry,
+          content = content,
+        )
+      DisposableEffect(Unit) {
+        require(key !in registries) { "Key $key was used multiple times " }
+        savedStates -= key
+        registries[key] = registry
+        onDispose {
+          if (registries.remove(key) === registry) {
+            registry.saveTo(savedStates, key)
+          }
+        }
+      }
+
+      model
+    }
+  }
+
+  private fun saveAll(): MutableMap<Any, Map<String, List<Any?>>>? {
+    val map = savedStates
+    registries.forEach { key, registry -> registry.saveTo(map, key) }
+    return map.ifEmpty { null }
+  }
+
+  override fun removeState(key: Any) {
+    if (registries.remove(key) == null) {
+      savedStates -= key
+    }
+  }
+
+  private fun SaveableStateRegistry.saveTo(
+    map: MutableMap<Any, Map<String, List<Any?>>>,
+    key: Any,
+  ) {
+    val savedData = performSave()
+    if (savedData.isEmpty()) {
+      map -= key
+    } else {
+      map[key] = savedData
+    }
+  }
+
+  companion object {
+    val Saver: Saver<CustomSaveableStateHolderImpl, *> =
+      Saver(save = { it.saveAll() }, restore = { CustomSaveableStateHolderImpl(it) })
+  }
+
+  @Composable
+  private inline fun <ModelT : BaseModel> returningReusableContent(
+    key: Any?,
+    content: @Composable () -> ModelT,
+  ): ModelT {
+    lateinit var result: ModelT
+    ReusableContent(key) { result = content() }
+    return result
+  }
+}


### PR DESCRIPTION
Presenters in the backstack get paused when a new presenter gets pushed. This is by design, because they're in the background and should not consume resources. However, they also lose their state, because their composable function is no longer part of the composition.

`rememberSaveable()` provided by the Compose runtime allows you to save and restore state of composable functions. This PR adds a custom implementation for this mechanism, which allows us to return a `Model`, but is otherwise identical.

Notice in the video how the counter value is restored. Previously it was always reset the 0.

https://github.com/user-attachments/assets/d3504a56-b9c5-4314-8ffb-290c120a7b17



