### PR TITLE
Provide an easy to use back press testing API

### DIFF
--- a/presenter-molecule/impl/build.gradle
+++ b/presenter-molecule/impl/build.gradle
@@ -15,7 +15,6 @@ dependencies {
     commonMainApi project(':scope:public')
 
     commonTestImplementation project(':kotlin-inject:impl')
-    commonTestImplementation project(':presenter-molecule:testing')
     commonTestImplementation libs.kotlin.inject.runtime.kmp
 }
 

--- a/presenter-molecule/impl/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenter.kt
+++ b/presenter-molecule/impl/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenter.kt
@@ -1,14 +1,5 @@
 package software.amazon.app.platform.presenter.molecule.backgesture
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import me.tatarka.inject.annotations.Inject
 import software.amazon.lastmile.kotlin.inject.anvil.AppScope
 import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
@@ -22,58 +13,5 @@ import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 @Inject
 @SingleIn(AppScope::class)
 @ContributesBinding(AppScope::class)
-public class DefaultBackGestureDispatcherPresenter : BackGestureDispatcherPresenter {
-
-  private val listeners = mutableListOf<Listener>()
-
-  private val _listenersCount = MutableStateFlow(0)
-  override val listenersCount: StateFlow<Int> = _listenersCount
-
-  override suspend fun onPredictiveBack(progress: Flow<BackEventPresenter>) {
-    val listener =
-      checkNotNull(listeners.lastOrNull { it.enabled }) {
-        "No back gesture listener was registered or they were all disabled. " +
-          "Check `listenerCount` before invoking this function."
-      }
-
-    listener.onBack(progress)
-  }
-
-  @Composable
-  override fun PredictiveBackHandlerPresenter(
-    enabled: Boolean,
-    onBack: suspend (Flow<BackEventPresenter>) -> Unit,
-  ) {
-    // This implementation is somewhat inspired by
-    // https://github.com/JetBrains/compose-multiplatform-core/blob/244635e202f9aa734bd8c86bd1748a9065ecd818/compose/ui/ui-backhandler/src/jbMain/kotlin/androidx/compose/ui/backhandler/BackHandler.jb.kt
-
-    // Ensure we don't re-register callbacks when onBack changes. It's always the same `listener`
-    // instance with its own callback that invokes the updated `onBack`.
-    val currentOnBack by rememberUpdatedState(onBack)
-    val listener = remember { Listener(enabled) { currentOnBack(it) } }
-
-    LaunchedEffect(enabled) {
-      listener.enabled = enabled
-      updateListenersCount()
-    }
-
-    DisposableEffect(Unit) {
-      listeners += listener
-      updateListenersCount()
-
-      onDispose {
-        listeners.remove(listener)
-        updateListenersCount()
-      }
-    }
-  }
-
-  private fun updateListenersCount() {
-    _listenersCount.value = listeners.count { it.enabled }
-  }
-
-  private class Listener(
-    var enabled: Boolean,
-    val onBack: suspend (Flow<BackEventPresenter>) -> Unit,
-  )
-}
+public class DefaultBackGestureDispatcherPresenter :
+  BackGestureDispatcherPresenter by BackGestureDispatcherPresenter.createNewInstance()

