### PR TITLE
Adding Unit tests to the current starter blueprint

### DIFF
--- a/blueprints/starter/gradle/libs.versions.toml
+++ b/blueprints/starter/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+assertk = "0.25"
 app-platfrom = "0.0.3"
 agp = "8.11.1"
 android-compileSdk = "36"
@@ -16,10 +17,13 @@ material = "1.7.3"
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity-compose" }
 androidx-lifecycle-viewmodel = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-viewmodel", version.ref = "androidx-lifecycle" }
+assertk = { module = "com.willowtreeapps.assertk:assertk", version.ref = "assertk" }
 compose-material = { module = "org.jetbrains.compose.material3:material3", version.ref = "compose" }
 compose-material-icons = { module = "org.jetbrains.compose.material:material-icons-extended", version.ref = "material" }
+compose-uitest = { module = "org.jetbrains.compose.ui:ui-test", version.ref = "compose" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "coroutines" }
+coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 compose-desktop-currentOs = { module = "org.jetbrains.compose.desktop:desktop", version.ref = "compose" }
 
 [plugins]

--- a/blueprints/starter/navigation/impl/src/commonTest/kotlin/software/amazon/app/platform/template/navigation/NavigationDetailPresenterTest.kt
+++ b/blueprints/starter/navigation/impl/src/commonTest/kotlin/software/amazon/app/platform/template/navigation/NavigationDetailPresenterTest.kt
@@ -1,0 +1,39 @@
+package software.amazon.app.platform.template.navigation
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+import software.amazon.app.platform.presenter.molecule.test
+import kotlin.time.Duration.Companion.milliseconds
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class NavigationDetailPresenterTest {
+
+  @Test
+  fun `model changes when setExampleFlowValue is called`() = runTest {
+    val exampleRepository = FakeExampleRepository()
+    NavigationDetailPresenterImpl(exampleRepository).test(this) {
+      awaitItem().let { model ->
+        assertThat(model.exampleValue).isEqualTo(0)
+        assertThat(model.exampleCount).isEqualTo(0)
+      }
+
+      exampleRepository.setExampleFlowValue(5)
+
+      awaitItem().let { model ->
+        assertThat(model.exampleValue).isEqualTo(5)
+      }
+
+      // There is a 1 milli delay within presenter before updating count.
+      advanceTimeBy(1.milliseconds)
+
+      awaitItem().let { model ->
+        assertThat(model.exampleValue).isEqualTo(5)
+        assertThat(model.exampleCount).isEqualTo(1)
+      }
+    }
+  }
+}

--- a/blueprints/starter/navigation/impl/src/commonTest/kotlin/software/amazon/app/platform/template/navigation/NavigationDetailPresenterTest.kt
+++ b/blueprints/starter/navigation/impl/src/commonTest/kotlin/software/amazon/app/platform/template/navigation/NavigationDetailPresenterTest.kt
@@ -2,12 +2,12 @@ package software.amazon.app.platform.template.navigation
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceTimeBy
-import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
 import software.amazon.app.platform.presenter.molecule.test
