### PR TITLE
Rename buildSrc kotlin-inject DSL

### DIFF
--- a/buildSrc/src/main/kotlin/software/amazon/app/platform/gradle/buildsrc/AppPlatformExtension.kt
+++ b/buildSrc/src/main/kotlin/software/amazon/app/platform/gradle/buildsrc/AppPlatformExtension.kt
@@ -7,7 +7,7 @@ import org.gradle.api.provider.Property
 import software.amazon.app.platform.gradle.AppPlatformExtension as AppPlatformExtensionGradlePlugin
 import software.amazon.app.platform.gradle.buildsrc.BaseAndroidPlugin.Companion.enableInstrumentedTests
 import software.amazon.app.platform.gradle.buildsrc.KmpPlugin.Companion.enableCompose
-import software.amazon.app.platform.gradle.buildsrc.KmpPlugin.Companion.enableDi
+import software.amazon.app.platform.gradle.buildsrc.KmpPlugin.Companion.enableKotlinInject
 import software.amazon.app.platform.gradle.buildsrc.KmpPlugin.Companion.enableMolecule
 import software.amazon.app.platform.gradle.buildsrc.SdkPlugin.publishSdk
 
@@ -29,18 +29,19 @@ constructor(objects: ObjectFactory, private val project: Project) {
 
   internal fun isComposeEnabled(): Property<Boolean> = enableCompose
 
-  private val enableDi: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
+  private val enableKotlinInject: Property<Boolean> =
+    objects.property(Boolean::class.java).convention(false)
 
-  public fun enableDi(enabled: Boolean) {
-    enableDi.set(enabled)
-    enableDi.disallowChanges()
+  public fun enableKotlinInject(enabled: Boolean) {
+    enableKotlinInject.set(enabled)
+    enableKotlinInject.disallowChanges()
 
     if (enabled) {
-      project.enableDi()
+      project.enableKotlinInject()
     }
   }
 
-  internal fun isDiEnabled(): Property<Boolean> = enableDi
+  internal fun isKotlinInjectEnabled(): Property<Boolean> = enableKotlinInject
 
   private val enableMolecule: Property<Boolean> =
     objects.property(Boolean::class.java).convention(false)

--- a/buildSrc/src/main/kotlin/software/amazon/app/platform/gradle/buildsrc/KmpPlugin.kt
+++ b/buildSrc/src/main/kotlin/software/amazon/app/platform/gradle/buildsrc/KmpPlugin.kt
@@ -177,7 +177,7 @@ public open class KmpPlugin : Plugin<Project> {
       allPlatforms().forEach { platform -> platform.configureCompose() }
     }
 
-    fun Project.enableDi() {
+    fun Project.enableKotlinInject() {
       plugins.apply(Plugins.KSP)
 
       val kspExtension = extensions.getByType(KspExtension::class.java)

--- a/di-common/public/build.gradle
+++ b/di-common/public/build.gradle
@@ -3,6 +3,6 @@ plugins {
 }
 
 appPlatformBuildSrc {
-    enableDi true
+    enableKotlinInject true
     enablePublishing true
 }

--- a/kotlin-inject-extensions/contribute/public/build.gradle
+++ b/kotlin-inject-extensions/contribute/public/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 appPlatformBuildSrc {
-    enableDi true
+    enableKotlinInject true
     enablePublishing true
 }
 

--- a/kotlin-inject/impl/build.gradle
+++ b/kotlin-inject/impl/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 appPlatformBuildSrc {
-    enableDi true
+    enableKotlinInject true
     enablePublishing true
 }
 

--- a/presenter-molecule/impl/build.gradle
+++ b/presenter-molecule/impl/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 appPlatformBuildSrc {
-    enableDi true
+    enableKotlinInject true
     enableMolecule true
     enablePublishing true
 

--- a/renderer-android-view/public/build.gradle
+++ b/renderer-android-view/public/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 appPlatformBuildSrc {
-    enableDi true
+    enableKotlinInject true
     enablePublishing true
     enableInstrumentedTests true
 }

--- a/renderer-compose-multiplatform/public/build.gradle
+++ b/renderer-compose-multiplatform/public/build.gradle
@@ -4,8 +4,8 @@ plugins {
 
 appPlatformBuildSrc {
     enableCompose true
-    enableDi true
     enableInstrumentedTests true
+    enableKotlinInject true
     enablePublishing true
 }
 

--- a/renderer/public/build.gradle
+++ b/renderer/public/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 appPlatformBuildSrc {
-    enableDi true
+    enableKotlinInject true
     enablePublishing true
 }
 

--- a/robot-compose-multiplatform/public/build.gradle
+++ b/robot-compose-multiplatform/public/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 appPlatformBuildSrc {
     enableCompose true
-    enableDi true
+    enableKotlinInject true
     enablePublishing true
 }
 

--- a/robot/public/build.gradle
+++ b/robot/public/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 appPlatformBuildSrc {
-    enableDi true
+    enableKotlinInject true
     enablePublishing true
 }
 


### PR DESCRIPTION
This DSL is not used by consumer projects, only App Platform itself. The new name is more explicit.

See #109