--- a/presenter-molecule/public/api/android/public.api
+++ b/presenter-molecule/public/api/android/public.api
@@ -46,9 +46,14 @@ public final class software/amazon/app/platform/presenter/molecule/backgesture/B
 }
 
 public abstract interface class software/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter {
+	public static final field Companion Lsoftware/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter$Companion;
 	public abstract fun PredictiveBackHandlerPresenter (ZLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
 	public abstract fun getListenersCount ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun onPredictiveBack (Lkotlinx/coroutines/flow/Flow;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class software/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter$Companion {
+	public final fun createNewInstance ()Lsoftware/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter;
 }
 
 public final class software/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenterKt {

--- a/presenter-molecule/public/api/desktop/public.api
+++ b/presenter-molecule/public/api/desktop/public.api
@@ -46,9 +46,14 @@ public final class software/amazon/app/platform/presenter/molecule/backgesture/B
 }
 
 public abstract interface class software/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter {
+	public static final field Companion Lsoftware/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter$Companion;
 	public abstract fun PredictiveBackHandlerPresenter (ZLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
 	public abstract fun getListenersCount ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun onPredictiveBack (Lkotlinx/coroutines/flow/Flow;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class software/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter$Companion {
+	public final fun createNewInstance ()Lsoftware/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter;
 }
 
 public final class software/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenterKt {

--- a/presenter-molecule/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter.kt
+++ b/presenter-molecule/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter.kt
@@ -42,6 +42,31 @@ public interface BackGestureDispatcherPresenter {
     enabled: Boolean,
     onBack: suspend (progress: Flow<BackEventPresenter>) -> Unit,
   )
+
+  public companion object {
+
+    /**
+     * Creates a new [BackGestureDispatcherPresenter] instance.
+     *
+     * Usually, calling this function is not necessary and a default instance of
+     * [BackGestureDispatcherPresenter] is provided by App Platform that can be injected, e.g.
+     *
+     * ```
+     * @Inject
+     * class RootPresenter(
+     *   private val backGestureDispatcherPresenter: BackGestureDispatcherPresenter,
+     *   ...
+     * )
+     * ```
+     *
+     * This provided instance is a singleton that can be shared between presenters and renderers.
+     *
+     * This function [createNewInstance] is helpful if you need multiple instances that you want to
+     * manage yourself.
+     */
+    public fun createNewInstance(): BackGestureDispatcherPresenter =
+      CommonBackGestureDispatcherPresenter()
+  }
 }
 
 /**

--- a/presenter-molecule/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/CommonBackGestureDispatcherPresenter.kt
+++ b/presenter-molecule/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/CommonBackGestureDispatcherPresenter.kt
@@ -1,0 +1,66 @@
+package software.amazon.app.platform.presenter.molecule.backgesture
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+internal class CommonBackGestureDispatcherPresenter : BackGestureDispatcherPresenter {
+  private val listeners = mutableListOf<Listener>()
+
+  private val _listenersCount = MutableStateFlow(0)
+  override val listenersCount: StateFlow<Int> = _listenersCount
+
+  override suspend fun onPredictiveBack(progress: Flow<BackEventPresenter>) {
+    val listener =
+      checkNotNull(listeners.lastOrNull { it.enabled }) {
+        "No back gesture listener was registered or they were all disabled. " +
+          "Check `listenerCount` before invoking this function."
+      }
+
+    listener.onBack(progress)
+  }
+
+  @Composable
+  override fun PredictiveBackHandlerPresenter(
+    enabled: Boolean,
+    onBack: suspend (Flow<BackEventPresenter>) -> Unit,
+  ) {
+    // This implementation is somewhat inspired by
+    // https://github.com/JetBrains/compose-multiplatform-core/blob/244635e202f9aa734bd8c86bd1748a9065ecd818/compose/ui/ui-backhandler/src/jbMain/kotlin/androidx/compose/ui/backhandler/BackHandler.jb.kt
+
+    // Ensure we don't re-register callbacks when onBack changes. It's always the same `listener`
+    // instance with its own callback that invokes the updated `onBack`.
+    val currentOnBack by rememberUpdatedState(onBack)
+    val listener = remember { Listener(enabled) { currentOnBack(it) } }
+
+    LaunchedEffect(enabled) {
+      listener.enabled = enabled
+      updateListenersCount()
+    }
+
+    DisposableEffect(Unit) {
+      listeners += listener
+      updateListenersCount()
+
+      onDispose {
+        listeners.remove(listener)
+        updateListenersCount()
+      }
+    }
+  }
+
+  private fun updateListenersCount() {
+    _listenersCount.value = listeners.count { it.enabled }
+  }
+
+  private class Listener(
+    var enabled: Boolean,
+    val onBack: suspend (Flow<BackEventPresenter>) -> Unit,
+  )
+}

--- a/presenter-molecule/public/src/commonTest/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/CommonBackGestureDispatcherPresenterTest.kt
+++ b/presenter-molecule/public/src/commonTest/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/CommonBackGestureDispatcherPresenterTest.kt
@@ -21,10 +21,10 @@ import software.amazon.app.platform.presenter.molecule.MoleculePresenter
 import software.amazon.app.platform.presenter.molecule.returningCompositionLocalProvider
 import software.amazon.app.platform.presenter.molecule.test
 
-class DefaultBackGestureDispatcherPresenterTest {
+class CommonBackGestureDispatcherPresenterTest {
   @Test
   fun `the back handler is invoked`() = runTest {
-    val dispatcher = DefaultBackGestureDispatcherPresenter()
+    val dispatcher = CommonBackGestureDispatcherPresenter()
 
     data class Model(val backPressCount: Int) : BaseModel
 
@@ -52,7 +52,7 @@ class DefaultBackGestureDispatcherPresenterTest {
 
   @Test
   fun `the predictive back handler is invoked`() = runTest {
-    val dispatcher = DefaultBackGestureDispatcherPresenter()
+    val dispatcher = CommonBackGestureDispatcherPresenter()
 
     data class Model(val lastEvent: BackEventPresenter?) : BaseModel
 
@@ -80,7 +80,7 @@ class DefaultBackGestureDispatcherPresenterTest {
 
   @Test
   fun `the last enabled handler wins`() = runTest {
-    val dispatcher = DefaultBackGestureDispatcherPresenter()
+    val dispatcher = CommonBackGestureDispatcherPresenter()
 
     data class Model(val backPressCount1: Int, val backPressCount2: Int) : BaseModel
 
@@ -145,7 +145,7 @@ class DefaultBackGestureDispatcherPresenterTest {
   @Test
   fun `the listener count increases with the number of enabled handlers`() =
     runTest(UnconfinedTestDispatcher()) {
-      val dispatcher = DefaultBackGestureDispatcherPresenter()
+      val dispatcher = CommonBackGestureDispatcherPresenter()
 
       var handlers by mutableIntStateOf(0)
       var disabledHandlers by mutableIntStateOf(0)
@@ -181,7 +181,7 @@ class DefaultBackGestureDispatcherPresenterTest {
   @Test
   fun `calling onPredictiveBack without a registered handler is an error`() =
     runTest(UnconfinedTestDispatcher()) {
-      val dispatcher = DefaultBackGestureDispatcherPresenter()
+      val dispatcher = CommonBackGestureDispatcherPresenter()
 
       var handlerEnabled by mutableStateOf(true)
 

--- a/presenter-molecule/testing/api/android/testing.api
+++ b/presenter-molecule/testing/api/android/testing.api
@@ -19,3 +19,9 @@ public final class software/amazon/app/platform/presenter/molecule/TestPresenter
 	public static synthetic fun test-Zzr-CC0$default (Lsoftware/amazon/app/platform/presenter/molecule/MoleculePresenter;Lkotlinx/coroutines/test/TestScope;Ljava/lang/Object;Lkotlin/coroutines/CoroutineContext;Lkotlin/time/Duration;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
+public final class software/amazon/app/platform/presenter/molecule/backgesture/TestBackGestureDispatcherPresenterKt {
+	public static final fun withBackGestureDispatcher (Lsoftware/amazon/app/platform/presenter/molecule/MoleculePresenter;Lkotlinx/coroutines/flow/SharedFlow;)Lsoftware/amazon/app/platform/presenter/molecule/MoleculePresenter;
+	public static final fun withBackGestureDispatcherUnit (Lsoftware/amazon/app/platform/presenter/molecule/MoleculePresenter;Lkotlinx/coroutines/flow/SharedFlow;)Lsoftware/amazon/app/platform/presenter/molecule/MoleculePresenter;
+	public static synthetic fun withBackGestureDispatcherUnit$default (Lsoftware/amazon/app/platform/presenter/molecule/MoleculePresenter;Lkotlinx/coroutines/flow/SharedFlow;ILjava/lang/Object;)Lsoftware/amazon/app/platform/presenter/molecule/MoleculePresenter;
+}
+

--- a/presenter-molecule/testing/api/desktop/testing.api
+++ b/presenter-molecule/testing/api/desktop/testing.api
@@ -19,3 +19,9 @@ public final class software/amazon/app/platform/presenter/molecule/TestPresenter
 	public static synthetic fun test-Zzr-CC0$default (Lsoftware/amazon/app/platform/presenter/molecule/MoleculePresenter;Lkotlinx/coroutines/test/TestScope;Ljava/lang/Object;Lkotlin/coroutines/CoroutineContext;Lkotlin/time/Duration;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
+public final class software/amazon/app/platform/presenter/molecule/backgesture/TestBackGestureDispatcherPresenterKt {
+	public static final fun withBackGestureDispatcher (Lsoftware/amazon/app/platform/presenter/molecule/MoleculePresenter;Lkotlinx/coroutines/flow/SharedFlow;)Lsoftware/amazon/app/platform/presenter/molecule/MoleculePresenter;
+	public static final fun withBackGestureDispatcherUnit (Lsoftware/amazon/app/platform/presenter/molecule/MoleculePresenter;Lkotlinx/coroutines/flow/SharedFlow;)Lsoftware/amazon/app/platform/presenter/molecule/MoleculePresenter;
+	public static synthetic fun withBackGestureDispatcherUnit$default (Lsoftware/amazon/app/platform/presenter/molecule/MoleculePresenter;Lkotlinx/coroutines/flow/SharedFlow;ILjava/lang/Object;)Lsoftware/amazon/app/platform/presenter/molecule/MoleculePresenter;
+}
+

--- a/presenter-molecule/testing/build.gradle
+++ b/presenter-molecule/testing/build.gradle
@@ -10,4 +10,5 @@ appPlatformBuildSrc {
 dependencies {
     commonMainApi project(':presenter:public')
     commonTestImplementation project(':internal:testing')
+    commonTestImplementation project(':presenter-molecule:testing')
 }

--- a/presenter-molecule/testing/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/TestBackGestureDispatcherPresenter.kt
+++ b/presenter-molecule/testing/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/TestBackGestureDispatcherPresenter.kt
@@ -1,0 +1,58 @@
+package software.amazon.app.platform.presenter.molecule.backgesture
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import kotlin.jvm.JvmName
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.map
+import software.amazon.app.platform.presenter.BaseModel
+import software.amazon.app.platform.presenter.molecule.MoleculePresenter
+import software.amazon.app.platform.presenter.molecule.returningCompositionLocalProvider
+
+private class TestBackGestureDispatcherPresenter<InputT : Any, ModelT : BaseModel>(
+  private val delegate: MoleculePresenter<InputT, ModelT>,
+  private val backEvents: Flow<Flow<BackEventPresenter>>,
+) : MoleculePresenter<InputT, ModelT> {
+  @Composable
+  override fun present(input: InputT): ModelT {
+    val dispatcher = remember { BackGestureDispatcherPresenter.createNewInstance() }
+
+    return returningCompositionLocalProvider(
+      LocalBackGestureDispatcherPresenter provides dispatcher
+    ) {
+      LaunchedEffect(Unit) { backEvents.collect { dispatcher.onPredictiveBack(it) } }
+
+      delegate.present(input)
+    }
+  }
+}
+
+/**
+ * Wraps the receiver presenter with another presenter to provide a [BackGestureDispatcherPresenter]
+ * as composition local. This is needed when your presenter uses [BackHandlerPresenter] or
+ * [PredictiveBackHandlerPresenter] and requires the composition local.
+ *
+ * [backEvents] is an optional parameter to simulate back press events.
+ */
+@JvmName("withBackGestureDispatcherUnit")
+public fun <InputT : Any, ModelT : BaseModel> MoleculePresenter<InputT, ModelT>
+  .withBackGestureDispatcher(
+  backEvents: SharedFlow<Unit> = MutableSharedFlow()
+): MoleculePresenter<InputT, ModelT> =
+  TestBackGestureDispatcherPresenter(this, backEvents.map { emptyFlow() })
+
+/**
+ * Wraps the receiver presenter with another presenter to provide a [BackGestureDispatcherPresenter]
+ * as composition local. This is needed when your presenter uses [BackHandlerPresenter] or
+ * [PredictiveBackHandlerPresenter] and requires the composition local.
+ *
+ * [backEvents] provides predictive back press events.
+ */
+public fun <InputT : Any, ModelT : BaseModel> MoleculePresenter<InputT, ModelT>
+  .withBackGestureDispatcher(
+  backEvents: SharedFlow<Flow<BackEventPresenter>>
+): MoleculePresenter<InputT, ModelT> = TestBackGestureDispatcherPresenter(this, backEvents)

--- a/presenter-molecule/testing/src/commonTest/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/TestBackGestureDispatcherPresenterTest.kt
+++ b/presenter-molecule/testing/src/commonTest/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/TestBackGestureDispatcherPresenterTest.kt
@@ -1,0 +1,140 @@
+package software.amazon.app.platform.presenter.molecule.backgesture
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.messageContains
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import software.amazon.app.platform.presenter.BaseModel
+import software.amazon.app.platform.presenter.molecule.MoleculePresenter
+import software.amazon.app.platform.presenter.molecule.test
+
+class TestBackGestureDispatcherPresenterTest {
+  @Test
+  fun `a presenter cannot be tested without the dispatcher wrapper`() = runTest {
+    val presenter =
+      object : MoleculePresenter<Unit, BaseModel> {
+        @Composable
+        override fun present(input: Unit): BaseModel {
+          BackHandlerPresenter {}
+          return object : BaseModel {}
+        }
+      }
+
+    assertFailure { presenter.test(this) {} }
+      .messageContains(
+        "Couldn't find the BackGestureDispatcherPresenter in the presenter hierarchy."
+      )
+  }
+
+  @Test
+  fun `a presenter cannot be tested with the dispatcher wrapper`() = runTest {
+    val presenter =
+      object : MoleculePresenter<Unit, BaseModel> {
+        @Composable
+        override fun present(input: Unit): BaseModel {
+          BackHandlerPresenter {}
+          return object : BaseModel {}
+        }
+      }
+
+    presenter.withBackGestureDispatcher().test(this) { awaitItem() }
+  }
+
+  @Test
+  fun `back press events can be provided in tests`() =
+    runTest(UnconfinedTestDispatcher()) {
+      data class Model(val count: Int) : BaseModel
+
+      val presenter =
+        object : MoleculePresenter<Unit, Model> {
+          @Composable
+          override fun present(input: Unit): Model {
+            var backPressCount by remember { mutableIntStateOf(0) }
+            BackHandlerPresenter { backPressCount++ }
+            return Model(backPressCount)
+          }
+        }
+
+      val backEvents = MutableSharedFlow<Unit>()
+      presenter.withBackGestureDispatcher(backEvents).test(this) {
+        assertThat(awaitItem().count).isEqualTo(0)
+
+        backEvents.emit(Unit)
+        assertThat(awaitItem().count).isEqualTo(1)
+
+        backEvents.emit(Unit)
+        assertThat(awaitItem().count).isEqualTo(2)
+      }
+    }
+
+  @Test
+  fun `predictive back press events can be provided in tests`() =
+    runTest(UnconfinedTestDispatcher()) {
+      data class Model(val eventCount: Int, val doneCount: Int) : BaseModel
+
+      val presenter =
+        object : MoleculePresenter<Unit, Model> {
+          @Composable
+          override fun present(input: Unit): Model {
+            var eventCount by remember { mutableIntStateOf(0) }
+            var doneCount by remember { mutableIntStateOf(0) }
+
+            PredictiveBackHandlerPresenter { progress ->
+              try {
+                progress.collect { eventCount++ }
+                doneCount++
+              } catch (_: CancellationException) {}
+            }
+            return Model(eventCount = eventCount, doneCount = doneCount)
+          }
+        }
+
+      val backEvents = MutableSharedFlow<Flow<BackEventPresenter>>()
+      presenter.withBackGestureDispatcher(backEvents).test(this) {
+        with(awaitItem()) {
+          assertThat(eventCount).isEqualTo(0)
+          assertThat(doneCount).isEqualTo(0)
+        }
+
+        backEvents.emit(
+          flow {
+            emit(BackEventPresenter(1f, 1f, 1f, BackEventPresenter.EDGE_LEFT))
+            delay(1.seconds)
+            emit(BackEventPresenter(1f, 1f, 1f, BackEventPresenter.EDGE_LEFT))
+          }
+        )
+
+        assertThat(awaitItem()).isEqualTo(Model(eventCount = 1, doneCount = 0))
+
+        advanceTimeBy(1.seconds)
+        assertThat(awaitItem()).isEqualTo(Model(eventCount = 2, doneCount = 0))
+        assertThat(awaitItem()).isEqualTo(Model(eventCount = 2, doneCount = 1))
+
+        backEvents.emit(
+          flowOf(
+            BackEventPresenter(1f, 1f, 1f, BackEventPresenter.EDGE_LEFT),
+            BackEventPresenter(1f, 1f, 1f, BackEventPresenter.EDGE_LEFT),
+          )
+        )
+        assertThat(awaitItem()).isEqualTo(Model(eventCount = 3, doneCount = 1))
+        assertThat(awaitItem()).isEqualTo(Model(eventCount = 4, doneCount = 1))
+        assertThat(awaitItem()).isEqualTo(Model(eventCount = 4, doneCount = 2))
+      }
+    }
+}


### PR DESCRIPTION
Presenters that use `BackHandler {}` crash when calling `test()` on them in unit tests, because no `BackGestureDispatcherPresenter` is provided as composition local. A new test API `withBackGestureDispatcher()` wraps the presenter and provides a composition local. Back press events can be provided for tests using an optional `SharedFlow`.

This PR moves the `DefaultBackGestureDispatcherPresenter` to the `:public` module to make it reusable between the `:impl` and `:testing` module. There is no need to provide a different fake implementation for `BackGestureDispatcherPresenter`, because the real implementation is small, very efficient and no dependencies need to be replaced.
