### PR TITLE
Don't build the blueprint for new tags

### DIFF
--- a/.github/workflows/blueprints-starter-ci.yml
+++ b/.github/workflows/blueprints-starter-ci.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - 'blueprints/starter/**'
       - '.github/**'
+    tags-ignore:
+      - '**'
   pull_request:
     paths:
       - 'blueprints/starter/**'


### PR DESCRIPTION
Don't build the blueprint projects when a new tag is pushed. This is redundant.

