### PR TITLE
Integrate the back press handler into the Recipes app

### DIFF
--- a/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/backstack/CrossSlideBackstackPresenter.kt
+++ b/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/backstack/CrossSlideBackstackPresenter.kt
@@ -3,6 +3,7 @@ package software.amazon.app.platform.recipes.backstack
 import androidx.compose.runtime.Composable
 import software.amazon.app.platform.presenter.BaseModel
 import software.amazon.app.platform.presenter.molecule.MoleculePresenter
+import software.amazon.app.platform.presenter.molecule.backgesture.BackHandlerPresenter
 import software.amazon.app.platform.recipes.appbar.AppBarConfig
 import software.amazon.app.platform.recipes.appbar.AppBarConfigModel
 import software.amazon.app.platform.recipes.backstack.CrossSlideBackstackPresenter.Model
@@ -18,6 +19,9 @@ class CrossSlideBackstackPresenter(
   @Composable
   override fun present(input: Unit): Model {
     return presenterBackstack(initialPresenter) { model ->
+      // Pop the top presenter on a back press event.
+      BackHandlerPresenter(enabled = lastBackstackChange.value.backstack.size > 1) { pop() }
+
       Model(delegate = model, backstackScope = this)
     }
   }

--- a/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/backstack/PresenterBackstackScope.kt
+++ b/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/backstack/PresenterBackstackScope.kt
@@ -139,7 +139,7 @@ val LocalBackstackScope = compositionLocalOf<PresenterBackstackScope?> { null }
 @Composable
 fun <ModelT : BaseModel> presenterBackstack(
   initialPresenter: MoleculePresenter<Unit, out BaseModel>,
-  content: PresenterBackstackScope.(model: BaseModel) -> ModelT,
+  content: @Composable PresenterBackstackScope.(model: BaseModel) -> ModelT,
 ): ModelT {
   val scope = remember { PresenterBackstackScopeImpl(initialPresenter) }
   val saveableStateHolder = rememberReturningSaveableStateHolder()

--- a/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/template/RootPresenterRenderer.kt
+++ b/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/template/RootPresenterRenderer.kt
@@ -31,6 +31,8 @@ import androidx.compose.ui.unit.dp
 import me.tatarka.inject.annotations.Inject
 import software.amazon.app.platform.inject.ContributesRenderer
 import software.amazon.app.platform.presenter.BaseModel
+import software.amazon.app.platform.presenter.molecule.backgesture.BackGestureDispatcherPresenter
+import software.amazon.app.platform.presenter.molecule.backgesture.ForwardBackPressEventsToPresenters
 import software.amazon.app.platform.recipes.appbar.AppBarConfig
 import software.amazon.app.platform.renderer.ComposeRenderer
 import software.amazon.app.platform.renderer.Renderer
@@ -44,10 +46,14 @@ import software.amazon.app.platform.renderer.getComposeRenderer
  */
 @Inject
 @ContributesRenderer
-class RootPresenterRenderer(private val rendererFactory: RendererFactory) :
-  ComposeRenderer<RecipesAppTemplate>() {
+class RootPresenterRenderer(
+  private val rendererFactory: RendererFactory,
+  private val backGestureDispatcherPresenter: BackGestureDispatcherPresenter,
+) : ComposeRenderer<RecipesAppTemplate>() {
   @Composable
   override fun Compose(model: RecipesAppTemplate) {
+    backGestureDispatcherPresenter.ForwardBackPressEventsToPresenters()
+
     when (model) {
       is RecipesAppTemplate.FullScreenTemplate -> FullScreen(model)
     }


### PR DESCRIPTION
Pop elements from the backstack when the back button is pressed. This works on all platforms, even Desktop where the Escape key functions as back button by default.

See #57

https://github.com/user-attachments/assets/21894f0f-b473-4103-9ad3-35c6fe1faffb