-import kotlin.time.Duration.Companion.milliseconds
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class NavigationDetailPresenterTest {
@@ -23,9 +23,7 @@ class NavigationDetailPresenterTest {
 
       exampleRepository.setExampleFlowValue(5)
 
-      awaitItem().let { model ->
-        assertThat(model.exampleValue).isEqualTo(5)
-      }
+      awaitItem().let { model -> assertThat(model.exampleValue).isEqualTo(5) }
 
       // There is a 1 milli delay within presenter before updating count.
       advanceTimeBy(1.milliseconds)

--- a/blueprints/starter/navigation/impl/src/commonTest/kotlin/software/amazon/app/platform/template/navigation/NavigationPresenterImplTest.kt
+++ b/blueprints/starter/navigation/impl/src/commonTest/kotlin/software/amazon/app/platform/template/navigation/NavigationPresenterImplTest.kt
@@ -11,32 +11,28 @@ import software.amazon.app.platform.template.templates.AppTemplate
 class NavigationPresenterImplTest {
 
   @Test
-  fun `correct template and presenter models are returned`() =
-    runTest {
-      val presenter =
-        NavigationPresenterImpl(
-          navigationHeaderPresenter = FakeNavigationHeaderPresenter(),
-          navigationDetailPresenter = FakeNavigationDetailPresenter(),
-        )
+  fun `correct template and presenter models are returned`() = runTest {
+    val presenter =
+      NavigationPresenterImpl(
+        navigationHeaderPresenter = FakeNavigationHeaderPresenter(),
+        navigationDetailPresenter = FakeNavigationDetailPresenter(),
+      )
 
-      presenter.test(this) {
-        awaitItem().let { template ->
-          assertThat(template).isInstanceOf<AppTemplate.HeaderDetailTemplate>()
-          (template as? AppTemplate.HeaderDetailTemplate)?.let { headerDetailTemplate ->
-            assertThat(headerDetailTemplate.header).isInstanceOf<NavigationHeaderPresenter.Model>()
-            assertThat(headerDetailTemplate.detail).isInstanceOf<NavigationDetailPresenter.Model>()
-          }
+    presenter.test(this) {
+      awaitItem().let { template ->
+        assertThat(template).isInstanceOf<AppTemplate.HeaderDetailTemplate>()
+        (template as? AppTemplate.HeaderDetailTemplate)?.let { headerDetailTemplate ->
+          assertThat(headerDetailTemplate.header).isInstanceOf<NavigationHeaderPresenter.Model>()
+          assertThat(headerDetailTemplate.detail).isInstanceOf<NavigationDetailPresenter.Model>()
         }
       }
     }
+  }
 
   private class FakeNavigationDetailPresenter : NavigationDetailPresenter {
     @Composable
     override fun present(input: Unit): NavigationDetailPresenter.Model =
-      NavigationDetailPresenter.Model(
-        exampleValue = 5,
-        exampleCount = 1,
-      )
+      NavigationDetailPresenter.Model(exampleValue = 5, exampleCount = 1)
   }
 
   private class FakeNavigationHeaderPresenter : NavigationHeaderPresenter {

--- a/blueprints/starter/navigation/impl/src/commonTest/kotlin/software/amazon/app/platform/template/navigation/NavigationPresenterImplTest.kt
+++ b/blueprints/starter/navigation/impl/src/commonTest/kotlin/software/amazon/app/platform/template/navigation/NavigationPresenterImplTest.kt
@@ -1,0 +1,47 @@
+package software.amazon.app.platform.template.navigation
+
+import androidx.compose.runtime.Composable
+import assertk.assertThat
+import assertk.assertions.isInstanceOf
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+import software.amazon.app.platform.presenter.molecule.test
+import software.amazon.app.platform.template.templates.AppTemplate
+
+class NavigationPresenterImplTest {
+
+  @Test
+  fun `correct template and presenter models are returned`() =
+    runTest {
+      val presenter =
+        NavigationPresenterImpl(
+          navigationHeaderPresenter = FakeNavigationHeaderPresenter(),
+          navigationDetailPresenter = FakeNavigationDetailPresenter(),
+        )
+
+      presenter.test(this) {
+        awaitItem().let { template ->
+          assertThat(template).isInstanceOf<AppTemplate.HeaderDetailTemplate>()
+          (template as? AppTemplate.HeaderDetailTemplate)?.let { headerDetailTemplate ->
+            assertThat(headerDetailTemplate.header).isInstanceOf<NavigationHeaderPresenter.Model>()
+            assertThat(headerDetailTemplate.detail).isInstanceOf<NavigationDetailPresenter.Model>()
+          }
+        }
+      }
+    }
+
+  private class FakeNavigationDetailPresenter : NavigationDetailPresenter {
+    @Composable
+    override fun present(input: Unit): NavigationDetailPresenter.Model =
+      NavigationDetailPresenter.Model(
+        exampleValue = 5,
+        exampleCount = 1,
+      )
+  }
+
+  private class FakeNavigationHeaderPresenter : NavigationHeaderPresenter {
+    @Composable
+    override fun present(input: Unit): NavigationHeaderPresenter.Model =
+      NavigationHeaderPresenter.Model(exampleBoolean = true)
+  }
+}

--- a/blueprints/starter/navigation/testing/build.gradle.kts
+++ b/blueprints/starter/navigation/testing/build.gradle.kts
@@ -10,7 +10,6 @@ plugins {
 }
 
 appPlatform {
-  enableComposeUi(true)
   enableModuleStructure(true)
   enableKotlinInject(true)
   enableMoleculePresenters(true)
@@ -42,31 +41,17 @@ kotlin {
   sourceSets {
     commonMain {
       dependencies {
-        implementation(libs.compose.material)
-        implementation(libs.compose.material.icons)
-        implementation(project(":templates:public"))
-      }
-    }
-    commonTest {
-      dependencies {
-        implementation(kotlin("test"))
-        implementation(libs.assertk)
-        implementation(libs.coroutines.test)
-        implementation(project(":navigation:testing"))
+        implementation(libs.kotlinx.coroutines.core)
       }
     }
   }
 }
 
 android {
-  namespace = "software.amazon.app.platform.template.navigation.impl"
+  namespace = "software.amazon.app.platform.template.navigation"
   compileSdk = libs.versions.android.compileSdk.get().toInt()
 
   defaultConfig {
     minSdk = libs.versions.android.minSdk.get().toInt()
-  }
-
-  testOptions.unitTests {
-    isReturnDefaultValues = true
   }
 }

--- a/blueprints/starter/navigation/testing/src/commonMain/kotlin/software/amazon/app/platform/template/navigation/FakeExampleRepository.kt
+++ b/blueprints/starter/navigation/testing/src/commonMain/kotlin/software/amazon/app/platform/template/navigation/FakeExampleRepository.kt
@@ -1,0 +1,17 @@
+package software.amazon.app.platform.template.navigation
+
+import kotlinx.coroutines.flow.MutableStateFlow
+
+/**
+ * Fake implementation of [ExampleRepository], which is useful in unit tests.
+ *
+ * This class is part of the `:testing` module and shared with other modules.
+ */
+class FakeExampleRepository(
+  override val exampleStateFlow: MutableStateFlow<Int> = MutableStateFlow(0)
+) : ExampleRepository {
+
+  override fun setExampleFlowValue(value: Int) {
+    exampleStateFlow.value = value
+  }
+}

--- a/blueprints/starter/settings.gradle.kts
+++ b/blueprints/starter/settings.gradle.kts
@@ -18,5 +18,6 @@ rootProject.name = "Template"
 include(":app")
 include(":navigation:impl")
 include(":navigation:public")
+include(":navigation:testing")
 include(":templates:impl")
 include(":templates:public")


### PR DESCRIPTION
Adding in all the needed dependencies to enable the creation of unit tests for presenters. Added in 2 different presenter tests, NavigationPresenter and NavigationDetailPresenter.
