### PR TITLE
Add a recipe for the Navigation 3 library

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,6 +47,7 @@ ktfmt-gradle = "0.23.0"
 ksp = "2.2.0-2.0.2"
 maven-publish = "0.34.0"
 molecule = "2.1.0"
+navigation3 = "1.0.0-alpha06"
 #noinspection GradleDependency
 recyclerView = "1.2.1"
 turbine = "1.2.1"
@@ -110,6 +111,8 @@ ksp-embeddable = { module = "com.google.devtools.ksp:symbol-processing-aa-embedd
 ksp-gradle-plugin = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin", version.ref = "ksp" }
 maven-publish-gradle-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "maven-publish" }
 molecule-runtime = { module = "app.cash.molecule:molecule-runtime", version.ref = "molecule" }
+navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "navigation3" }
+navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "navigation3" }
 recyclerView = { module = "androidx.recyclerview:recyclerview", version.ref = "recyclerView" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 #noinspection SimilarGradleDependency

--- a/recipes/common/impl/build.gradle
+++ b/recipes/common/impl/build.gradle
@@ -14,6 +14,20 @@ appPlatform {
     enableMoleculePresenters true
 }
 
+kotlin {
+    def noAndroid = sourceSets.create("noAndroidMain")
+
+    sourceSets.named('commonMain').configure {
+        noAndroid.dependsOn(it)
+    }
+    sourceSets.named('appleAndDesktopMain').configure {
+        it.dependsOn(noAndroid)
+    }
+    sourceSets.named('wasmJsMain').configure {
+        it.dependsOn(noAndroid)
+    }
+}
+
 dependencies {
     commonMainImplementation compose.components.resources
     commonMainImplementation compose.material3
@@ -22,4 +36,7 @@ dependencies {
     commonMainImplementation compose.ui
 
     commonMainImplementation libs.androidx.collection
+
+    androidMainImplementation libs.navigation3.runtime
+    androidMainImplementation libs.navigation3.ui
 }

--- a/recipes/common/impl/src/androidMain/kotlin/software/amazon/app/platform/recipes/nav3/AndroidNavigation3HomeRenderer.kt
+++ b/recipes/common/impl/src/androidMain/kotlin/software/amazon/app/platform/recipes/nav3/AndroidNavigation3HomeRenderer.kt
@@ -1,0 +1,41 @@
+package software.amazon.app.platform.recipes.nav3
+
+import androidx.compose.runtime.Composable
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.ui.NavDisplay
+import me.tatarka.inject.annotations.Inject
+import software.amazon.app.platform.inject.ContributesRenderer
+import software.amazon.app.platform.recipes.nav3.Navigation3HomePresenter.Event
+import software.amazon.app.platform.recipes.nav3.Navigation3HomePresenter.Model
+import software.amazon.app.platform.renderer.ComposeRenderer
+import software.amazon.app.platform.renderer.RendererFactory
+import software.amazon.app.platform.renderer.getComposeRenderer
+
+/**
+ * Navigation3 is only supported on Android, therefore this renderer lives in `androidMain`. This
+ * Renderer integrates the Navigation3 library. The backstack is managed in the presenter for
+ * idiomatic navigation with presenters, but interactions with the backstack are handled by the
+ * Navigation3 library, e.g. back gestures.
+ */
+@Inject
+@ContributesRenderer
+class AndroidNavigation3HomeRenderer(private val rendererFactory: RendererFactory) :
+  ComposeRenderer<Model>() {
+  @Composable
+  override fun Compose(model: Model) {
+    // Use the position of the model in the backstack as key for `NavDisplay`. This way
+    // we can update models without Navigation 3 treating those changes as a new screen.
+    val backstack = model.backstack.mapIndexed { index, _ -> index }
+
+    NavDisplay(
+      backStack = backstack,
+      onBack = { model.onEvent(Event.Pop) },
+      entryProvider = { key ->
+        NavEntry(key) {
+          val model = model.backstack[it]
+          rendererFactory.getComposeRenderer(model).renderCompose(model)
+        }
+      },
+    )
+  }
+}

--- a/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/landing/LandingPresenter.kt
+++ b/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/landing/LandingPresenter.kt
@@ -8,6 +8,7 @@ import software.amazon.app.platform.recipes.appbar.menu.MenuPresenter
 import software.amazon.app.platform.recipes.backstack.LocalBackstackScope
 import software.amazon.app.platform.recipes.backstack.presenter.BackstackChildPresenter
 import software.amazon.app.platform.recipes.landing.LandingPresenter.Model
+import software.amazon.app.platform.recipes.nav3.Navigation3HomePresenter
 
 /** The presenter that is responsible to show the content of the landing page in the Recipes app. */
 @Inject
@@ -24,6 +25,10 @@ class LandingPresenter : MoleculePresenter<Unit, Model> {
 
         Event.MenuPresenter -> {
           backstack.push(MenuPresenter())
+        }
+
+        Event.Navigation3 -> {
+          backstack.push(Navigation3HomePresenter())
         }
       }
     }
@@ -42,5 +47,8 @@ class LandingPresenter : MoleculePresenter<Unit, Model> {
 
     /** Show the presenter with a custom App Bar menu. */
     data object MenuPresenter : Event
+
+    /** Show the presenter highlighting navigation3 integration. */
+    data object Navigation3 : Event
   }
 }

