### PR TITLE
Forward back press events from Compose Multiplatform

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,11 +25,11 @@ assertk = "0.28.1"
 auto-service = "1.1.1"
 auto-service-ksp = "1.2.0"
 build-config = "5.6.7"
-compose-hot-reload-plugin = "1.0.0-beta03"
+compose-hot-reload-plugin = "1.0.0-beta04"
 # https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-compatibility-and-versioning.html#kotlin-compatibility
 # https://mvnrepository.com/artifact/org.jetbrains.compose/compose-gradle-plugin
 # https://github.com/JetBrains/compose-multiplatform/releases
-compose-plugin = "1.8.2"
+compose-multiplatform = "1.8.2"
 coroutines = "1.10.2"
 detekt = "1.23.8"
 graphviz-java = "0.18.1"
@@ -72,7 +72,8 @@ assertk = { module = "com.willowtreeapps.assertk:assertk", version.ref = "assert
 auto-service-annotations = { module = "com.google.auto.service:auto-service-annotations", version.ref = "auto-service" }
 auto-service-ksp = { module = "dev.zacsweers.autoservice:auto-service-ksp", version.ref = "auto-service-ksp" }
 build-config-gradle-plugin = { module = "com.github.gmazzo.buildconfig:plugin", version.ref = "build-config" }
-compose-gradle-plugin = { module = "org.jetbrains.compose:compose-gradle-plugin", version.ref = "compose-plugin" }
+compose-gradle-plugin = { module = "org.jetbrains.compose:compose-gradle-plugin", version.ref = "compose-multiplatform" }
+compose-ui-back-handler = { module = "org.jetbrains.compose.ui:ui-backhandler", version.ref = "compose-multiplatform" }
 compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "android-compose-version" }
 compose-ui-test-junit4-android = { module = "androidx.compose.ui:ui-test-junit4-android", version.ref = "android-compose-version" }
 compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "android-compose-version" }

--- a/presenter-molecule/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter.kt
+++ b/presenter-molecule/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter.kt
@@ -99,6 +99,12 @@ public val LocalBackGestureDispatcherPresenter:
  * call to system back and invoke its lambda. The call will continue to propagate up until it finds
  * an enabled BackHandler.
  *
+ * **Important:** Back gestures can only be handled if a [BackGestureDispatcherPresenter] is
+ * provided as composition local in the presenter hierarchy. See
+ * [LocalBackGestureDispatcherPresenter] for more details. Further, back gestures need to be
+ * forwarded from the UI layer to the [BackGestureDispatcherPresenter], e.g. using
+ * `BackGestureDispatcherPresenter.ForwardBackPressEventsToPresenters()`.
+ *
  * @param enabled if this BackHandler should be enabled, true by default.
  * @param onBack the action invoked by back gesture.
  */
