### PR TITLE
Remove redundant namespace declarations

### DIFF
--- a/blueprints/starter/navigation/impl/build.gradle.kts
+++ b/blueprints/starter/navigation/impl/build.gradle.kts
@@ -59,7 +59,6 @@ kotlin {
 }
 
 android {
-  namespace = "software.amazon.app.platform.template.navigation.impl"
   compileSdk = libs.versions.android.compileSdk.get().toInt()
 
   defaultConfig {

--- a/blueprints/starter/navigation/public/build.gradle.kts
+++ b/blueprints/starter/navigation/public/build.gradle.kts
@@ -48,7 +48,6 @@ kotlin {
 }
 
 android {
-  namespace = "software.amazon.app.platform.template.navigation"
   compileSdk = libs.versions.android.compileSdk.get().toInt()
 
   defaultConfig {

--- a/blueprints/starter/navigation/testing/build.gradle.kts
+++ b/blueprints/starter/navigation/testing/build.gradle.kts
@@ -48,7 +48,6 @@ kotlin {
 }
 
 android {
-  namespace = "software.amazon.app.platform.template.navigation"
   compileSdk = libs.versions.android.compileSdk.get().toInt()
 
   defaultConfig {

--- a/blueprints/starter/templates/impl/build.gradle.kts
+++ b/blueprints/starter/templates/impl/build.gradle.kts
@@ -49,7 +49,6 @@ kotlin {
 }
 
 android {
-  namespace = "software.amazon.app.platform.template.templates.impl"
   compileSdk = libs.versions.android.compileSdk.get().toInt()
 
   defaultConfig {

--- a/blueprints/starter/templates/public/build.gradle.kts
+++ b/blueprints/starter/templates/public/build.gradle.kts
@@ -40,7 +40,6 @@ kotlin {
 }
 
 android {
-  namespace = "software.amazon.app.platform.template.templates"
   compileSdk = libs.versions.android.compileSdk.get().toInt()
 
   defaultConfig {


### PR DESCRIPTION
The namespace is automatically applied in the App Platform Gradle plugin.
