### PR TITLE
Use `MainScope()` for the UI scope

### DIFF
--- a/renderer-android-view/public/api/public.api
+++ b/renderer-android-view/public/api/public.api
@@ -55,10 +55,6 @@ public abstract class software/amazon/app/platform/renderer/ViewRenderer : softw
 	protected fun renderModel (Lsoftware/amazon/app/platform/presenter/BaseModel;Lsoftware/amazon/app/platform/presenter/BaseModel;)V
 }
 
-public abstract interface class software/amazon/app/platform/renderer/ViewRenderer$Component {
-	public abstract fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
-}
-
 public abstract class software/amazon/app/platform/renderer/template/AndroidTemplateRenderer : software/amazon/app/platform/renderer/ViewRenderer {
 	public fun <init> (Lsoftware/amazon/app/platform/renderer/RendererFactory;)V
 }

--- a/renderer-android-view/public/build.gradle
+++ b/renderer-android-view/public/build.gradle
@@ -3,7 +3,6 @@ plugins {
 }
 
 appPlatformBuildSrc {
-    enableKotlinInject true
     enablePublishing true
     enableInstrumentedTests true
 }
@@ -38,6 +37,7 @@ dependencies {
     androidMainApi libs.recyclerView
     androidMainImplementation libs.androidx.core
 
+    androidInstrumentedTestImplementation project(':kotlin-inject:public')
     androidInstrumentedTestImplementation libs.androidx.test.espresso
     // Use the version aligned with AGP in tests.
     androidInstrumentedTestImplementation libs.viewbinding.agp

--- a/renderer-android-view/public/src/androidInstrumentedTest/kotlin/software/amazon/app/platform/renderer/TestApplication.kt
+++ b/renderer-android-view/public/src/androidInstrumentedTest/kotlin/software/amazon/app/platform/renderer/TestApplication.kt
@@ -2,9 +2,7 @@ package software.amazon.app.platform.renderer
 
 import android.app.Application
 import androidx.test.platform.app.InstrumentationRegistry
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineName
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import software.amazon.app.platform.scope.RootScopeProvider
 import software.amazon.app.platform.scope.Scope
@@ -22,9 +20,7 @@ class TestApplication : Application(), RootScopeProvider {
       addCoroutineScopeScoped(CoroutineScopeScoped(Job() + CoroutineName("test")))
     }
 
-  private inner class Component : ViewRenderer.Component, RendererComponent.Parent {
-    override val dispatcher: CoroutineDispatcher = Dispatchers.Main.immediate
-
+  private inner class Component : RendererComponent.Parent {
     override fun rendererComponent(factory: RendererFactory): RendererComponent =
       requireNotNull(rendererComponent)
   }

--- a/renderer-android-view/public/src/androidMain/kotlin/software/amazon/app/platform/renderer/ViewRenderer.kt
+++ b/renderer-android-view/public/src/androidMain/kotlin/software/amazon/app/platform/renderer/ViewRenderer.kt
@@ -8,16 +8,10 @@ import androidx.core.view.children
 import androidx.core.view.doOnAttach
 import androidx.core.view.doOnDetach
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
+import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
 import software.amazon.app.platform.presenter.BaseModel
-import software.amazon.app.platform.scope.RootScopeProvider
-import software.amazon.app.platform.scope.coroutine.MainCoroutineDispatcher
-import software.amazon.app.platform.scope.di.kotlinInjectComponent
-import software.amazon.lastmile.kotlin.inject.anvil.AppScope
-import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
 
 /**
  * An implementation of [Renderer] that is specific to Android View based UI. This renderer provides
@@ -84,11 +78,7 @@ public abstract class ViewRenderer<in ModelT : BaseModel> : BaseAndroidViewRende
   }
 
   private fun createView(model: ModelT): View {
-    val rootScopeProvider = activity.application as RootScopeProvider
-    coroutineScope =
-      CoroutineScope(
-        rootScopeProvider.rootScope.kotlinInjectComponent<Component>().dispatcher + Job()
-      )
+    coroutineScope = MainScope()
     return inflate(activity, parent, inflater, model).also { view = it }
   }
 
@@ -201,12 +191,5 @@ public abstract class ViewRenderer<in ModelT : BaseModel> : BaseAndroidViewRende
         .takeWhile { it.id != android.R.id.content }
 
     return parents.none { it is RecyclerView }
-  }
-
-  /** DI component that provides objects from the dependency graph. */
-  @ContributesTo(AppScope::class)
-  public interface Component {
-    /** The coroutine dispatcher using the main thread. */
-    @MainCoroutineDispatcher public val dispatcher: CoroutineDispatcher
   }
 }

--- a/renderer-compose-multiplatform/public/build.gradle
+++ b/renderer-compose-multiplatform/public/build.gradle
@@ -5,7 +5,6 @@ plugins {
 appPlatformBuildSrc {
     enableCompose true
     enableInstrumentedTests true
-    enableKotlinInject true
     enablePublishing true
 }
 
@@ -19,12 +18,16 @@ dependencies {
 
     androidMainApi project(':renderer-android-view:public')
 
+    commonTestImplementation project(':metro:public')
     commonTestImplementation project(':scope:testing')
+    commonTestImplementation libs.metro.runtime
 
+    androidTestImplementation project(':metro:public')
     androidTestImplementation project(':presenter-molecule:impl')
     androidTestImplementation libs.androidx.activity.compose
     androidTestImplementation libs.androidx.test.espresso
     androidTestImplementation libs.compose.ui.test.junit4
     androidTestImplementation libs.compose.ui.test.junit4.android
     androidTestImplementation libs.compose.ui.test.manifest
+    androidTestImplementation libs.metro.runtime
 }

--- a/renderer-compose-multiplatform/public/src/androidInstrumentedTest/kotlin/software/amazon/app/platform/renderer/ComposeAndroidRendererFactoryDeviceTest.kt
+++ b/renderer-compose-multiplatform/public/src/androidInstrumentedTest/kotlin/software/amazon/app/platform/renderer/ComposeAndroidRendererFactoryDeviceTest.kt
@@ -31,6 +31,8 @@ import assertk.assertions.isInstanceOf
 import assertk.assertions.isNull
 import assertk.assertions.isSameInstanceAs
 import assertk.assertions.messageContains
+import dev.zacsweers.metro.Provider
+import dev.zacsweers.metro.provider
 import kotlin.reflect.KClass
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.After
@@ -53,7 +55,7 @@ class ComposeAndroidRendererFactoryDeviceTest {
 
   @Before
   fun prepare() {
-    testApplication.rendererComponent = TestRendererComponent { factory }
+    testApplication.rendererGraph = TestRendererGraph { factory }
 
     activityRule.scenario.onActivity {
       activity = it
@@ -80,7 +82,7 @@ class ComposeAndroidRendererFactoryDeviceTest {
       childAt
     }
 
-    testApplication.rendererComponent = null
+    testApplication.rendererGraph = null
   }
 
   @Test
@@ -420,12 +422,12 @@ class ComposeAndroidRendererFactoryDeviceTest {
     }
   }
 
-  private inner class TestRendererComponent(private val rendererFactory: () -> RendererFactory) :
-    RendererComponent {
-    override val renderers: Map<KClass<out BaseModel>, () -> Renderer<*>> =
+  private inner class TestRendererGraph(private val rendererFactory: () -> RendererFactory) :
+    RendererGraph {
+    override val renderers: Map<KClass<out BaseModel>, Provider<Renderer<*>>> =
       mapOf(
-        ViewModel::class to { TestViewRenderer(rendererFactory()) },
-        ComposeModel::class to { TestComposeRenderer(rendererFactory()) },
+        ViewModel::class to provider { TestViewRenderer(rendererFactory()) },
+        ComposeModel::class to provider { TestComposeRenderer(rendererFactory()) },
       )
     override val modelToRendererMapping: Map<KClass<out BaseModel>, KClass<out Renderer<*>>> =
       mapOf(

--- a/renderer-compose-multiplatform/public/src/androidInstrumentedTest/kotlin/software/amazon/app/platform/renderer/TestApplication.kt
+++ b/renderer-compose-multiplatform/public/src/androidInstrumentedTest/kotlin/software/amazon/app/platform/renderer/TestApplication.kt
@@ -2,31 +2,27 @@ package software.amazon.app.platform.renderer
 
 import android.app.Application
 import androidx.test.platform.app.InstrumentationRegistry
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineName
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import software.amazon.app.platform.scope.RootScopeProvider
 import software.amazon.app.platform.scope.Scope
 import software.amazon.app.platform.scope.coroutine.CoroutineScopeScoped
 import software.amazon.app.platform.scope.coroutine.addCoroutineScopeScoped
-import software.amazon.app.platform.scope.di.addKotlinInjectComponent
+import software.amazon.app.platform.scope.di.metro.addMetroDependencyGraph
 
 class TestApplication : Application(), RootScopeProvider {
 
-  var rendererComponent: RendererComponent? = null
+  var rendererGraph: RendererGraph? = null
 
   override val rootScope: Scope =
     Scope.buildRootScope {
-      addKotlinInjectComponent(Component())
+      addMetroDependencyGraph(Graph())
       addCoroutineScopeScoped(CoroutineScopeScoped(Job() + CoroutineName("test")))
     }
 
-  private inner class Component : ViewRenderer.Component, RendererComponent.Parent {
-    override val dispatcher: CoroutineDispatcher = Dispatchers.Main.immediate
-
-    override fun rendererComponent(factory: RendererFactory): RendererComponent =
-      requireNotNull(rendererComponent)
+  private inner class Graph : RendererGraph.Factory {
+    override fun createRendererGraph(factory: RendererFactory): RendererGraph =
+      requireNotNull(rendererGraph)
   }
 }
 

--- a/renderer-compose-multiplatform/public/src/androidUnitTest/kotlin/software/amazon/app/platform/renderer/ComposeAndroidRendererFactoryTest.kt
+++ b/renderer-compose-multiplatform/public/src/androidUnitTest/kotlin/software/amazon/app/platform/renderer/ComposeAndroidRendererFactoryTest.kt
@@ -9,6 +9,8 @@ import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.isInstanceOf
 import assertk.assertions.messageContains
+import dev.zacsweers.metro.Provider
+import dev.zacsweers.metro.provider
 import kotlin.reflect.KClass
 import kotlin.test.Test
 import kotlinx.coroutines.test.TestScope
@@ -17,7 +19,7 @@ import software.amazon.app.platform.presenter.BaseModel
 import software.amazon.app.platform.scope.RootScopeProvider
 import software.amazon.app.platform.scope.Scope
 import software.amazon.app.platform.scope.buildTestScope
-import software.amazon.app.platform.scope.di.addKotlinInjectComponent
+import software.amazon.app.platform.scope.di.metro.addMetroDependencyGraph
 
 class ComposeAndroidRendererFactoryTest {
 
@@ -53,15 +55,15 @@ class ComposeAndroidRendererFactoryTest {
   private fun TestScope.rootScopeProvider(): RootScopeProvider {
     val scope =
       Scope.buildTestScope(this) {
-        addKotlinInjectComponent(
-          object : RendererComponent.Parent {
-            override fun rendererComponent(factory: RendererFactory): RendererComponent {
-              return object : RendererComponent {
-                override val renderers: Map<KClass<out BaseModel>, () -> Renderer<*>> =
+        addMetroDependencyGraph(
+          object : RendererGraph.Factory {
+            override fun createRendererGraph(factory: RendererFactory): RendererGraph {
+              return object : RendererGraph {
+                override val renderers: Map<KClass<out BaseModel>, Provider<Renderer<*>>> =
                   mapOf(
-                    ComposeModel::class to { TestComposeRenderer() },
-                    AndroidModel::class to { TestAndroidRenderer() },
-                    UnsupportedModel::class to { UnsupportedRenderer() },
+                    ComposeModel::class to provider { TestComposeRenderer() },
+                    AndroidModel::class to provider { TestAndroidRenderer() },
+                    UnsupportedModel::class to provider { UnsupportedRenderer() },
                   )
                 override val modelToRendererMapping:
                   Map<KClass<out BaseModel>, KClass<out Renderer<*>>> =

--- a/renderer-compose-multiplatform/public/src/desktopTest/kotlin/software/amazon/app/platform/renderer/ComposeRendererFactoryTest.kt
+++ b/renderer-compose-multiplatform/public/src/desktopTest/kotlin/software/amazon/app/platform/renderer/ComposeRendererFactoryTest.kt
@@ -6,6 +6,8 @@ import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.isInstanceOf
 import assertk.assertions.messageContains
+import dev.zacsweers.metro.Provider
+import dev.zacsweers.metro.provider
 import kotlin.reflect.KClass
 import kotlin.test.Test
 import kotlinx.coroutines.test.TestScope
@@ -14,7 +16,7 @@ import software.amazon.app.platform.presenter.BaseModel
 import software.amazon.app.platform.scope.RootScopeProvider
 import software.amazon.app.platform.scope.Scope
 import software.amazon.app.platform.scope.buildTestScope
-import software.amazon.app.platform.scope.di.addKotlinInjectComponent
+import software.amazon.app.platform.scope.di.metro.addMetroDependencyGraph
 
 class ComposeRendererFactoryTest {
 
@@ -60,14 +62,14 @@ class ComposeRendererFactoryTest {
   private fun TestScope.rootScopeProvider(): RootScopeProvider {
     val scope =
       Scope.buildTestScope(this) {
-        addKotlinInjectComponent(
-          object : RendererComponent.Parent {
-            override fun rendererComponent(factory: RendererFactory): RendererComponent {
-              return object : RendererComponent {
-                override val renderers: Map<KClass<out BaseModel>, () -> Renderer<*>> =
+        addMetroDependencyGraph(
+          object : RendererGraph.Factory {
+            override fun createRendererGraph(factory: RendererFactory): RendererGraph {
+              return object : RendererGraph {
+                override val renderers: Map<KClass<out BaseModel>, Provider<Renderer<*>>> =
                   mapOf(
-                    ComposeModel::class to { TestComposeRenderer() },
-                    AndroidModel::class to { AndroidRenderer() },
+                    ComposeModel::class to provider { TestComposeRenderer() },
+                    AndroidModel::class to provider { AndroidRenderer() },
                   )
                 override val modelToRendererMapping:
                   Map<KClass<out BaseModel>, KClass<out Renderer<*>>> =


### PR DESCRIPTION
Use the `MainScope()` provided by the coroutine library as UI scope instead of creating our own scope. The `MainScope` is the better default, available in KMP by default and removes the dependency on kotlin-inject.

