### PR TITLE
Support the new Android KMP plugin

### DIFF
--- a/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/AppPlatformPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/AppPlatformPlugin.kt
@@ -60,6 +60,13 @@ public open class AppPlatformPlugin : Plugin<Project> {
       }
     }
 
+    plugins.withId(PluginIds.ANDROID_KMP_LIBRARY) {
+      dependencies.add(
+        "androidMainImplementation",
+        "$APP_PLATFORM_GROUP:renderer-android-view-public:$APP_PLATFORM_VERSION",
+      )
+    }
+
     plugins.withIds(PluginIds.ANDROID_APP, PluginIds.ANDROID_LIBRARY) {
       dependencies.add(
         "implementation",
@@ -80,7 +87,7 @@ public open class AppPlatformPlugin : Plugin<Project> {
 
     val implementationDependencies = buildSet {
       if (appPlatform.isMoleculeEnabled().get()) {
-        add("$APP_PLATFORM_GROUP:presenter-molecule-impl:" + APP_PLATFORM_VERSION)
+        add("$APP_PLATFORM_GROUP:presenter-molecule-impl:$APP_PLATFORM_VERSION")
       }
       if (appPlatform.isKotlinInjectEnabled().get()) {
         add("$APP_PLATFORM_GROUP:kotlin-inject-impl:$APP_PLATFORM_VERSION")

--- a/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/ModuleStructurePlugin.kt
+++ b/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/ModuleStructurePlugin.kt
@@ -1,5 +1,6 @@
 package software.amazon.app.platform.gradle
 
+import com.android.build.api.dsl.androidLibrary
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import software.amazon.app.platform.gradle.ModuleStructureDependencyCheckTask.Companion.registerModuleStructureDependencyCheckTask
@@ -83,6 +84,14 @@ public open class ModuleStructurePlugin : Plugin<Project> {
       // Do not override any configured namespace.
       if (android.namespace == null) {
         android.namespace = namespace()
+      }
+    }
+    plugins.withId(PluginIds.ANDROID_KMP_LIBRARY) {
+      @Suppress("UnstableApiUsage")
+      kmpExtension.androidLibrary {
+        if (namespace == null) {
+          namespace = namespace()
+        }
       }
     }
   }

--- a/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/PluginIds.kt
+++ b/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/PluginIds.kt
@@ -2,6 +2,7 @@ package software.amazon.app.platform.gradle
 
 internal object PluginIds {
   const val ANDROID_APP = "com.android.application"
+  const val ANDROID_KMP_LIBRARY = "com.android.kotlin.multiplatform.library"
   const val ANDROID_LIBRARY = "com.android.library"
   const val COMPOSE_COMPILER = "org.jetbrains.kotlin.plugin.compose"
   const val COMPOSE_MULTIPLATFORM = "org.jetbrains.compose"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -122,6 +122,7 @@ viewbinding-agp = { module = "androidx.databinding:viewbinding", version.ref = "
 
 [plugins]
 android-app = { id = "com.android.application", version.ref = "agp" }
+android-kmp-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 android-lint = { id = "com.android.lint", version.ref = "agp" }
 app-platform = { id = "software.amazon.app.platform" }


### PR DESCRIPTION
This change adds support for the new Android KMP plugin in App Platform's Gradle plugin. The plugin still must be adopted by App Platform modules themselves, because all new development for Android KMP will happen in this plugin, but this at least unblocks consumers who want to use new plugin.

For more details see: https://developer.android.com/kotlin/multiplatform/plugin

I tested and verified that these changes work in #100 with local builds.

See #60

