### PR TITLE
MoleculePresenter bindings for Metro

### DIFF
--- a/presenter-molecule/impl/api/android/impl.api
+++ b/presenter-molecule/impl/api/android/impl.api
@@ -1,3 +1,11 @@
+public final class metro/hints/SoftwareAmazonAppPlatformPresenterMoleculeAndroidMoleculeScopeFactoryGraphAppScopeKt {
+	public static final fun AppScope (Lsoftware/amazon/app/platform/presenter/molecule/AndroidMoleculeScopeFactoryGraph;)V
+}
+
+public final class metro/hints/SoftwareAmazonAppPlatformPresenterMoleculeBackgestureDefaultBackGestureDispatcherPresenterGraphAppScopeKt {
+	public static final fun AppScope (Lsoftware/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterGraph;)V
+}
+
 public final class software/amazon/app/platform/presenter/molecule/AndroidMoleculeScopeFactory : software/amazon/app/platform/presenter/molecule/MoleculeScopeFactory {
 	public static final field $stable I
 	public fun <init> (Lkotlin/jvm/functions/Function0;)V
@@ -5,11 +13,77 @@ public final class software/amazon/app/platform/presenter/molecule/AndroidMolecu
 	public fun createMoleculeScopeFromCoroutineScope (Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;)Lsoftware/amazon/app/platform/presenter/molecule/MoleculeScope;
 }
 
