### PR TITLE
Remove unused AtomicFU plugin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -128,7 +128,6 @@ app-platform = { id = "software.amazon.app.platform" }
 build-config = { id = "com.github.gmazzo.buildconfig", version.ref = "build-config" }
 compose-hot-reload = { id = "org.jetbrains.compose.hot-reload", version.ref = "compose-hot-reload-plugin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
-kotlin-atomicfu = { id = "org.jetbrains.kotlinx.atomicfu", version.ref = "kotlin-atomicfu" }
 kotlin-hierarchy = { id = "io.github.terrakok.kmp-hierarchy", version.ref = "kotlin-hierarchy" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlinx-binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "kotlinx-binaryCompatibilityValidator" }

--- a/renderer/public/build.gradle
+++ b/renderer/public/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'software.amazon.app.platform.lib'
-    alias libs.plugins.kotlin.atomicfu
 }
 
 appPlatformBuildSrc {
@@ -11,6 +10,8 @@ appPlatformBuildSrc {
 dependencies {
     commonMainApi project(':presenter:public')
     commonMainApi project(':scope:public')
+
+    commonMainImplementation libs.kotlin.atomicfu
 
     commonTestImplementation project(':internal:testing')
     commonTestImplementation project(':scope:testing')

--- a/scope/public/build.gradle
+++ b/scope/public/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'software.amazon.app.platform.lib'
-    alias libs.plugins.kotlin.atomicfu
 }
 
 appPlatformBuildSrc {


### PR DESCRIPTION
The plugin is not needed in our modules. This will unblock #60, because the AtomicFU Gradle plugin doesn't support the new Android plugin for KMP yet, see https://github.com/Kotlin/kotlinx-atomicfu/issues/511