### PR TITLE
Support Back gestures for presenters.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ android-minSdk = "21"
 android-targetSdk = "36"
 #noinspection GradleDependency
 androidx-activity = "1.8.2"
+androidx-annotations = "1.9.1"
 androidx-collection = "1.5.0"
 #noinspection GradleDependency
 androidx-constraintlayout = "2.1.4"
@@ -56,6 +57,7 @@ viewbinding = "7.0.0"
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 android-gradle-plugin-api = { module = "com.android.tools.build:gradle-api", version.ref = "agp" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
+androidx-annotations = { module = "androidx.annotation:annotation", version.ref = "androidx-annotations" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-collection = { module = "androidx.collection:collection", version.ref = "androidx-collection" }

--- a/presenter-molecule/impl/api/android/impl.api
+++ b/presenter-molecule/impl/api/android/impl.api
@@ -5,3 +5,11 @@ public final class software/amazon/app/platform/presenter/molecule/AndroidMolecu
 	public fun createMoleculeScopeFromCoroutineScope (Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;)Lsoftware/amazon/app/platform/presenter/molecule/MoleculeScope;
 }
 
+public final class software/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenter : software/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun PredictiveBackHandlerPresenter (ZLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+	public fun getListenersCount ()Lkotlinx/coroutines/flow/StateFlow;
+	public fun onPredictiveBack (Lkotlinx/coroutines/flow/Flow;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+

--- a/presenter-molecule/impl/api/desktop/impl.api
+++ b/presenter-molecule/impl/api/desktop/impl.api
@@ -5,3 +5,11 @@ public final class software/amazon/app/platform/presenter/molecule/DesktopMolecu
 	public fun createMoleculeScopeFromCoroutineScope (Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;)Lsoftware/amazon/app/platform/presenter/molecule/MoleculeScope;
 }
 
+public final class software/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenter : software/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun PredictiveBackHandlerPresenter (ZLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+	public fun getListenersCount ()Lkotlinx/coroutines/flow/StateFlow;
+	public fun onPredictiveBack (Lkotlinx/coroutines/flow/Flow;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+

--- a/presenter-molecule/impl/build.gradle
+++ b/presenter-molecule/impl/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     commonMainApi project(':scope:public')
 
     commonTestImplementation project(':kotlin-inject:impl')
+    commonTestImplementation project(':presenter-molecule:testing')
     commonTestImplementation libs.kotlin.inject.runtime.kmp
 }
 

--- a/presenter-molecule/impl/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenter.kt
+++ b/presenter-molecule/impl/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenter.kt
@@ -1,0 +1,79 @@
+package software.amazon.app.platform.presenter.molecule.backgesture
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import me.tatarka.inject.annotations.Inject
+import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
+import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
+
+/**
+ * Implementation of [BackGestureDispatcherPresenter] that maintains a list of registered back
+ * gesture listeners and forwards events to the last registered callback. See
+ * [BackGestureDispatcherPresenter] for more details.
+ */
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+public class DefaultBackGestureDispatcherPresenter : BackGestureDispatcherPresenter {
+
+  private val listeners = mutableListOf<Listener>()
+
+  private val _listenersCount = MutableStateFlow(0)
+  override val listenersCount: StateFlow<Int> = _listenersCount
+
+  override suspend fun onPredictiveBack(progress: Flow<BackEventPresenter>) {
+    val listener =
+      checkNotNull(listeners.lastOrNull { it.enabled }) {
+        "No back gesture listener was registered or they were all disabled. " +
+          "Check `listenerCount` before invoking this function."
+      }
+
+    listener.onBack(progress)
+  }
+
+  @Composable
+  override fun PredictiveBackHandlerPresenter(
+    enabled: Boolean,
+    onBack: suspend (Flow<BackEventPresenter>) -> Unit,
+  ) {
+    // This implementation is somewhat inspired by
+    // https://github.com/JetBrains/compose-multiplatform-core/blob/244635e202f9aa734bd8c86bd1748a9065ecd818/compose/ui/ui-backhandler/src/jbMain/kotlin/androidx/compose/ui/backhandler/BackHandler.jb.kt
+
+    // Ensure we don't re-register callbacks when onBack changes. It's always the same `listener`
+    // instance with its own callback that invokes the updated `onBack`.
+    val currentOnBack by rememberUpdatedState(onBack)
+    val listener = remember { Listener(enabled) { currentOnBack(it) } }
+
+    LaunchedEffect(enabled) {
+      listener.enabled = enabled
+      updateListenersCount()
+    }
+
+    DisposableEffect(Unit) {
+      listeners += listener
+      updateListenersCount()
+
+      onDispose {
+        listeners.remove(listener)
+        updateListenersCount()
+      }
+    }
+  }
+
+  private fun updateListenersCount() {
+    _listenersCount.value = listeners.count { it.enabled }
+  }
+
+  private class Listener(
+    var enabled: Boolean,
+    val onBack: suspend (Flow<BackEventPresenter>) -> Unit,
+  )
+}

--- a/presenter-molecule/impl/src/commonTest/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterTest.kt
+++ b/presenter-molecule/impl/src/commonTest/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterTest.kt
@@ -1,0 +1,232 @@
+package software.amazon.app.platform.presenter.molecule.backgesture
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import assertk.assertions.messageContains
+import kotlin.test.Test
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import software.amazon.app.platform.presenter.BaseModel
+import software.amazon.app.platform.presenter.molecule.MoleculePresenter
+import software.amazon.app.platform.presenter.molecule.returningCompositionLocalProvider
+import software.amazon.app.platform.presenter.molecule.test
+
+class DefaultBackGestureDispatcherPresenterTest {
+  @Test
+  fun `the back handler is invoked`() = runTest {
+    val dispatcher = DefaultBackGestureDispatcherPresenter()
+
+    data class Model(val backPressCount: Int) : BaseModel
+
+    val presenter =
+      object : MoleculePresenter<Unit, Model> {
+        @Composable
+        override fun present(input: Unit): Model {
+          var backPressCount by remember { mutableIntStateOf(0) }
+          BackHandlerPresenter { backPressCount++ }
+
+          return Model(backPressCount = backPressCount)
+        }
+      }
+
+    RootPresenter(dispatcher, presenter).test(this) {
+      assertThat(awaitItem().backPressCount).isEqualTo(0)
+
+      dispatcher.onPredictiveBack(emptyFlow())
+      assertThat(awaitItem().backPressCount).isEqualTo(1)
+
+      dispatcher.onPredictiveBack(emptyFlow())
+      assertThat(awaitItem().backPressCount).isEqualTo(2)
+    }
+  }
+
+  @Test
+  fun `the predictive back handler is invoked`() = runTest {
+    val dispatcher = DefaultBackGestureDispatcherPresenter()
+
+    data class Model(val lastEvent: BackEventPresenter?) : BaseModel
+
+    val presenter =
+      object : MoleculePresenter<Unit, Model> {
+        @Composable
+        override fun present(input: Unit): Model {
+          var lastEvent by remember { mutableStateOf<BackEventPresenter?>(null) }
+
+          PredictiveBackHandlerPresenter { progress -> progress.collect { lastEvent = it } }
+
+          return Model(lastEvent = lastEvent)
+        }
+      }
+
+    RootPresenter(dispatcher, presenter).test(this) {
+      assertThat(awaitItem().lastEvent).isNull()
+
+      dispatcher.onPredictiveBack(
+        flowOf(BackEventPresenter(1f, 1f, 1f, BackEventPresenter.EDGE_RIGHT))
+      )
+      assertThat(awaitItem().lastEvent?.touchX).isEqualTo(1f)
+    }
+  }
+
+  @Test
+  fun `the last enabled handler wins`() = runTest {
+    val dispatcher = DefaultBackGestureDispatcherPresenter()
+
+    data class Model(val backPressCount1: Int, val backPressCount2: Int) : BaseModel
+
+    val presenter =
+      object : MoleculePresenter<Unit, Model> {
+        @Composable
+        override fun present(input: Unit): Model {
+          var backPressCount1 by remember { mutableIntStateOf(0) }
+          BackHandlerPresenter { backPressCount1++ }
+
+          var backPressCount2 by remember { mutableIntStateOf(0) }
+          BackHandlerPresenter(enabled = backPressCount2 == 0) { backPressCount2++ }
+
+          return Model(backPressCount1 = backPressCount1, backPressCount2 = backPressCount2)
+        }
+      }
+
+    RootPresenter(dispatcher, presenter).test(this) {
+      with(awaitItem()) {
+        assertThat(backPressCount1).isEqualTo(0)
+        assertThat(backPressCount2).isEqualTo(0)
+      }
+
+      dispatcher.onPredictiveBack(emptyFlow())
+      with(awaitItem()) {
+        assertThat(backPressCount1).isEqualTo(0)
+        assertThat(backPressCount2).isEqualTo(1)
+      }
+
+      dispatcher.onPredictiveBack(emptyFlow())
+      with(awaitItem()) {
+        assertThat(backPressCount1).isEqualTo(1)
+        assertThat(backPressCount2).isEqualTo(1)
+      }
+    }
+  }
+
+  @Test
+  fun `not registering BackGestureDispatcherPresenter as composition local throws an error`() =
+    runTest {
+      data class Model(val backPressCount: Int) : BaseModel
+
+      val presenter =
+        object : MoleculePresenter<Unit, Model> {
+          @Composable
+          override fun present(input: Unit): Model {
+            var backPressCount by remember { mutableIntStateOf(0) }
+            BackHandlerPresenter { backPressCount++ }
+
+            return Model(backPressCount = backPressCount)
+          }
+        }
+
+      assertFailure { presenter.test(this) {} }
+        .messageContains(
+          "Couldn't find the BackGestureDispatcherPresenter in the presenter hierarchy. " +
+            "Did you register the BackGestureDispatcherPresenter instance as composition local? " +
+            "See LocalBackGestureDispatcherPresenter for more details."
+        )
+    }
+
+  @Test
+  fun `the listener count increases with the number of enabled handlers`() =
+    runTest(UnconfinedTestDispatcher()) {
+      val dispatcher = DefaultBackGestureDispatcherPresenter()
+
+      var handlers by mutableIntStateOf(0)
+      var disabledHandlers by mutableIntStateOf(0)
+
+      class Model : BaseModel
+      val model = Model()
+
+      val presenter =
+        object : MoleculePresenter<Unit, Model> {
+          @Composable
+          override fun present(input: Unit): Model {
+            repeat(handlers) { index ->
+              BackHandlerPresenter(enabled = index >= disabledHandlers) {}
+            }
+
+            return model
+          }
+        }
+
+      RootPresenter(dispatcher, presenter).test(this) {
+        skipItems(1)
+
+        assertThat(dispatcher.listenersCount.value).isEqualTo(0)
+
+        handlers = 2
+        assertThat(dispatcher.listenersCount.value).isEqualTo(2)
+
+        disabledHandlers = 1
+        assertThat(dispatcher.listenersCount.value).isEqualTo(1)
+      }
+    }
+
+  @Test
+  fun `calling onPredictiveBack without a registered handler is an error`() =
+    runTest(UnconfinedTestDispatcher()) {
+      val dispatcher = DefaultBackGestureDispatcherPresenter()
+
+      var handlerEnabled by mutableStateOf(true)
+
+      data class Model(val count: Int) : BaseModel
+
+      val presenter =
+        object : MoleculePresenter<Unit, Model> {
+          @Composable
+          override fun present(input: Unit): Model {
+            var count by remember { mutableIntStateOf(0) }
+            BackHandlerPresenter(enabled = handlerEnabled) { count++ }
+
+            return Model(count)
+          }
+        }
+
+      RootPresenter(dispatcher, presenter).test(this) {
+        assertThat(awaitItem().count).isEqualTo(0)
+        assertThat(dispatcher.listenersCount.value).isEqualTo(1)
+
+        dispatcher.onPredictiveBack(emptyFlow())
+        assertThat(awaitItem().count).isEqualTo(1)
+
+        handlerEnabled = false
+        assertThat(dispatcher.listenersCount.value).isEqualTo(0)
+
+        assertFailure { dispatcher.onPredictiveBack(emptyFlow()) }
+          .messageContains(
+            "No back gesture listener was registered or they were all disabled. Check " +
+              "`listenerCount` before invoking this function."
+          )
+      }
+    }
+
+  private class RootPresenter<ModelT : BaseModel>(
+    private val dispatcher: BackGestureDispatcherPresenter,
+    private val presenter: MoleculePresenter<Unit, ModelT>,
+  ) : MoleculePresenter<Unit, ModelT> {
+    @Composable
+    override fun present(input: Unit): ModelT {
+      return returningCompositionLocalProvider(
+        LocalBackGestureDispatcherPresenter provides dispatcher
+      ) {
+        presenter.present(Unit)
+      }
+    }
+  }
+}

--- a/presenter-molecule/public/api/android/public.api
+++ b/presenter-molecule/public/api/android/public.api
@@ -30,3 +30,30 @@ public final class software/amazon/app/platform/presenter/molecule/ReturningComp
 	public static final fun returningCompositionLocalProvider ([Landroidx/compose/runtime/ProvidedValue;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)Lsoftware/amazon/app/platform/presenter/BaseModel;
 }
 
+public final class software/amazon/app/platform/presenter/molecule/backgesture/BackEventPresenter {
+	public static final field $stable I
+	public static final field Companion Lsoftware/amazon/app/platform/presenter/molecule/backgesture/BackEventPresenter$Companion;
+	public static final field EDGE_LEFT I
+	public static final field EDGE_RIGHT I
+	public fun <init> (FFFI)V
+	public final fun getProgress ()F
+	public final fun getSwipeEdge ()I
+	public final fun getTouchX ()F
+	public final fun getTouchY ()F
+}
+
+public final class software/amazon/app/platform/presenter/molecule/backgesture/BackEventPresenter$Companion {
+}
+
+public abstract interface class software/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter {
+	public abstract fun PredictiveBackHandlerPresenter (ZLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun getListenersCount ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun onPredictiveBack (Lkotlinx/coroutines/flow/Flow;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class software/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenterKt {
+	public static final fun BackHandlerPresenter (Lsoftware/amazon/app/platform/presenter/molecule/MoleculePresenter;ZLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)V
+	public static final fun PredictiveBackHandlerPresenter (Lsoftware/amazon/app/platform/presenter/molecule/MoleculePresenter;ZLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun getLocalBackGestureDispatcherPresenter ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+

--- a/presenter-molecule/public/api/desktop/public.api
+++ b/presenter-molecule/public/api/desktop/public.api
@@ -30,3 +30,30 @@ public final class software/amazon/app/platform/presenter/molecule/ReturningComp
 	public static final fun returningCompositionLocalProvider ([Landroidx/compose/runtime/ProvidedValue;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)Lsoftware/amazon/app/platform/presenter/BaseModel;
 }
 
+public final class software/amazon/app/platform/presenter/molecule/backgesture/BackEventPresenter {
+	public static final field $stable I
+	public static final field Companion Lsoftware/amazon/app/platform/presenter/molecule/backgesture/BackEventPresenter$Companion;
+	public static final field EDGE_LEFT I
+	public static final field EDGE_RIGHT I
+	public fun <init> (FFFI)V
+	public final fun getProgress ()F
+	public final fun getSwipeEdge ()I
+	public final fun getTouchX ()F
+	public final fun getTouchY ()F
+}
+
+public final class software/amazon/app/platform/presenter/molecule/backgesture/BackEventPresenter$Companion {
+}
+
+public abstract interface class software/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter {
+	public abstract fun PredictiveBackHandlerPresenter (ZLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun getListenersCount ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun onPredictiveBack (Lkotlinx/coroutines/flow/Flow;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class software/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenterKt {
+	public static final fun BackHandlerPresenter (Lsoftware/amazon/app/platform/presenter/molecule/MoleculePresenter;ZLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)V
+	public static final fun PredictiveBackHandlerPresenter (Lsoftware/amazon/app/platform/presenter/molecule/MoleculePresenter;ZLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun getLocalBackGestureDispatcherPresenter ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+

--- a/presenter-molecule/public/build.gradle
+++ b/presenter-molecule/public/build.gradle
@@ -9,6 +9,7 @@ appPlatformBuildSrc {
 
 dependencies {
     commonMainApi project(':presenter:public')
+    commonMainApi libs.androidx.annotations
     commonTestImplementation project(':internal:testing')
     commonTestImplementation project(':presenter-molecule:testing')
 }

--- a/presenter-molecule/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/BackEventPresenter.kt
+++ b/presenter-molecule/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/BackEventPresenter.kt
@@ -1,0 +1,38 @@
+package software.amazon.app.platform.presenter.molecule.backgesture
+
+import androidx.annotation.FloatRange
+import androidx.annotation.IntRange
+
+/**
+ * Object used to report back gesture progress. Holds information about the touch event, swipe
+ * direction and the animation progress that predictive back animations should seek to.
+ */
+// Note, this is a copy from
+// https://github.com/JetBrains/compose-multiplatform-core/blob/244635e202f9aa734bd8c86bd1748a9065ecd818/compose/ui/ui-backhandler/src/commonMain/kotlin/androidx/compose/ui/backhandler/BackEventCompat.kt
+//
+// By copying the class we don't need to expose the Compose Multiplatform APIs from the presenter
+// artifact, which is independent of the UI layer implementation.
+public class BackEventPresenter(
+  /**
+   * Absolute X location of the touch point of this event in the coordinate space of the view that
+   * * received this back event.
+   */
+  public val touchX: Float,
+  /**
+   * Absolute Y location of the touch point of this event in the coordinate space of the view that
+   * received this back event.
+   */
+  public val touchY: Float,
+  /** Value between 0 and 1 on how far along the back gesture is. */
+  @get:FloatRange(from = 0.0, to = 1.0) public val progress: Float,
+  /** Indicates which edge the swipe starts from. */
+  @get:IntRange(from = 0, to = 1) public val swipeEdge: Int,
+) {
+  public companion object {
+    /** Indicates that the edge swipe starts from the left edge of the screen. */
+    public const val EDGE_LEFT: Int = 0
+
+    /** Indicates that the edge swipe starts from the right edge of the screen. */
+    public const val EDGE_RIGHT: Int = 1
+  }
+}

--- a/presenter-molecule/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter.kt
+++ b/presenter-molecule/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter.kt
@@ -1,0 +1,149 @@
+package software.amazon.app.platform.presenter.molecule.backgesture
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.compositionLocalOf
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+import software.amazon.app.platform.presenter.molecule.MoleculePresenter
+
+/**
+ * A dispatcher that forwards back press events from the UI layer to presenters. Internally it
+ * manages a list of listeners and determines which listener is actively handling back gesture
+ * events.
+ *
+ * This class facilitates managing multiple back gesture event listeners, allowing the most recently
+ * added and enabled listener to handle events.
+ *
+ * An implementation of this interface is provided by App Platform and it's safe to inject this type
+ * within the App scope.
+ */
+public interface BackGestureDispatcherPresenter {
+  /**
+   * The count of enabled listeners. The UI layer should observe this count and enable the back
+   * gesture callback if its greater than 0 and disable the callback for a count of 0.
+   */
+  public val listenersCount: StateFlow<Int>
+
+  /**
+   * This is the callback for the UI layer to forward back press events to presenters when they
+   * happen. The [progress] Flow will be consumed by presenters.
+   */
+  public suspend fun onPredictiveBack(progress: Flow<BackEventPresenter>)
+
+  /**
+   * Presenters call this function to register the [onBack] callback for back press gestures. See
+   * [software.amazon.app.platform.presenter.molecule.backgesture.PredictiveBackHandlerPresenter]
+   * for more details.
+   */
+  @Composable
+  public fun PredictiveBackHandlerPresenter(
+    enabled: Boolean,
+    onBack: suspend (progress: Flow<BackEventPresenter>) -> Unit,
+  )
+}
+
+/**
+ * Provides the instance of [BackGestureDispatcherPresenter] to the presenter hierarchy. This value
+ * is used by [PredictiveBackHandlerPresenter] and [BackHandlerPresenter]. If the value is not
+ * provided, then these functions will throw an error when used.
+ *
+ * This composition local is usually registered in the root presenter of the presenter hierarchy,
+ * e.g.
+ *
+ * ```
+ * @Inject
+ * class RootPresenter(
+ *   private val backPressDispatcherPresenter: BackPressDispatcherPresenter,
+ * ) : MoleculePresenter<Unit, Model> {
+ *   @Composable
+ *   override fun present(input: Unit): Model {
+ *     return returningCompositionLocalProvider(
+ *       LocalBackPressDispatcherPresenter provides backPressDispatcherPresenter
+ *     ) {
+ *       ... // Call other presenters.
+ *     }
+ *   }
+ * }
+ * ```
+ */
+public val LocalBackGestureDispatcherPresenter:
+  ProvidableCompositionLocal<BackGestureDispatcherPresenter?> =
+  compositionLocalOf {
+    null
+  }
+
+/**
+ * An effect for handling predictive system back gestures.
+ *
+ * Calling this in your presenter adds the given [onBack] lambda to the
+ * [BackGestureDispatcherPresenter]. The lambda passes in a `Flow<BackEventPresenter>` where each
+ * [BackEventPresenter] reflects the progress of current gesture back. The lambda content should
+ * follow this structure:
+ * ```
+ * PredictiveBackHandler { progress: Flow<BackEventCompat> ->
+ *   // code for gesture back started
+ *   try {
+ *     progress.collect { backevent ->
+ *       // code for progress
+ *     }
+ *     // code for completion
+ *   } catch (e: CancellationException) {
+ *     // code for cancellation
+ *   }
+ * }
+ * ```
+ *
+ * If this is called by nested composables, if enabled, the inner most composable will consume the
+ * call to system back and invoke its lambda. The call will continue to propagate up until it finds
+ * an enabled BackHandler.
+ *
+ * @param enabled if this BackHandler should be enabled, true by default.
+ * @param onBack the action invoked by back gesture.
+ */
+// Note that the receiver parameter is used to ensure that this function is only called within a
+// presenter. This will make sure that a renderer doesn't call this function accidentally.
+@Suppress("UnusedReceiverParameter")
+@Composable
+public fun MoleculePresenter<*, *>.PredictiveBackHandlerPresenter(
+  enabled: Boolean = true,
+  onBack: suspend (progress: Flow<BackEventPresenter>) -> Unit,
+) {
+  val dispatcher =
+    checkNotNull(LocalBackGestureDispatcherPresenter.current) {
+      "Couldn't find the BackGestureDispatcherPresenter in the presenter hierarchy. " +
+        "Did you register the BackGestureDispatcherPresenter instance as composition " +
+        "local? See LocalBackGestureDispatcherPresenter for more details."
+    }
+  dispatcher.PredictiveBackHandlerPresenter(enabled, onBack)
+}
+
+/**
+ * An effect for handling the back event.
+ *
+ * Calling this in your presenter adds the given lambda to the [BackGestureDispatcherPresenter].
+ *
+ * If this is called by nested composables, if enabled, the inner most composable will consume the
+ * call to system back and invoke its lambda. The call will continue to propagate up until it finds
+ * an enabled BackHandler.
+ *
+ * @param enabled if this BackHandler should be enabled
+ * @param onBack the action invoked by system back event
+ */
+// Note that the receiver parameter is used to ensure that this function is only called within a
+// presenter. This will make sure that a renderer doesn't call this function accidentally.
+@Composable
+public fun MoleculePresenter<*, *>.BackHandlerPresenter(
+  enabled: Boolean = true,
+  onBack: () -> Unit,
+) {
+  PredictiveBackHandlerPresenter(enabled) { progress ->
+    try {
+      progress.collect { /*ignore*/ }
+      onBack()
+    } catch (_: CancellationException) {
+      // ignore
+    }
+  }
+}


### PR DESCRIPTION
This change introduces `BackGestureDispatcherPresenter`, which functions as a bridge between presenters and the UI layer to forward back gestures to presenters.

Two new functions `BackHandlerPresenter {}` and `PredictiveBackHandlerPresenter {}` were introduced that mimic the APIs from Compose Multiplatform `BackHandler {}` and `PredictiveBackHandler` to consume back gestures. The "Presenter" suffix was chosen to avoid conflicts and confusions with the APIs from Compose Multiplatform or Android Compose UI.

The UI layer integration will be implemented in subsequent changes.

See #57