@@ -127,6 +133,12 @@ public fun MoleculePresenter<*, *>.PredictiveBackHandlerPresenter(
  * If this is called by nested composables, if enabled, the inner most composable will consume the
  * call to system back and invoke its lambda. The call will continue to propagate up until it finds
  * an enabled BackHandler.
+ *
+ * **Important:** Back gestures can only be handled if a [BackGestureDispatcherPresenter] is
+ * provided as composition local in the presenter hierarchy. See
+ * [LocalBackGestureDispatcherPresenter] for more details. Further, back gestures need to be
+ * forwarded from the UI layer to the [BackGestureDispatcherPresenter], e.g. using
+ * `BackGestureDispatcherPresenter.ForwardBackPressEventsToPresenters()`.
  *
  * @param enabled if this BackHandler should be enabled
  * @param onBack the action invoked by system back event

--- a/renderer-compose-multiplatform/public/api/android/public.api
+++ b/renderer-compose-multiplatform/public/api/android/public.api
@@ -1,3 +1,7 @@
+public final class software/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenterComposeKt {
+	public static final fun ForwardBackPressEventsToPresenters (Lsoftware/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter;Landroidx/compose/runtime/Composer;I)V
+}
+
 public abstract interface class software/amazon/app/platform/renderer/BaseComposeRenderer {
 	public abstract fun renderCompose (Lsoftware/amazon/app/platform/presenter/BaseModel;Landroidx/compose/runtime/Composer;I)V
 }

--- a/renderer-compose-multiplatform/public/api/desktop/public.api
+++ b/renderer-compose-multiplatform/public/api/desktop/public.api
@@ -1,3 +1,7 @@
+public final class software/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenterComposeKt {
+	public static final fun ForwardBackPressEventsToPresenters (Lsoftware/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter;Landroidx/compose/runtime/Composer;I)V
+}
+
 public abstract interface class software/amazon/app/platform/renderer/BaseComposeRenderer {
 	public abstract fun renderCompose (Lsoftware/amazon/app/platform/presenter/BaseModel;Landroidx/compose/runtime/Composer;I)V
 }

--- a/renderer-compose-multiplatform/public/build.gradle
+++ b/renderer-compose-multiplatform/public/build.gradle
@@ -14,11 +14,16 @@ dependencies {
     commonMainApi project(':renderer:public')
     commonMainApi project(':scope:public')
 
+    commonMainImplementation project(':presenter-molecule:public')
+    commonMainImplementation libs.compose.ui.back.handler
+
     androidMainApi project(':renderer-android-view:public')
 
     commonTestImplementation project(':scope:testing')
 
+    androidTestImplementation project(':presenter-molecule:impl')
     androidTestImplementation libs.androidx.activity.compose
+    androidTestImplementation libs.androidx.test.espresso
     androidTestImplementation libs.compose.ui.test.junit4
     androidTestImplementation libs.compose.ui.test.junit4.android
     androidTestImplementation libs.compose.ui.test.manifest

--- a/renderer-compose-multiplatform/public/src/androidInstrumentedTest/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/ForwardBackPressEventsToPresentersTest.kt
+++ b/renderer-compose-multiplatform/public/src/androidInstrumentedTest/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/ForwardBackPressEventsToPresentersTest.kt
@@ -1,0 +1,94 @@
+package software.amazon.app.platform.presenter.molecule.backgesture
+
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.AndroidComposeTestRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.espresso.Espresso
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import org.junit.Rule
+import org.junit.Test
+import software.amazon.app.platform.presenter.BaseModel
+import software.amazon.app.platform.presenter.molecule.MoleculePresenter
+import software.amazon.app.platform.presenter.molecule.backgesture.ForwardBackPressEventsToPresentersTest.TestPresenter.Model
+import software.amazon.app.platform.presenter.molecule.returningCompositionLocalProvider
+import software.amazon.app.platform.renderer.ComposeRenderer
+import software.amazon.app.platform.renderer.TestActivity
+import software.amazon.app.platform.renderer.getActivityFromTestRule
+
+class ForwardBackPressEventsToPresentersTest {
+
+  @get:Rule val activityRule = ActivityScenarioRule(TestActivity::class.java)
+
+  @get:Rule val composeTestRule = AndroidComposeTestRule(activityRule, ::getActivityFromTestRule)
+
+  @Test
+  fun back_press_events_are_forwarded_to_presenters() {
+    val backGestureDispatcherPresenter = DefaultBackGestureDispatcherPresenter()
+
+    val testPresenter = TestPresenter(backGestureDispatcherPresenter)
+    val testRenderer = TestRenderer()
+    val rootRenderer = RootRenderer(backGestureDispatcherPresenter, testRenderer)
+
+    activityRule.scenario.onActivity { activity ->
+      activity.setContent {
+        val model = testPresenter.present(Unit)
+        rootRenderer.renderCompose(model)
+      }
+    }
+
+    composeTestRule.onNodeWithTag("count").assertTextEquals("Count: 0")
+
+    Espresso.pressBack()
+    composeTestRule.onNodeWithTag("count").assertTextEquals("Count: 1")
+
+    Espresso.pressBack()
+    composeTestRule.onNodeWithTag("count").assertTextEquals("Count: 2")
+  }
+
+  private class RootRenderer(
+    private val backGestureDispatcherPresenter: BackGestureDispatcherPresenter,
+    private val testRenderer: TestRenderer,
+  ) : ComposeRenderer<Model>() {
+    @Composable
+    override fun Compose(model: Model) {
+      backGestureDispatcherPresenter.ForwardBackPressEventsToPresenters()
+
+      testRenderer.renderCompose(model)
+    }
+  }
+
+  private class TestPresenter(
+    private val backGestureDispatcherPresenter: BackGestureDispatcherPresenter
+  ) : MoleculePresenter<Unit, Model> {
+    @Composable
+    override fun present(input: Unit): Model {
+      return returningCompositionLocalProvider(
+        LocalBackGestureDispatcherPresenter provides backGestureDispatcherPresenter
+      ) {
+        var backPressCount by remember { mutableIntStateOf(0) }
+
+        BackHandlerPresenter { backPressCount++ }
+
+        Model(backPressCount = backPressCount)
+      }
+    }
+
+    data class Model(val backPressCount: Int) : BaseModel
+  }
+
+  private class TestRenderer : ComposeRenderer<Model>() {
+    @Composable
+    override fun Compose(model: Model) {
+      BasicText(text = "Count: ${model.backPressCount}", modifier = Modifier.testTag("count"))
+    }
+  }
+}

--- a/renderer-compose-multiplatform/public/src/androidInstrumentedTest/kotlin/software/amazon/app/platform/renderer/ComposeAndroidRendererFactoryDeviceTest.kt
+++ b/renderer-compose-multiplatform/public/src/androidInstrumentedTest/kotlin/software/amazon/app/platform/renderer/ComposeAndroidRendererFactoryDeviceTest.kt
@@ -6,7 +6,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import android.widget.TextView
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.text.BasicText
@@ -329,16 +328,6 @@ class ComposeAndroidRendererFactoryDeviceTest {
     val activityField = ViewRenderer::class.java.declaredFields.single { it.name == "activity" }
     activityField.isAccessible = true
     assertThat(activityField.get(innerRenderer)).isSameInstanceAs(activity)
-  }
-
-  // Borrowed from AndroidComposeTestRule.
-  private fun <A : ComponentActivity> getActivityFromTestRule(rule: ActivityScenarioRule<A>): A {
-    var activity: A? = null
-    rule.scenario.onActivity { activity = it }
-
-    return with(activity) {
-      checkNotNull(this) { "Activity was not set in the ActivityScenarioRule!" }
-    }
   }
 
   private val Activity.contentView: ViewGroup

--- a/renderer-compose-multiplatform/public/src/androidInstrumentedTest/kotlin/software/amazon/app/platform/renderer/TestActivity.kt
+++ b/renderer-compose-multiplatform/public/src/androidInstrumentedTest/kotlin/software/amazon/app/platform/renderer/TestActivity.kt
@@ -1,5 +1,16 @@
 package software.amazon.app.platform.renderer
 
 import androidx.activity.ComponentActivity
+import androidx.test.ext.junit.rules.ActivityScenarioRule
 
 class TestActivity : ComponentActivity()
+
+// Borrowed from AndroidComposeTestRule.
+fun <A : ComponentActivity> getActivityFromTestRule(rule: ActivityScenarioRule<A>): A {
+  var activity: A? = null
+  rule.scenario.onActivity { activity = it }
+
+  return with(activity) {
+    checkNotNull(this) { "Activity was not set in the ActivityScenarioRule!" }
+  }
+}

--- a/renderer-compose-multiplatform/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenterCompose.kt
+++ b/renderer-compose-multiplatform/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenterCompose.kt
@@ -1,0 +1,50 @@
+package software.amazon.app.platform.presenter.molecule.backgesture
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.backhandler.PredictiveBackHandler
+import kotlinx.coroutines.flow.map
+import software.amazon.app.platform.renderer.ComposeRenderer
+
+/**
+ * Registers a callback in the `BackGestureDispatcher` that is enabled as long as there is a
+ * presenter with an enabled back handler.
+ *
+ * It's recommended to call this function from your root [ComposeRenderer], e.g.
+ *
+ * ```
+ * @Inject
+ * @ContributesRenderer
+ * class RootPresenterRenderer(
+ *   private val rendererFactory: RendererFactory,
+ *   private val backGestureDispatcherPresenter: BackGestureDispatcherPresenter,
+ * ) : ComposeRenderer<Model>() {
+ *
+ *   @Composable
+ *   override fun Compose(model: Model) {
+ *     backGestureDispatcherPresenter.ForwardBackPressEventsToPresenters()
+ *
+ *     ...
+ *   }
+ * ```
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+public fun BackGestureDispatcherPresenter.ForwardBackPressEventsToPresenters() {
+  val count by listenersCount.collectAsState()
+
+  PredictiveBackHandler(enabled = count > 0) {
+    onPredictiveBack(
+      it.map { event ->
+        BackEventPresenter(
+          touchX = event.touchX,
+          touchY = event.touchY,
+          progress = event.progress,
+          swipeEdge = event.swipeEdge,
+        )
+      }
+    )
+  }
+}


### PR DESCRIPTION
Provide an easy to use API that forwards back press events from the Compose Multiplatform UI layer to presenters. This makes it easy to setup back press handling for presenters from root renderers for KMP applications.

See #57

