### PR TITLE
Combine Compose dependencies block

### DIFF
--- a/recipes/common/impl/build.gradle
+++ b/recipes/common/impl/build.gradle
@@ -14,16 +14,12 @@ appPlatform {
     enableMoleculePresenters true
 }
 
-compose {
-    dependencies {
-        commonMainImplementation dependencies.components.resources
-        commonMainImplementation dependencies.material3
-        commonMainImplementation dependencies.materialIconsExtended
-        commonMainImplementation dependencies.runtimeSaveable
-        commonMainImplementation dependencies.ui
-    }
-}
-
 dependencies {
+    commonMainImplementation compose.components.resources
+    commonMainImplementation compose.material3
+    commonMainImplementation compose.materialIconsExtended
+    commonMainImplementation compose.runtimeSaveable
+    commonMainImplementation compose.ui
+
     commonMainImplementation libs.androidx.collection
 }

--- a/robot-compose-multiplatform/public/build.gradle
+++ b/robot-compose-multiplatform/public/build.gradle
@@ -11,16 +11,12 @@ appPlatformBuildSrc {
 dependencies {
     commonMainApi project(':robot:public')
     commonMainApi project(':scope:public')
+    commonMainApi compose.uiTest
+
     commonMainImplementation project(':robot-internal:public')
 
     commonTestApi project(':scope:testing')
-}
 
-compose {
-    dependencies {
-        commonMainApi dependencies.uiTest
-
-        desktopTestImplementation dependencies.material
-        iosTestImplementation dependencies.material
-    }
+    desktopTestImplementation compose.material
+    iosTestImplementation compose.material
 }

--- a/sample/login/impl/build.gradle
+++ b/sample/login/impl/build.gradle
@@ -16,14 +16,11 @@ appPlatform {
 
 dependencies {
     commonMainApi project(':sample:user:public')
+
+    commonMainImplementation compose.components.resources
+    commonMainImplementation compose.material
+
     commonTestImplementation project(':sample:user:testing')
-}
 
-compose {
-    dependencies {
-        commonMainImplementation dependencies.components.resources
-        commonMainImplementation dependencies.material
-
-        appleAndDesktopTestImplementation dependencies.uiTest
-    }
+    appleAndDesktopTestImplementation compose.uiTest
 }

--- a/sample/user/impl/build.gradle
+++ b/sample/user/impl/build.gradle
@@ -16,12 +16,9 @@ appPlatform {
 
 dependencies {
     commonMainApi project(':sample:templates:public')
-    commonTestImplementation project(':sample:user:testing')
-}
 
-compose {
-    dependencies {
-        commonMainImplementation dependencies.components.resources
-        commonMainImplementation dependencies.material
-    }
+    commonMainImplementation compose.components.resources
+    commonMainImplementation compose.material
+
+    commonTestImplementation project(':sample:user:testing')
 }


### PR DESCRIPTION
Move the Compose dependencies in the same Gradle `dependencies {}` block as the other dependencies for clarity.

Fixes #88