--- a/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/landing/LandingRenderer.kt
+++ b/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/landing/LandingRenderer.kt
@@ -31,6 +31,12 @@ class LandingRenderer : ComposeRenderer<Model>() {
       ) {
         Text("Menu presenter")
       }
+      Button(
+        onClick = { model.onEvent(LandingPresenter.Event.Navigation3) },
+        modifier = Modifier.padding(top = 12.dp),
+      ) {
+        Text("Navigation3")
+      }
     }
   }
 }

--- a/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/nav3/Navigation3ChildPresenter.kt
+++ b/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/nav3/Navigation3ChildPresenter.kt
@@ -1,0 +1,63 @@
+@file:Suppress("UndocumentedPublicProperty", "UndocumentedPublicClass")
+
+package software.amazon.app.platform.recipes.nav3
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import software.amazon.app.platform.presenter.BaseModel
+import software.amazon.app.platform.presenter.molecule.MoleculePresenter
+import software.amazon.app.platform.recipes.nav3.Navigation3ChildPresenter.Model
+
+class Navigation3ChildPresenter(
+  private val index: Int,
+  private val backstack: SnapshotStateList<MoleculePresenter<Unit, out BaseModel>>,
+) : MoleculePresenter<Unit, Model> {
+  @Composable
+  override fun present(input: Unit): Model {
+    val color = remember { nextColor() }
+
+    val counter by
+      produceState(0) {
+        while (isActive) {
+          delay(1.seconds)
+          value += 1
+        }
+      }
+
+    return Model(index = index, color = color, counter = counter) {
+      when (it) {
+        Event.AddPresenter ->
+          backstack.add(Navigation3ChildPresenter(index = index + 1, backstack = backstack))
+      }
+    }
+  }
+
+  data class Model(
+    val index: Int,
+    val color: Long,
+    val counter: Int,
+    val onEvent: (Event) -> Unit,
+  ) : BaseModel
+
+  sealed interface Event {
+    data object AddPresenter : Event
+  }
+
+  private companion object {
+    private val colors =
+      listOf(0xFFA5D6A7, 0xFF81D4FA, 0xFFB0BEC5, 0xFFBCAAA4, 0xFF80CBC4, 0xFFFFAB91)
+
+    private var index = 0
+
+    fun nextColor(): Long {
+      index = (index + 1).mod(colors.size)
+      return colors[index]
+    }
+  }
+}

--- a/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/nav3/Navigation3ChildRenderer.kt
+++ b/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/nav3/Navigation3ChildRenderer.kt
@@ -1,0 +1,37 @@
+@file:Suppress("UndocumentedPublicProperty", "UndocumentedPublicClass")
+
+package software.amazon.app.platform.recipes.nav3
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import software.amazon.app.platform.inject.ContributesRenderer
+import software.amazon.app.platform.recipes.nav3.Navigation3ChildPresenter.Model
+import software.amazon.app.platform.renderer.ComposeRenderer
+
+@ContributesRenderer
+class Navigation3ChildRenderer : ComposeRenderer<Model>() {
+  @Composable
+  override fun Compose(model: Model) {
+    Box(modifier = Modifier.Companion.fillMaxSize().background(Color(model.color))) {
+      Column {
+        Text("Index: ${model.index}")
+        Text("Count: ${model.counter}")
+      }
+
+      Button(
+        onClick = { model.onEvent(Navigation3ChildPresenter.Event.AddPresenter) },
+        modifier = Modifier.Companion.align(Alignment.Companion.Center),
+      ) {
+        Text("Add Presenter")
+      }
+    }
+  }
+}

