### PR TITLE
Show menu button presses in the UI

### DIFF
--- a/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/appbar/menu/MenuPresenter.kt
+++ b/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/appbar/menu/MenuPresenter.kt
@@ -2,19 +2,25 @@
 
 package software.amazon.app.platform.recipes.appbar.menu
 
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.delay
 import software.amazon.app.platform.inject.ContributesRenderer
 import software.amazon.app.platform.presenter.BaseModel
 import software.amazon.app.platform.presenter.molecule.MoleculePresenter
@@ -28,17 +34,20 @@ class MenuPresenter : MoleculePresenter<Unit, Model> {
   @Composable
   override fun present(input: Unit): Model {
     var itemCount by remember { mutableIntStateOf(2) }
+    var pressedItem by remember { mutableStateOf<Int?>(null) }
 
     val items =
       List(itemCount) {
         val number = it + 1
-        AppBarConfig.MenuItem(
-          text = "Option $number",
-          action = { println("Option $number was pressed.") },
-        )
+        AppBarConfig.MenuItem(text = "Option $number", action = { pressedItem = number })
       }
 
-    return Model(items) {
+    LaunchedEffect(pressedItem) {
+      delay(3.seconds)
+      pressedItem = null
+    }
+
+    return Model(items, pressedItem) {
       when (it) {
         Event.AddMenuItem -> itemCount += 1
       }
@@ -47,6 +56,7 @@ class MenuPresenter : MoleculePresenter<Unit, Model> {
 
   data class Model(
     private val menuItems: List<AppBarConfig.MenuItem>,
+    val pressedItem: Int?,
     val onEvent: (Event) -> Unit,
   ) : BaseModel, AppBarConfigModel {
     override fun appBarConfig(): AppBarConfig {
@@ -68,6 +78,16 @@ class MenuRenderer : ComposeRenderer<Model>() {
       horizontalAlignment = Alignment.CenterHorizontally,
     ) {
       Button(onClick = { model.onEvent(MenuPresenter.Event.AddMenuItem) }) { Text("Add menu item") }
+
+      AnimatedContent(targetState = model, contentKey = { it.pressedItem != null }) { targetModel ->
+        if (targetModel.pressedItem != null) {
+          Text(
+            text = "Pressed option ${targetModel.pressedItem}",
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.padding(top = 12.dp),
+          )
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
In the UI of the recipes app show a text when a menu item was pressed. At the moment it appears as if nothing would have happened, because only a message is logged in the console.