-public final class software/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenter : software/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter {
+public abstract interface class software/amazon/app/platform/presenter/molecule/AndroidMoleculeScopeFactoryComponent {
+	public fun provideAndroidMoleculeScopeFactory (Lkotlin/jvm/functions/Function0;)Lsoftware/amazon/app/platform/presenter/molecule/MoleculeScopeFactory;
+}
+
+public final class software/amazon/app/platform/presenter/molecule/AndroidMoleculeScopeFactoryComponent$DefaultImpls {
+	public static fun provideAndroidMoleculeScopeFactory (Lsoftware/amazon/app/platform/presenter/molecule/AndroidMoleculeScopeFactoryComponent;Lkotlin/jvm/functions/Function0;)Lsoftware/amazon/app/platform/presenter/molecule/MoleculeScopeFactory;
+}
+
+public abstract interface class software/amazon/app/platform/presenter/molecule/AndroidMoleculeScopeFactoryGraph {
+	public fun provideAndroidMoleculeScopeFactory (Ldev/zacsweers/metro/Provider;)Lsoftware/amazon/app/platform/presenter/molecule/MoleculeScopeFactory;
+}
+
+public abstract interface class software/amazon/app/platform/presenter/molecule/AndroidMoleculeScopeFactoryGraph$$$MetroContributionToMetroAppScope : software/amazon/app/platform/presenter/molecule/AndroidMoleculeScopeFactoryGraph {
+}
+
+public final class software/amazon/app/platform/presenter/molecule/AndroidMoleculeScopeFactoryGraph$$$MetroContributionToMetroAppScope$DefaultImpls {
+	public static fun provideAndroidMoleculeScopeFactory (Lsoftware/amazon/app/platform/presenter/molecule/AndroidMoleculeScopeFactoryGraph$$$MetroContributionToMetroAppScope;Ldev/zacsweers/metro/Provider;)Lsoftware/amazon/app/platform/presenter/molecule/MoleculeScopeFactory;
+}
+
+public final class software/amazon/app/platform/presenter/molecule/AndroidMoleculeScopeFactoryGraph$DefaultImpls {
+	public static fun provideAndroidMoleculeScopeFactory (Lsoftware/amazon/app/platform/presenter/molecule/AndroidMoleculeScopeFactoryGraph;Ldev/zacsweers/metro/Provider;)Lsoftware/amazon/app/platform/presenter/molecule/MoleculeScopeFactory;
+}
+
+public final class software/amazon/app/platform/presenter/molecule/AndroidMoleculeScopeFactoryGraph$ProvideAndroidMoleculeScopeFactory$$MetroFactory : dev/zacsweers/metro/internal/Factory {
 	public static final field $stable I
-	public fun <init> ()V
-	public fun PredictiveBackHandlerPresenter (ZLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
-	public fun getListenersCount ()Lkotlinx/coroutines/flow/StateFlow;
-	public fun onPredictiveBack (Lkotlinx/coroutines/flow/Flow;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final field Companion Lsoftware/amazon/app/platform/presenter/molecule/AndroidMoleculeScopeFactoryGraph$ProvideAndroidMoleculeScopeFactory$$MetroFactory$Companion;
+	public synthetic fun <init> (Lsoftware/amazon/app/platform/presenter/molecule/AndroidMoleculeScopeFactoryGraph;Ldev/zacsweers/metro/Provider;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lsoftware/amazon/app/platform/presenter/molecule/MoleculeScopeFactory;
+	public final fun mirrorFunction (Ldev/zacsweers/metro/Provider;)Lsoftware/amazon/app/platform/presenter/molecule/MoleculeScopeFactory;
+}
+
+public final class software/amazon/app/platform/presenter/molecule/AndroidMoleculeScopeFactoryGraph$ProvideAndroidMoleculeScopeFactory$$MetroFactory$Companion {
+	public final fun create (Lsoftware/amazon/app/platform/presenter/molecule/AndroidMoleculeScopeFactoryGraph;Ldev/zacsweers/metro/Provider;)Ldev/zacsweers/metro/internal/Factory;
+	public final fun provideAndroidMoleculeScopeFactory (Lsoftware/amazon/app/platform/presenter/molecule/AndroidMoleculeScopeFactoryGraph;Ldev/zacsweers/metro/Provider;)Lsoftware/amazon/app/platform/presenter/molecule/MoleculeScopeFactory;
+}
+
+public abstract interface class software/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterComponent {
+	public fun provideDefaultBackGestureDispatcherPresenter ()Lsoftware/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter;
+}
+
+public final class software/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterComponent$DefaultImpls {
+	public static fun provideDefaultBackGestureDispatcherPresenter (Lsoftware/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterComponent;)Lsoftware/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter;
+}
+
+public abstract interface class software/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterGraph {
+	public fun provideDefaultBackGestureDispatcherPresenter ()Lsoftware/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter;
+}
+
+public abstract interface class software/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterGraph$$$MetroContributionToMetroAppScope : software/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterGraph {
+}
+
+public final class software/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterGraph$$$MetroContributionToMetroAppScope$DefaultImpls {
+	public static fun provideDefaultBackGestureDispatcherPresenter (Lsoftware/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterGraph$$$MetroContributionToMetroAppScope;)Lsoftware/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter;
+}
+
+public final class software/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterGraph$DefaultImpls {
+	public static fun provideDefaultBackGestureDispatcherPresenter (Lsoftware/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterGraph;)Lsoftware/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter;
+}
+
+public final class software/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterGraph$ProvideDefaultBackGestureDispatcherPresenter$$MetroFactory : dev/zacsweers/metro/internal/Factory {
+	public static final field $stable I
+	public static final field Companion Lsoftware/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterGraph$ProvideDefaultBackGestureDispatcherPresenter$$MetroFactory$Companion;
+	public synthetic fun <init> (Lsoftware/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterGraph;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lsoftware/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter;
+	public final fun mirrorFunction ()Lsoftware/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter;
+}
+
+public final class software/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterGraph$ProvideDefaultBackGestureDispatcherPresenter$$MetroFactory$Companion {
+	public final fun create (Lsoftware/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterGraph;)Ldev/zacsweers/metro/internal/Factory;
+	public final fun provideDefaultBackGestureDispatcherPresenter (Lsoftware/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterGraph;)Lsoftware/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter;
 }
 

--- a/presenter-molecule/impl/api/desktop/impl.api
+++ b/presenter-molecule/impl/api/desktop/impl.api
@@ -1,3 +1,11 @@
+public final class metro/hints/SoftwareAmazonAppPlatformPresenterMoleculeBackgestureDefaultBackGestureDispatcherPresenterGraphAppScopeKt {
+	public static final fun AppScope (Lsoftware/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterGraph;)V
+}
+
+public final class metro/hints/SoftwareAmazonAppPlatformPresenterMoleculeDesktopMoleculeScopeFactoryGraphAppScopeKt {
+	public static final fun AppScope (Lsoftware/amazon/app/platform/presenter/molecule/DesktopMoleculeScopeFactoryGraph;)V
+}
+
 public final class software/amazon/app/platform/presenter/molecule/DesktopMoleculeScopeFactory : software/amazon/app/platform/presenter/molecule/MoleculeScopeFactory {
 	public static final field $stable I
 	public fun <init> (Lkotlin/jvm/functions/Function0;)V
@@ -5,11 +13,77 @@ public final class software/amazon/app/platform/presenter/molecule/DesktopMolecu
 	public fun createMoleculeScopeFromCoroutineScope (Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;)Lsoftware/amazon/app/platform/presenter/molecule/MoleculeScope;
 }
 
-public final class software/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenter : software/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter {
+public abstract interface class software/amazon/app/platform/presenter/molecule/DesktopMoleculeScopeFactoryComponent {
+	public fun provideDesktopMoleculeScopeFactory (Lkotlin/jvm/functions/Function0;)Lsoftware/amazon/app/platform/presenter/molecule/MoleculeScopeFactory;
+}
+
+public final class software/amazon/app/platform/presenter/molecule/DesktopMoleculeScopeFactoryComponent$DefaultImpls {
+	public static fun provideDesktopMoleculeScopeFactory (Lsoftware/amazon/app/platform/presenter/molecule/DesktopMoleculeScopeFactoryComponent;Lkotlin/jvm/functions/Function0;)Lsoftware/amazon/app/platform/presenter/molecule/MoleculeScopeFactory;
+}
+
+public abstract interface class software/amazon/app/platform/presenter/molecule/DesktopMoleculeScopeFactoryGraph {
+	public fun provideDesktopMoleculeScopeFactory (Ldev/zacsweers/metro/Provider;)Lsoftware/amazon/app/platform/presenter/molecule/MoleculeScopeFactory;
+}
+
+public abstract interface class software/amazon/app/platform/presenter/molecule/DesktopMoleculeScopeFactoryGraph$$$MetroContributionToMetroAppScope : software/amazon/app/platform/presenter/molecule/DesktopMoleculeScopeFactoryGraph {
+}
+
+public final class software/amazon/app/platform/presenter/molecule/DesktopMoleculeScopeFactoryGraph$$$MetroContributionToMetroAppScope$DefaultImpls {
+	public static fun provideDesktopMoleculeScopeFactory (Lsoftware/amazon/app/platform/presenter/molecule/DesktopMoleculeScopeFactoryGraph$$$MetroContributionToMetroAppScope;Ldev/zacsweers/metro/Provider;)Lsoftware/amazon/app/platform/presenter/molecule/MoleculeScopeFactory;
+}
+
+public final class software/amazon/app/platform/presenter/molecule/DesktopMoleculeScopeFactoryGraph$DefaultImpls {
+	public static fun provideDesktopMoleculeScopeFactory (Lsoftware/amazon/app/platform/presenter/molecule/DesktopMoleculeScopeFactoryGraph;Ldev/zacsweers/metro/Provider;)Lsoftware/amazon/app/platform/presenter/molecule/MoleculeScopeFactory;
+}
+
+public final class software/amazon/app/platform/presenter/molecule/DesktopMoleculeScopeFactoryGraph$ProvideDesktopMoleculeScopeFactory$$MetroFactory : dev/zacsweers/metro/internal/Factory {
 	public static final field $stable I
-	public fun <init> ()V
-	public fun PredictiveBackHandlerPresenter (ZLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
-	public fun getListenersCount ()Lkotlinx/coroutines/flow/StateFlow;
-	public fun onPredictiveBack (Lkotlinx/coroutines/flow/Flow;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final field Companion Lsoftware/amazon/app/platform/presenter/molecule/DesktopMoleculeScopeFactoryGraph$ProvideDesktopMoleculeScopeFactory$$MetroFactory$Companion;
+	public synthetic fun <init> (Lsoftware/amazon/app/platform/presenter/molecule/DesktopMoleculeScopeFactoryGraph;Ldev/zacsweers/metro/Provider;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lsoftware/amazon/app/platform/presenter/molecule/MoleculeScopeFactory;
+	public final fun mirrorFunction (Ldev/zacsweers/metro/Provider;)Lsoftware/amazon/app/platform/presenter/molecule/MoleculeScopeFactory;
+}
+
+public final class software/amazon/app/platform/presenter/molecule/DesktopMoleculeScopeFactoryGraph$ProvideDesktopMoleculeScopeFactory$$MetroFactory$Companion {
+	public final fun create (Lsoftware/amazon/app/platform/presenter/molecule/DesktopMoleculeScopeFactoryGraph;Ldev/zacsweers/metro/Provider;)Ldev/zacsweers/metro/internal/Factory;
+	public final fun provideDesktopMoleculeScopeFactory (Lsoftware/amazon/app/platform/presenter/molecule/DesktopMoleculeScopeFactoryGraph;Ldev/zacsweers/metro/Provider;)Lsoftware/amazon/app/platform/presenter/molecule/MoleculeScopeFactory;
+}
+
+public abstract interface class software/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterComponent {
+	public fun provideDefaultBackGestureDispatcherPresenter ()Lsoftware/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter;
+}
+
+public final class software/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterComponent$DefaultImpls {
+	public static fun provideDefaultBackGestureDispatcherPresenter (Lsoftware/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterComponent;)Lsoftware/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter;
+}
+
+public abstract interface class software/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterGraph {
+	public fun provideDefaultBackGestureDispatcherPresenter ()Lsoftware/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter;
+}
+
+public abstract interface class software/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterGraph$$$MetroContributionToMetroAppScope : software/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterGraph {
+}
+
+public final class software/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterGraph$$$MetroContributionToMetroAppScope$DefaultImpls {
+	public static fun provideDefaultBackGestureDispatcherPresenter (Lsoftware/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterGraph$$$MetroContributionToMetroAppScope;)Lsoftware/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter;
+}
+
+public final class software/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterGraph$DefaultImpls {
+	public static fun provideDefaultBackGestureDispatcherPresenter (Lsoftware/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterGraph;)Lsoftware/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter;
+}
+
+public final class software/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterGraph$ProvideDefaultBackGestureDispatcherPresenter$$MetroFactory : dev/zacsweers/metro/internal/Factory {
+	public static final field $stable I
+	public static final field Companion Lsoftware/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterGraph$ProvideDefaultBackGestureDispatcherPresenter$$MetroFactory$Companion;
+	public synthetic fun <init> (Lsoftware/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterGraph;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun invoke ()Ljava/lang/Object;
+	public final fun invoke ()Lsoftware/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter;
+	public final fun mirrorFunction ()Lsoftware/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter;
+}
+
+public final class software/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterGraph$ProvideDefaultBackGestureDispatcherPresenter$$MetroFactory$Companion {
+	public final fun create (Lsoftware/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterGraph;)Ldev/zacsweers/metro/internal/Factory;
+	public final fun provideDefaultBackGestureDispatcherPresenter (Lsoftware/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenterGraph;)Lsoftware/amazon/app/platform/presenter/molecule/backgesture/BackGestureDispatcherPresenter;
 }
 

--- a/presenter-molecule/impl/build.gradle
+++ b/presenter-molecule/impl/build.gradle
@@ -4,6 +4,7 @@ plugins {
 
 appPlatformBuildSrc {
     enableKotlinInject true
+    enableMetro true
     enableMolecule true
     enablePublishing true
 

--- a/presenter-molecule/impl/src/androidMain/kotlin/software/amazon/app/platform/presenter/molecule/AndroidMoleculeScopeFactory.kt
+++ b/presenter-molecule/impl/src/androidMain/kotlin/software/amazon/app/platform/presenter/molecule/AndroidMoleculeScopeFactory.kt
@@ -2,25 +2,47 @@ package software.amazon.app.platform.presenter.molecule
 
 import app.cash.molecule.AndroidUiDispatcher
 import app.cash.molecule.RecompositionMode
+import dev.zacsweers.metro.AppScope as MetroAppScope
+import dev.zacsweers.metro.ContributesTo as MetroContributesTo
+import dev.zacsweers.metro.Provider
+import dev.zacsweers.metro.Provides as MetroProvides
+import dev.zacsweers.metro.SingleIn as MetroSingleIn
 import kotlinx.coroutines.CoroutineScope
-import me.tatarka.inject.annotations.Inject
+import me.tatarka.inject.annotations.Provides as KiProvides
 import software.amazon.app.platform.presenter.PresenterCoroutineScope
-import software.amazon.lastmile.kotlin.inject.anvil.AppScope
-import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
-import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
+import software.amazon.lastmile.kotlin.inject.anvil.AppScope as KiAppScope
+import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo as KiContributesTo
+import software.amazon.lastmile.kotlin.inject.anvil.SingleIn as KiSingleIn
 
 /**
  * Runs `MoleculePresenters` on the main thread provided by [PresenterCoroutineScope] and recomposes
  * only once per screen refresh when needed.
  */
-@Inject
-@SingleIn(AppScope::class)
-@ContributesBinding(AppScope::class)
-public class AndroidMoleculeScopeFactory(
-  @PresenterCoroutineScope coroutineScopeFactory: () -> CoroutineScope
-) :
+public class AndroidMoleculeScopeFactory(coroutineScopeFactory: () -> CoroutineScope) :
   MoleculeScopeFactory by DefaultMoleculeScopeFactory(
     coroutineScopeFactory = coroutineScopeFactory,
     coroutineContext = AndroidUiDispatcher.Main,
     recompositionMode = RecompositionMode.ContextClock,
   )
+
+/** Provides the [AndroidMoleculeScopeFactory] in the kotlin-inject graph. */
+@KiContributesTo(KiAppScope::class)
+public interface AndroidMoleculeScopeFactoryComponent {
+  /** Provides the [AndroidMoleculeScopeFactory] in the kotlin-inject graph as a singleton. */
+  @KiProvides
+  @KiSingleIn(KiAppScope::class)
+  public fun provideAndroidMoleculeScopeFactory(
+    @PresenterCoroutineScope coroutineScopeFactory: () -> CoroutineScope
+  ): MoleculeScopeFactory = AndroidMoleculeScopeFactory(coroutineScopeFactory)
+}
+
+/** Provides the [AndroidMoleculeScopeFactory] in the Metro graph. */
+@MetroContributesTo(MetroAppScope::class)
+public interface AndroidMoleculeScopeFactoryGraph {
+  /** Provides the [AndroidMoleculeScopeFactory] in the Metro graph as a singleton. */
+  @MetroProvides
+  @MetroSingleIn(MetroAppScope::class)
+  public fun provideAndroidMoleculeScopeFactory(
+    @PresenterCoroutineScope coroutineScopeFactory: Provider<CoroutineScope>
+  ): MoleculeScopeFactory = AndroidMoleculeScopeFactory { coroutineScopeFactory() }
+}

--- a/presenter-molecule/impl/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenter.kt
+++ b/presenter-molecule/impl/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/DefaultBackGestureDispatcherPresenter.kt
@@ -1,17 +1,38 @@
 package software.amazon.app.platform.presenter.molecule.backgesture
 
-import me.tatarka.inject.annotations.Inject
-import software.amazon.lastmile.kotlin.inject.anvil.AppScope
-import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
-import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
+import dev.zacsweers.metro.AppScope as MetroAppScope
+import dev.zacsweers.metro.ContributesTo as MetroContributesTo
+import dev.zacsweers.metro.Provides as MetroProvides
+import dev.zacsweers.metro.SingleIn as MetroSingleIn
+import me.tatarka.inject.annotations.Provides as KiProvides
+import software.amazon.lastmile.kotlin.inject.anvil.AppScope as KiAppScope
+import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo as KiContributesTo
+import software.amazon.lastmile.kotlin.inject.anvil.SingleIn as KiSingleIn
 
 /**
- * Implementation of [BackGestureDispatcherPresenter] that maintains a list of registered back
- * gesture listeners and forwards events to the last registered callback. See
+ * Provides a [BackGestureDispatcherPresenter] that maintains a list of registered back gesture
+ * listeners and forwards events to the last registered callback. See
  * [BackGestureDispatcherPresenter] for more details.
  */
-@Inject
-@SingleIn(AppScope::class)
-@ContributesBinding(AppScope::class)
-public class DefaultBackGestureDispatcherPresenter :
-  BackGestureDispatcherPresenter by BackGestureDispatcherPresenter.createNewInstance()
+@KiContributesTo(KiAppScope::class)
+public interface DefaultBackGestureDispatcherPresenterComponent {
+  /** Provides a [BackGestureDispatcherPresenter] as singleton in the kotlin-inject graph. */
+  @KiProvides
+  @KiSingleIn(KiAppScope::class)
+  public fun provideDefaultBackGestureDispatcherPresenter(): BackGestureDispatcherPresenter =
+    BackGestureDispatcherPresenter.createNewInstance()
+}
+
+/**
+ * Provides a [BackGestureDispatcherPresenter] that maintains a list of registered back gesture
+ * listeners and forwards events to the last registered callback. See
+ * [BackGestureDispatcherPresenter] for more details.
+ */
+@MetroContributesTo(MetroAppScope::class)
+public interface DefaultBackGestureDispatcherPresenterGraph {
+  /** Provides a [BackGestureDispatcherPresenter] as singleton in the Metro graph. */
+  @MetroProvides
+  @MetroSingleIn(MetroAppScope::class)
+  public fun provideDefaultBackGestureDispatcherPresenter(): BackGestureDispatcherPresenter =
+    BackGestureDispatcherPresenter.createNewInstance()
+}

--- a/presenter-molecule/impl/src/commonTest/kotlin/software/amazon/app/platform/presenter/molecule/KotlinInjectInjectionTest.kt
+++ b/presenter-molecule/impl/src/commonTest/kotlin/software/amazon/app/platform/presenter/molecule/KotlinInjectInjectionTest.kt
@@ -20,7 +20,7 @@ import software.amazon.lastmile.kotlin.inject.anvil.AppScope
 import software.amazon.lastmile.kotlin.inject.anvil.ForScope
 import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 
-class InjectionTest {
+class KotlinInjectInjectionTest {
 
   @Test
   fun `the PresenterCoroutineScope can be injected lazily`() {
@@ -40,7 +40,7 @@ class InjectionTest {
 
 @Component
 @SingleIn(AppScope::class)
-abstract class TestComponent(
+abstract class KotlinInjectTestComponent(
   private val coroutineScope: CoroutineScope,
   private val coroutineDispatcher: CoroutineDispatcher,
 ) : PresenterCoroutineScopeComponent {
@@ -55,12 +55,14 @@ abstract class TestComponent(
   fun provideMainCoroutineDispatcher(): CoroutineDispatcher = coroutineDispatcher
 
   @Provides
-  fun provideMoleculeScopeFactory(factory: TestMoleculeScopeFactory): MoleculeScopeFactory = factory
+  fun provideMoleculeScopeFactory(
+    factory: KotlinInjectTestMoleculeScopeFactory
+  ): MoleculeScopeFactory = factory
 }
 
 @Inject
 @SingleIn(AppScope::class)
-class TestMoleculeScopeFactory(
+class KotlinInjectTestMoleculeScopeFactory(
   @PresenterCoroutineScope coroutineScopeFactory: () -> CoroutineScope
 ) :
   MoleculeScopeFactory by DefaultMoleculeScopeFactory(
@@ -73,4 +75,4 @@ class TestMoleculeScopeFactory(
 expect fun createTestComponent(
   coroutineScope: CoroutineScope,
   coroutineDispatcher: CoroutineDispatcher,
-): TestComponent
+): KotlinInjectTestComponent

--- a/presenter-molecule/impl/src/commonTest/kotlin/software/amazon/app/platform/presenter/molecule/MetroInjectionTest.kt
+++ b/presenter-molecule/impl/src/commonTest/kotlin/software/amazon/app/platform/presenter/molecule/MetroInjectionTest.kt
@@ -1,0 +1,63 @@
+package software.amazon.app.platform.presenter.molecule
+
+import app.cash.molecule.RecompositionMode
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.Binds
+import dev.zacsweers.metro.DependencyGraph
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.Provider
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.SingleIn
+import dev.zacsweers.metro.createGraphFactory
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.Test
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import software.amazon.app.platform.presenter.PresenterCoroutineScope
+
+class MetroInjectionTest {
+
+  @Test
+  fun `the PresenterCoroutineScope can be injected lazily`() {
+    val testScope = CoroutineScope(CoroutineName("TestName"))
+
+    val component = createGraphFactory<MetroTestComponent.Factory>().create(testScope)
+
+    val moleculeScope = component.moleculeScopeFactory.createMoleculeScope()
+
+    assertThat(moleculeScope.coroutineScope.coroutineContext[CoroutineName.Key]?.name)
+      .isEqualTo("TestName")
+
+    moleculeScope.cancel()
+  }
+}
+
+@Suppress("unused")
+@DependencyGraph
+@SingleIn(AppScope::class)
+interface MetroTestComponent {
+
+  @DependencyGraph.Factory
+  fun interface Factory {
+    fun create(
+      @Provides @PresenterCoroutineScope coroutineScope: CoroutineScope
+    ): MetroTestComponent
+  }
+
+  val moleculeScopeFactory: MoleculeScopeFactory
+
+  @Binds val MetroTestMoleculeScopeFactory.bind: MoleculeScopeFactory
+}
+
+@Inject
+@SingleIn(AppScope::class)
+class MetroTestMoleculeScopeFactory(
+  @PresenterCoroutineScope coroutineScopeFactory: Provider<CoroutineScope>
+) :
+  MoleculeScopeFactory by DefaultMoleculeScopeFactory(
+    coroutineScopeFactory = { coroutineScopeFactory() },
+    coroutineContext = EmptyCoroutineContext,
+    recompositionMode = RecompositionMode.Immediate,
+  )

--- a/presenter-molecule/impl/src/desktopMain/kotlin/software/amazon/app/platform/presenter/molecule/DesktopMoleculeScopeFactory.kt
+++ b/presenter-molecule/impl/src/desktopMain/kotlin/software/amazon/app/platform/presenter/molecule/DesktopMoleculeScopeFactory.kt
@@ -1,24 +1,46 @@
 package software.amazon.app.platform.presenter.molecule
 
 import app.cash.molecule.RecompositionMode
+import dev.zacsweers.metro.AppScope as MetroAppScope
+import dev.zacsweers.metro.ContributesTo as MetroContributesTo
+import dev.zacsweers.metro.Provider
+import dev.zacsweers.metro.Provides as MetroProvides
+import dev.zacsweers.metro.SingleIn as MetroSingleIn
 import kotlinx.coroutines.CoroutineScope
-import me.tatarka.inject.annotations.Inject
+import me.tatarka.inject.annotations.Provides as KiProvides
 import software.amazon.app.platform.presenter.PresenterCoroutineScope
-import software.amazon.lastmile.kotlin.inject.anvil.AppScope
-import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
-import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
+import software.amazon.lastmile.kotlin.inject.anvil.AppScope as KiAppScope
+import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo as KiContributesTo
+import software.amazon.lastmile.kotlin.inject.anvil.SingleIn as KiSingleIn
 
 /**
  * Runs `MoleculePresenters` on the main thread provided by [PresenterCoroutineScope] and recomposes
  * as fast as possible.
  */
-@Inject
-@SingleIn(AppScope::class)
-@ContributesBinding(AppScope::class)
-public class DesktopMoleculeScopeFactory(
-  @PresenterCoroutineScope coroutineScopeFactory: () -> CoroutineScope
-) :
+public class DesktopMoleculeScopeFactory(coroutineScopeFactory: () -> CoroutineScope) :
   MoleculeScopeFactory by DefaultMoleculeScopeFactory(
     coroutineScopeFactory = coroutineScopeFactory,
     recompositionMode = RecompositionMode.Immediate,
   )
+
+/** Provides the [DesktopMoleculeScopeFactory] in the kotlin-inject graph. */
+@KiContributesTo(KiAppScope::class)
+public interface DesktopMoleculeScopeFactoryComponent {
+  /** Provides the [DesktopMoleculeScopeFactory] in the kotlin-inject graph as a singleton. */
+  @KiProvides
+  @KiSingleIn(KiAppScope::class)
+  public fun provideDesktopMoleculeScopeFactory(
+    @PresenterCoroutineScope coroutineScopeFactory: () -> CoroutineScope
+  ): MoleculeScopeFactory = DesktopMoleculeScopeFactory(coroutineScopeFactory)
+}
+
+/** Provides the [DesktopMoleculeScopeFactory] in the Metro graph. */
+@MetroContributesTo(MetroAppScope::class)
+public interface DesktopMoleculeScopeFactoryGraph {
+  /** Provides the [DesktopMoleculeScopeFactory] in the Metro graph as a singleton. */
+  @MetroProvides
+  @MetroSingleIn(MetroAppScope::class)
+  public fun provideDesktopMoleculeScopeFactory(
+    @PresenterCoroutineScope coroutineScopeFactory: Provider<CoroutineScope>
+  ): MoleculeScopeFactory = DesktopMoleculeScopeFactory { coroutineScopeFactory() }
+}

--- a/presenter-molecule/impl/src/iosMain/kotlin/software/amazon/app/platform/presenter/molecule/IosMoleculeScopeFactory.kt
+++ b/presenter-molecule/impl/src/iosMain/kotlin/software/amazon/app/platform/presenter/molecule/IosMoleculeScopeFactory.kt
@@ -2,25 +2,47 @@ package software.amazon.app.platform.presenter.molecule
 
 import app.cash.molecule.DisplayLinkClock
 import app.cash.molecule.RecompositionMode
+import dev.zacsweers.metro.AppScope as MetroAppScope
+import dev.zacsweers.metro.ContributesTo as MetroContributesTo
+import dev.zacsweers.metro.Provider
+import dev.zacsweers.metro.Provides as MetroProvides
+import dev.zacsweers.metro.SingleIn as MetroSingleIn
 import kotlinx.coroutines.CoroutineScope
-import me.tatarka.inject.annotations.Inject
+import me.tatarka.inject.annotations.Provides as KiProvides
 import software.amazon.app.platform.presenter.PresenterCoroutineScope
-import software.amazon.lastmile.kotlin.inject.anvil.AppScope
-import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
-import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
+import software.amazon.lastmile.kotlin.inject.anvil.AppScope as KiAppScope
+import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo as KiContributesTo
+import software.amazon.lastmile.kotlin.inject.anvil.SingleIn as KiSingleIn
 
 /**
  * Runs `MoleculePresenters` on the main thread provided by [PresenterCoroutineScope] and recomposes
  * only once per screen refresh when needed.
  */
-@Inject
-@SingleIn(AppScope::class)
-@ContributesBinding(AppScope::class)
-public class IosMoleculeScopeFactory(
-  @PresenterCoroutineScope coroutineScopeFactory: () -> CoroutineScope
-) :
+public class IosMoleculeScopeFactory(coroutineScopeFactory: () -> CoroutineScope) :
   MoleculeScopeFactory by DefaultMoleculeScopeFactory(
     coroutineScopeFactory = coroutineScopeFactory,
     coroutineContext = DisplayLinkClock,
     recompositionMode = RecompositionMode.ContextClock,
   )
+
+/** Provides the [IosMoleculeScopeFactory] in the kotlin-inject graph. */
+@KiContributesTo(KiAppScope::class)
+public interface IosMoleculeScopeFactoryComponent {
+  /** Provides the [IosMoleculeScopeFactory] in the kotlin-inject graph as a singleton. */
+  @KiProvides
+  @KiSingleIn(KiAppScope::class)
+  public fun provideIosMoleculeScopeFactory(
+    @PresenterCoroutineScope coroutineScopeFactory: () -> CoroutineScope
+  ): MoleculeScopeFactory = IosMoleculeScopeFactory(coroutineScopeFactory)
+}
+
+/** Provides the [IosMoleculeScopeFactory] in the Metro graph. */
+@MetroContributesTo(MetroAppScope::class)
+public interface IosMoleculeScopeFactoryGraph {
+  /** Provides the [IosMoleculeScopeFactory] in the Metro graph as a singleton. */
+  @MetroProvides
+  @MetroSingleIn(MetroAppScope::class)
+  public fun provideIosMoleculeScopeFactory(
+    @PresenterCoroutineScope coroutineScopeFactory: Provider<CoroutineScope>
+  ): MoleculeScopeFactory = IosMoleculeScopeFactory { coroutineScopeFactory() }
+}

--- a/presenter-molecule/impl/src/linuxMain/kotlin/software/amazon/app/platform/presenter/molecule/LinuxMoleculeScopeFactory.kt
+++ b/presenter-molecule/impl/src/linuxMain/kotlin/software/amazon/app/platform/presenter/molecule/LinuxMoleculeScopeFactory.kt
@@ -1,24 +1,46 @@
 package software.amazon.app.platform.presenter.molecule
 
 import app.cash.molecule.RecompositionMode
+import dev.zacsweers.metro.AppScope as MetroAppScope
+import dev.zacsweers.metro.ContributesTo as MetroContributesTo
+import dev.zacsweers.metro.Provider
+import dev.zacsweers.metro.Provides as MetroProvides
+import dev.zacsweers.metro.SingleIn as MetroSingleIn
 import kotlinx.coroutines.CoroutineScope
-import me.tatarka.inject.annotations.Inject
+import me.tatarka.inject.annotations.Provides as KiProvides
 import software.amazon.app.platform.presenter.PresenterCoroutineScope
-import software.amazon.lastmile.kotlin.inject.anvil.AppScope
-import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
-import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
+import software.amazon.lastmile.kotlin.inject.anvil.AppScope as KiAppScope
+import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo as KiContributesTo
+import software.amazon.lastmile.kotlin.inject.anvil.SingleIn as KiSingleIn
 
 /**
  * Runs `MoleculePresenters` on the main thread provided by [PresenterCoroutineScope] and recomposes
  * as fast as possible.
  */
-@Inject
-@SingleIn(AppScope::class)
-@ContributesBinding(AppScope::class)
-public class LinuxMoleculeScopeFactory(
-  @PresenterCoroutineScope coroutineScopeFactory: () -> CoroutineScope
-) :
+public class LinuxMoleculeScopeFactory(coroutineScopeFactory: () -> CoroutineScope) :
   MoleculeScopeFactory by DefaultMoleculeScopeFactory(
     coroutineScopeFactory = coroutineScopeFactory,
     recompositionMode = RecompositionMode.Immediate,
   )
+
+/** Provides the [LinuxMoleculeScopeFactory] in the kotlin-inject graph. */
+@KiContributesTo(KiAppScope::class)
+public interface LinuxMoleculeScopeFactoryComponent {
+  /** Provides the [LinuxMoleculeScopeFactory] in the kotlin-inject graph as a singleton. */
+  @KiProvides
+  @KiSingleIn(KiAppScope::class)
+  public fun provideLinuxMoleculeScopeFactory(
+    @PresenterCoroutineScope coroutineScopeFactory: () -> CoroutineScope
+  ): MoleculeScopeFactory = LinuxMoleculeScopeFactory(coroutineScopeFactory)
+}
+
+/** Provides the [LinuxMoleculeScopeFactory] in the Metro graph. */
+@MetroContributesTo(MetroAppScope::class)
+public interface LinuxMoleculeScopeFactoryGraph {
+  /** Provides the [LinuxMoleculeScopeFactory] in the Metro graph as a singleton. */
+  @MetroProvides
+  @MetroSingleIn(MetroAppScope::class)
+  public fun provideLinuxMoleculeScopeFactory(
+    @PresenterCoroutineScope coroutineScopeFactory: Provider<CoroutineScope>
+  ): MoleculeScopeFactory = LinuxMoleculeScopeFactory { coroutineScopeFactory() }
+}

--- a/presenter-molecule/impl/src/wasmJsMain/kotlin/software/amazon/app/platform/presenter/molecule/WasmJsMoleculeScopeFactory.kt
+++ b/presenter-molecule/impl/src/wasmJsMain/kotlin/software/amazon/app/platform/presenter/molecule/WasmJsMoleculeScopeFactory.kt
@@ -1,24 +1,46 @@
 package software.amazon.app.platform.presenter.molecule
 
 import app.cash.molecule.RecompositionMode
+import dev.zacsweers.metro.AppScope as MetroAppScope
+import dev.zacsweers.metro.ContributesTo as MetroContributesTo
+import dev.zacsweers.metro.Provider
+import dev.zacsweers.metro.Provides as MetroProvides
+import dev.zacsweers.metro.SingleIn as MetroSingleIn
 import kotlinx.coroutines.CoroutineScope
-import me.tatarka.inject.annotations.Inject
+import me.tatarka.inject.annotations.Provides as KiProvides
 import software.amazon.app.platform.presenter.PresenterCoroutineScope
-import software.amazon.lastmile.kotlin.inject.anvil.AppScope
-import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
-import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
+import software.amazon.lastmile.kotlin.inject.anvil.AppScope as KiAppScope
+import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo as KiContributesTo
+import software.amazon.lastmile.kotlin.inject.anvil.SingleIn as KiSingleIn
 
 /**
  * Runs `MoleculePresenters` on the main thread provided by [PresenterCoroutineScope] and recomposes
  * as fast as possible.
  */
-@Inject
-@SingleIn(AppScope::class)
-@ContributesBinding(AppScope::class)
-public class WasmJsMoleculeScopeFactory(
-  @PresenterCoroutineScope coroutineScopeFactory: () -> CoroutineScope
-) :
+public class WasmJsMoleculeScopeFactory(coroutineScopeFactory: () -> CoroutineScope) :
   MoleculeScopeFactory by DefaultMoleculeScopeFactory(
     coroutineScopeFactory = coroutineScopeFactory,
     recompositionMode = RecompositionMode.Immediate,
   )
+
+/** Provides the [WasmJsMoleculeScopeFactory] in the kotlin-inject graph. */
+@KiContributesTo(KiAppScope::class)
+public interface WasmJsMoleculeScopeFactoryComponent {
+  /** Provides the [WasmJsMoleculeScopeFactory] in the kotlin-inject graph as a singleton. */
+  @KiProvides
+  @KiSingleIn(KiAppScope::class)
+  public fun provideWasmJsMoleculeScopeFactory(
+    @PresenterCoroutineScope coroutineScopeFactory: () -> CoroutineScope
+  ): MoleculeScopeFactory = WasmJsMoleculeScopeFactory(coroutineScopeFactory)
+}
+
+/** Provides the [WasmJsMoleculeScopeFactory] in the Metro graph. */
+@MetroContributesTo(MetroAppScope::class)
+public interface WasmJsMoleculeScopeFactoryGraph {
+  /** Provides the [WasmJsMoleculeScopeFactory] in the Metro graph as a singleton. */
+  @MetroProvides
+  @MetroSingleIn(MetroAppScope::class)
+  public fun provideWasmJsMoleculeScopeFactory(
+    @PresenterCoroutineScope coroutineScopeFactory: Provider<CoroutineScope>
+  ): MoleculeScopeFactory = WasmJsMoleculeScopeFactory { coroutineScopeFactory() }
+}

--- a/renderer-compose-multiplatform/public/src/androidInstrumentedTest/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/ForwardBackPressEventsToPresentersComposeTest.kt
+++ b/renderer-compose-multiplatform/public/src/androidInstrumentedTest/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/ForwardBackPressEventsToPresentersComposeTest.kt
@@ -32,7 +32,7 @@ class ForwardBackPressEventsToPresentersComposeTest {
 
   @Test
   fun back_press_events_are_forwarded_to_presenters() {
-    val backGestureDispatcherPresenter = DefaultBackGestureDispatcherPresenter()
+    val backGestureDispatcherPresenter = BackGestureDispatcherPresenter.createNewInstance()
 
     val testPresenter = TestPresenter(backGestureDispatcherPresenter)
     val testRenderer = TestRenderer()


### PR DESCRIPTION
Provide default bindings for `MoleculePresenter` integrations for Metro.

See #119