--- a/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/nav3/Navigation3HomePresenter.kt
+++ b/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/nav3/Navigation3HomePresenter.kt
@@ -1,0 +1,48 @@
+@file:Suppress("UndocumentedPublicProperty", "UndocumentedPublicClass")
+
+package software.amazon.app.platform.recipes.nav3
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import me.tatarka.inject.annotations.Inject
+import software.amazon.app.platform.presenter.BaseModel
+import software.amazon.app.platform.presenter.molecule.MoleculePresenter
+import software.amazon.app.platform.recipes.appbar.AppBarConfig
+import software.amazon.app.platform.recipes.appbar.AppBarConfigModel
+import software.amazon.app.platform.recipes.nav3.Navigation3HomePresenter.Model
+
+/**
+ * This presenter manages its own backstack. All presenters in the stack are always active, because
+ * Navigation3 renders them during a back gesture. This could be optimized further in the future to
+ * compute the model of the top 2 presenters only and remembering the state of all other presenters.
+ */
+@Inject
+class Navigation3HomePresenter : MoleculePresenter<Unit, Model> {
+  @Composable
+  override fun present(input: Unit): Model {
+    val backstack = remember {
+      mutableStateListOf<MoleculePresenter<Unit, out BaseModel>>().apply {
+        // There must be always one element.
+        add(Navigation3ChildPresenter(index = 0, backstack = this))
+      }
+    }
+
+    return Model(backstack = backstack.map { it.present(Unit) }) {
+      when (it) {
+        Event.Pop -> {
+          backstack.removeAt(backstack.size - 1)
+        }
+      }
+    }
+  }
+
+  data class Model(val backstack: List<BaseModel>, val onEvent: (Event) -> Unit) :
+    BaseModel, AppBarConfigModel {
+    override fun appBarConfig(): AppBarConfig = AppBarConfig(title = "Navigation3")
+  }
+
+  sealed interface Event {
+    data object Pop : Event
+  }
+}

--- a/recipes/common/impl/src/noAndroidMain/kotlin/software/amazon/app/platform/recipes/nav3/CommonNavigation3HomeRenderer.kt
+++ b/recipes/common/impl/src/noAndroidMain/kotlin/software/amazon/app/platform/recipes/nav3/CommonNavigation3HomeRenderer.kt
@@ -1,0 +1,26 @@
+package software.amazon.app.platform.recipes.nav3
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import software.amazon.app.platform.inject.ContributesRenderer
+import software.amazon.app.platform.recipes.nav3.Navigation3HomePresenter.Model
+import software.amazon.app.platform.renderer.ComposeRenderer
+
+/**
+ * Navigation3 isn't supported for platforms other than Android yet. There are two renderers for
+ * this model. One only in the Android source folder and one in the special "noAndroid" source
+ * folder. At runtime depending on the platform the right renderer is used.
+ */
+@ContributesRenderer
+class CommonNavigation3HomeRenderer : ComposeRenderer<Model>() {
+  @Composable
+  override fun Compose(model: Model) {
+    Box(modifier = Modifier.fillMaxSize()) {
+      Text("Navigation3 is only supported on Android", Modifier.align(Alignment.Center))
+    }
+  }
+}


### PR DESCRIPTION
The Navigation 3 library is in early alpha stages. This change demonstrates how Navigation 3 can be used with App Platform. A new screen in the Recipes app manages its own backstack and forwards navigation events from Navigation 3 to the presenter.

Navigation 3 is only available for Android for now. On other platforms a placeholder UI is shown.

https://github.com/user-attachments/assets/70fa58a6-92f0-4893-8849-cd9585ea1a37


