### PR TITLE
Forward back press events from Android Activities

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,6 +56,7 @@ viewbinding = "7.0.0"
 [libraries]
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 android-gradle-plugin-api = { module = "com.android.tools.build:gradle-api", version.ref = "agp" }
+androidx-activity = { module = "androidx.activity:activity", version.ref = "androidx-activity" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-annotations = { module = "androidx.annotation:annotation", version.ref = "androidx-annotations" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }

--- a/renderer-android-view/public/api/public.api
+++ b/renderer-android-view/public/api/public.api
@@ -1,3 +1,7 @@
+public final class software/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenterAndroidKt {
+	public static final fun forwardBackPressEventsToPresenters (Lsoftware/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter;Landroidx/activity/OnBackPressedDispatcherOwner;)V
+}
+
 public class software/amazon/app/platform/renderer/AndroidRendererFactory : software/amazon/app/platform/renderer/BaseRendererFactory {
 	public fun <init> (Lsoftware/amazon/app/platform/scope/RootScopeProvider;Landroid/app/Activity;Landroid/view/ViewGroup;)V
 	public fun createRenderer (Lkotlin/reflect/KClass;)Lsoftware/amazon/app/platform/renderer/Renderer;

--- a/renderer-android-view/public/build.gradle
+++ b/renderer-android-view/public/build.gradle
@@ -30,11 +30,15 @@ dependencies {
     commonMainApi project(':presenter:public')
     commonMainApi project(':renderer:public')
 
+    commonMainImplementation project(':presenter-molecule:public')
+
     // Use a lower version to not force a higher version on consumers.
+    androidMainApi libs.androidx.activity
     androidMainApi libs.viewbinding.api
     androidMainApi libs.recyclerView
     androidMainImplementation libs.androidx.core
 
+    androidInstrumentedTestImplementation libs.androidx.test.espresso
     // Use the version aligned with AGP in tests.
     androidInstrumentedTestImplementation libs.viewbinding.agp
 }

--- a/renderer-android-view/public/src/androidInstrumentedTest/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/ForwardBackPressEventsToPresentersAndroidTest.kt
+++ b/renderer-android-view/public/src/androidInstrumentedTest/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/ForwardBackPressEventsToPresentersAndroidTest.kt
@@ -1,0 +1,45 @@
+package software.amazon.app.platform.presenter.molecule.backgesture
+
+import androidx.test.espresso.Espresso
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import org.junit.Rule
+import org.junit.Test
+import software.amazon.app.platform.renderer.TestActivity
+
+class ForwardBackPressEventsToPresentersAndroidTest {
+  @get:Rule val activityRule = ActivityScenarioRule(TestActivity::class.java)
+
+  @Test
+  fun back_press_events_are_forwarded_to_presenters() {
+    val dispatcher = InterceptorBackGestureDispatcherPresenter()
+
+    activityRule.scenario.onActivity { activity ->
+      dispatcher.forwardBackPressEventsToPresenters(activity)
+    }
+
+    assertThat(dispatcher.onPredictiveBackCount).isEqualTo(0)
+
+    Espresso.pressBack()
+    assertThat(dispatcher.onPredictiveBackCount).isEqualTo(1)
+
+    Espresso.pressBack()
+    assertThat(dispatcher.onPredictiveBackCount).isEqualTo(2)
+  }
+
+  private class InterceptorBackGestureDispatcherPresenter :
+    BackGestureDispatcherPresenter by BackGestureDispatcherPresenter.createNewInstance() {
+    override val listenersCount: StateFlow<Int> = MutableStateFlow(1)
+
+    var onPredictiveBackCount = 0
+
+    override suspend fun onPredictiveBack(progress: Flow<BackEventPresenter>) {
+      progress.collect {}
+      onPredictiveBackCount++
+    }
+  }
+}

--- a/renderer-android-view/public/src/androidInstrumentedTest/kotlin/software/amazon/app/platform/renderer/TestActivity.kt
+++ b/renderer-android-view/public/src/androidInstrumentedTest/kotlin/software/amazon/app/platform/renderer/TestActivity.kt
@@ -1,5 +1,5 @@
 package software.amazon.app.platform.renderer
 
-import android.app.Activity
+import androidx.activity.ComponentActivity
 
-class TestActivity : Activity()
+class TestActivity : ComponentActivity()

--- a/renderer-android-view/public/src/androidMain/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenterAndroid.kt
+++ b/renderer-android-view/public/src/androidMain/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenterAndroid.kt
@@ -1,0 +1,160 @@
+package software.amazon.app.platform.presenter.molecule.backgesture
+
+import androidx.activity.BackEventCompat
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.OnBackPressedDispatcher
+import androidx.activity.OnBackPressedDispatcherOwner
+import androidx.lifecycle.lifecycleScope
+import java.util.concurrent.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.BufferOverflow.SUSPEND
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.Channel.Factory.BUFFERED
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.launch
+
+/**
+ * Registers a callback in the [OnBackPressedDispatcher] that is enabled as long as there is a
+ * presenter with an enabled back handler. This function forwards back press events to presenters
+ * until the lifecycle from [onBackPressedDispatcherOwner] is in the destroyed state.
+ *
+ * It's recommended to call this function from your Android `Activity`:
+ * ```
+ * class MainActivity : ComponentActivity() {
+ *   override fun onCreate(savedInstanceState: Bundle?) {
+ *     super.onCreate(savedInstanceState)
+ *
+ *     // Inject the dispatcher from the dependency injection graph.
+ *     backGestureDispatcherPresenter.forwardBackPressEventsToPresenters(this)
+ *
+ *     ...
+ *   }
+ * }
+ * ```
+ */
+public fun BackGestureDispatcherPresenter.forwardBackPressEventsToPresenters(
+  onBackPressedDispatcherOwner: OnBackPressedDispatcherOwner
+) {
+  // Later if needed we can consider limiting this to the STARTED lifecycle if needed with
+  // repeatOnLifecycle API. For now we forward events until the lifecycle changes to DESTROYED.
+  onBackPressedDispatcherOwner.lifecycleScope.launch {
+    val forwarder =
+      BackGestureForwarder(
+        onBackPressedDispatcherOwner = onBackPressedDispatcherOwner,
+        dispatcherPresenter = this@forwardBackPressEventsToPresenters,
+      )
+    forwarder.forwardEvents()
+  }
+}
+
+private class BackGestureForwarder(
+  private val onBackPressedDispatcherOwner: OnBackPressedDispatcherOwner,
+  private val dispatcherPresenter: BackGestureDispatcherPresenter,
+) {
+  // This function never returns and this is by design. We stop listening to updates when the
+  // coroutine get canceled.
+  suspend fun forwardEvents(): Nothing = coroutineScope {
+    val backCallBack = createOnBackPressCallback(this)
+    try {
+      onBackPressedDispatcherOwner.onBackPressedDispatcher.addCallback(
+        onBackPressedDispatcherOwner,
+        backCallBack,
+      )
+
+      dispatcherPresenter.listenersCount.collect { count -> backCallBack.isEnabled = count > 0 }
+    } finally {
+      backCallBack.remove()
+    }
+  }
+
+  private fun createOnBackPressCallback(coroutineScope: CoroutineScope): OnBackPressedCallback {
+    val enabled = dispatcherPresenter.listenersCount.value > 0
+
+    // This implementation comes mainly from
+    // https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:activity/activity-compose/src/main/java/androidx/activity/compose/PredictiveBackHandler.kt
+    return object : OnBackPressedCallback(enabled) {
+      var onBackInstance: OnBackInstance? = null
+
+      override fun handleOnBackStarted(backEvent: BackEventCompat) {
+        super.handleOnBackStarted(backEvent)
+        // in case the previous onBackInstance was started by a normal back gesture
+        // we want to make sure it's still cancelled before we start a predictive
+        // back gesture
+        onBackInstance?.cancel()
+        onBackInstance = OnBackInstance(coroutineScope, true) { onBack(it) }
+      }
+
+      override fun handleOnBackProgressed(backEvent: BackEventCompat) {
+        super.handleOnBackProgressed(backEvent)
+        onBackInstance?.send(backEvent)
+      }
+
+      override fun handleOnBackPressed() {
+        // handleOnBackPressed could be called by regular back to restart
+        // a new back instance. If this is the case (where current back instance
+        // was NOT started by handleOnBackStarted) then we need to reset the previous
+        // regular back.
+        onBackInstance?.run {
+          if (!isPredictiveBack) {
+            cancel()
+            onBackInstance = null
+          }
+        }
+        if (onBackInstance == null) {
+          onBackInstance = OnBackInstance(coroutineScope, false) { onBack(it) }
+        }
+
+        // finally, we close the channel to ensure no more events can be sent
+        // but let the job complete normally
+        onBackInstance?.close()
+      }
+
+      override fun handleOnBackCancelled() {
+        super.handleOnBackCancelled()
+        // cancel will purge the channel of any sent events that are yet to be received
+        onBackInstance?.cancel()
+      }
+    }
+  }
+
+  private suspend fun onBack(events: Flow<BackEventCompat>) {
+    dispatcherPresenter.onPredictiveBack(
+      events.map {
+        BackEventPresenter(
+          touchX = it.touchX,
+          touchY = it.touchY,
+          progress = it.progress,
+          swipeEdge = it.swipeEdge,
+        )
+      }
+    )
+  }
+}
+
+private class OnBackInstance(
+  scope: CoroutineScope,
+  val isPredictiveBack: Boolean,
+  onBack: suspend (progress: Flow<BackEventCompat>) -> Unit,
+) {
+  val channel = Channel<BackEventCompat>(capacity = BUFFERED, onBufferOverflow = SUSPEND)
+  val job =
+    scope.launch {
+      var completed = false
+      onBack(channel.consumeAsFlow().onCompletion { completed = true })
+      check(completed) { "You must collect the progress flow" }
+    }
+
+  fun send(backEvent: BackEventCompat) = channel.trySend(backEvent)
+
+  // idempotent if invoked more than once
+  fun close() = channel.close()
+
+  fun cancel() {
+    channel.cancel(CancellationException("onBack cancelled"))
+    job.cancel()
+  }
+}

--- a/renderer-compose-multiplatform/public/src/androidInstrumentedTest/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/ForwardBackPressEventsToPresentersComposeTest.kt
+++ b/renderer-compose-multiplatform/public/src/androidInstrumentedTest/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/ForwardBackPressEventsToPresentersComposeTest.kt
@@ -18,13 +18,13 @@ import org.junit.Rule
 import org.junit.Test
 import software.amazon.app.platform.presenter.BaseModel
 import software.amazon.app.platform.presenter.molecule.MoleculePresenter
-import software.amazon.app.platform.presenter.molecule.backgesture.ForwardBackPressEventsToPresentersTest.TestPresenter.Model
+import software.amazon.app.platform.presenter.molecule.backgesture.ForwardBackPressEventsToPresentersComposeTest.TestPresenter.Model
 import software.amazon.app.platform.presenter.molecule.returningCompositionLocalProvider
 import software.amazon.app.platform.renderer.ComposeRenderer
 import software.amazon.app.platform.renderer.TestActivity
 import software.amazon.app.platform.renderer.getActivityFromTestRule
 
-class ForwardBackPressEventsToPresentersTest {
+class ForwardBackPressEventsToPresentersComposeTest {
 
   @get:Rule val activityRule = ActivityScenarioRule(TestActivity::class.java)
 


### PR DESCRIPTION
Provide an easy to use API that forwards back press events from an Android `Activity` to presenters. This makes it easy to setup back press handling for presenters in Android applications not using Compose UI.

See #57
