### PR TITLE
`@ContributesRobot` code generator

### DIFF
--- a/metro-extensions/contribute/impl-code-generators/src/main/kotlin/software/amazon/app/platform/metro/KotlinInjectExtensionSymbolProcessorProvider.kt
+++ b/metro-extensions/contribute/impl-code-generators/src/main/kotlin/software/amazon/app/platform/metro/KotlinInjectExtensionSymbolProcessorProvider.kt
@@ -6,6 +6,7 @@ import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.processing.SymbolProcessorProvider
 import software.amazon.app.platform.ksp.CompositeSymbolProcessor
 import software.amazon.app.platform.metro.processor.ContributesRendererProcessor
+import software.amazon.app.platform.metro.processor.ContributesRobotProcessor
 
 /** Entry point for KSP to pick up our [SymbolProcessor]. */
 @AutoService(SymbolProcessorProvider::class)
@@ -16,7 +17,11 @@ public class KotlinInjectExtensionSymbolProcessorProvider : SymbolProcessorProvi
       ContributesRendererProcessor(
         codeGenerator = environment.codeGenerator,
         logger = environment.logger,
-      )
+      ),
+      ContributesRobotProcessor(
+        codeGenerator = environment.codeGenerator,
+        logger = environment.logger,
+      ),
     )
   }
 }

--- a/metro-extensions/contribute/impl-code-generators/src/main/kotlin/software/amazon/app/platform/metro/MetroContextAware.kt
+++ b/metro-extensions/contribute/impl-code-generators/src/main/kotlin/software/amazon/app/platform/metro/MetroContextAware.kt
@@ -1,5 +1,7 @@
 package software.amazon.app.platform.metro
 
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSType
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.Scope
 import software.amazon.app.platform.ksp.ContextAware
@@ -10,4 +12,16 @@ internal interface MetroContextAware : ContextAware {
 
   private val scopeFqName
     get() = Scope::class.requireQualifiedName()
+
+  fun KSAnnotation.isMetroScopeAnnotation(): Boolean {
+    return annotationType.resolve().isMetroScopeAnnotation()
+  }
+
+  private fun KSType.isMetroScopeAnnotation(): Boolean {
+    return declaration.annotations.any {
+      // Don't use requireQualifiedName(), because @ContributingAnnotation might not be
+      // on the compile classpath.
+      it.annotationType.resolve().declaration.qualifiedName?.asString() == scopeFqName
+    }
+  }
 }

--- a/metro-extensions/contribute/impl-code-generators/src/main/kotlin/software/amazon/app/platform/metro/processor/ContributesRobotProcessor.kt
+++ b/metro-extensions/contribute/impl-code-generators/src/main/kotlin/software/amazon/app/platform/metro/processor/ContributesRobotProcessor.kt
@@ -1,0 +1,168 @@
+package software.amazon.app.platform.metro.processor
+
+import com.google.devtools.ksp.KspExperimental
+import com.google.devtools.ksp.getAllSuperTypes
+import com.google.devtools.ksp.isAnnotationPresent
+import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.asClassName
+import com.squareup.kotlinpoet.ksp.addOriginatingKSFile
+import com.squareup.kotlinpoet.ksp.toClassName
+import com.squareup.kotlinpoet.ksp.writeTo
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.IntoMap
+import dev.zacsweers.metro.Provider
+import dev.zacsweers.metro.Provides
+import software.amazon.app.platform.inject.robot.ContributesRobot
+import software.amazon.app.platform.ksp.decapitalize
+import software.amazon.app.platform.metro.METRO_LOOKUP_PACKAGE
+import software.amazon.app.platform.metro.MetroContextAware
+import software.amazon.app.platform.renderer.metro.RobotKey
+
+/**
+ * Generates the necessary code in order to support [ContributesRobot].
+ *
+ * If you use `@ContributesRobot(AbcScope::class)`, then this processor will generate a graph
+ * interface, which gets contributed to this scope.
+ *
+ * ```
+ * package app.platform.inject.metro.software.amazon.test
+ *
+ * @ContributesTo(scope = AbcScope::class)
+ * public interface AbcRobotGraph {
+ *     @Provide
+ *     fun provideAbcRobot(): AbcRobot = AbcRobot()
+ *
+ *     @Provides
+ *     @IntoMap
+ *     @RobotKey(AbcRobot::class)
+ *     fun provideAbcRobotIntoMap(
+ *         robot: Provider<AbcRobot>,
+ *     ): Robot = robot()
+ * }
+ * ```
+ */
+@OptIn(KspExperimental::class)
+internal class ContributesRobotProcessor(
+  private val codeGenerator: CodeGenerator,
+  override val logger: KSPLogger,
+) : SymbolProcessor, MetroContextAware {
+
+  private val robotClassName = ClassName("software.amazon.app.platform.robot", "Robot")
+  private val robotFqName = robotClassName.canonicalName
+
+  private val robotKey = RobotKey::class.asClassName()
+
+  override fun process(resolver: Resolver): List<KSAnnotated> {
+    resolver
+      .getSymbolsWithAnnotation(ContributesRobot::class)
+      .filterIsInstance<KSClassDeclaration>()
+      .onEach {
+        checkIsPublic(it)
+        checkHasInjectAnnotation(it)
+        checkNotSingleton(it)
+        checkSuperType(it)
+        checkAppScope(it)
+      }
+      .forEach { generateGraph(it) }
+
+    return emptyList()
+  }
+
+  private fun generateGraph(clazz: KSClassDeclaration) {
+    val packageName = "${METRO_LOOKUP_PACKAGE}.${clazz.packageName.asString()}"
+    val graphClassName = ClassName(packageName, "${clazz.innerClassNames()}Graph")
+
+    val fileSpec =
+      FileSpec.builder(graphClassName)
+        .addType(
+          TypeSpec.interfaceBuilder(graphClassName)
+            .addOriginatingKSFile(clazz.requireContainingFile())
+            .addAnnotation(
+              AnnotationSpec.builder(ContributesTo::class)
+                .addMember("%T::class", clazz.scope().type.toClassName())
+                .build()
+            )
+            .apply {
+              if (!clazz.isAnnotationPresent(Inject::class)) {
+                addFunction(
+                  FunSpec.builder("provide${clazz.innerClassNames()}")
+                    .addAnnotation(Provides::class)
+                    .returns(clazz.toClassName())
+                    .addStatement("return %T()", clazz.toClassName())
+                    .build()
+                )
+              }
+            }
+            .addFunction(
+              FunSpec.builder("provide${clazz.innerClassNames()}IntoMap")
+                .addAnnotation(Provides::class)
+                .addAnnotation(IntoMap::class)
+                .addAnnotation(
+                  AnnotationSpec.builder(robotKey)
+                    .addMember("%T::class", clazz.toClassName())
+                    .build()
+                )
+                .addParameter(
+                  name = "robot",
+                  type = Provider::class.asClassName().parameterizedBy(clazz.toClassName()),
+                )
+                .returns(robotClassName)
+                .addStatement("return robot()")
+                .build()
+            )
+            .addProperty(name = clazz.innerClassNames().decapitalize(), type = clazz.toClassName())
+            .build()
+        )
+        .build()
+
+    fileSpec.writeTo(codeGenerator, aggregating = false)
+  }
+
+  private fun checkHasInjectAnnotation(clazz: KSClassDeclaration) {
+    if (clazz.primaryConstructor?.parameters?.isNotEmpty() == true) {
+      check(clazz.annotations.any { it.isAnnotation(injectFqName) }, clazz) {
+        "${clazz.simpleName.asString()} must be annotated with @Inject when " +
+          "injecting arguments into a robot."
+      }
+    }
+  }
+
+  private fun checkNotSingleton(clazz: KSClassDeclaration) {
+    check(clazz.annotations.none { it.isMetroScopeAnnotation() }, clazz) {
+      "It's not allowed allowed for a robot to be a singleton, because the lifetime " +
+        "of the robot is scoped to the robot() factory function. Remove the @" +
+        clazz.annotations.first { it.isMetroScopeAnnotation() }.shortName.asString() +
+        " annotation."
+    }
+  }
+
+  private fun checkSuperType(clazz: KSClassDeclaration) {
+    val extendsRobot =
+      clazz.getAllSuperTypes().any { it.declaration.requireQualifiedName() == robotFqName }
+
+    check(extendsRobot, clazz) {
+      "In order to use @ContributesRobot, ${clazz.simpleName.asString()} must " +
+        "implement $robotFqName."
+    }
+  }
+
+  private fun checkAppScope(clazz: KSClassDeclaration) {
+    val scope = clazz.scope().type.declaration.requireQualifiedName()
+    check(scope == AppScope::class.requireQualifiedName(), clazz) {
+      "Robots can only be contributed to the AppScope for now. Scope $scope is unsupported."
+    }
+  }
+}

--- a/metro-extensions/contribute/impl-code-generators/src/test/kotlin/software/amazon/app/platform/inject/metro/CommonSourceCode.kt
+++ b/metro-extensions/contribute/impl-code-generators/src/test/kotlin/software/amazon/app/platform/inject/metro/CommonSourceCode.kt
@@ -5,6 +5,7 @@ package software.amazon.app.platform.inject.metro
 import com.tschuchort.compiletesting.JvmCompilationResult
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import software.amazon.test.TestRendererGraph
+import software.amazon.test.TestRobotGraph
 
 internal val JvmCompilationResult.graphInterface: Class<*>
   get() = classLoader.loadClass("software.amazon.test.GraphInterface")
@@ -16,4 +17,13 @@ internal fun Class<*>.newTestRendererGraph(): TestRendererGraph {
     .declaredMethods
     .single { it.name == "create" }
     .invoke(companionObject) as TestRendererGraph
+}
+
+internal fun Class<*>.newTestRobotGraph(): TestRobotGraph {
+  val companionObject = fields.single().get(null)
+  return classes
+    .single { it.simpleName == "Companion" }
+    .declaredMethods
+    .single { it.name == "create" }
+    .invoke(companionObject) as TestRobotGraph
 }

--- a/metro-extensions/contribute/impl-code-generators/src/test/kotlin/software/amazon/app/platform/inject/metro/processor/ContributesRobotGeneratorTest.kt
+++ b/metro-extensions/contribute/impl-code-generators/src/test/kotlin/software/amazon/app/platform/inject/metro/processor/ContributesRobotGeneratorTest.kt
@@ -1,0 +1,242 @@
+@file:OptIn(ExperimentalCompilerApi::class)
+
+package software.amazon.app.platform.inject.metro.processor
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.containsOnly
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import com.tschuchort.compiletesting.JvmCompilationResult
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.IntoMap
+import dev.zacsweers.metro.Provider
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.SingleIn
+import org.intellij.lang.annotations.Language
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.jupiter.api.Test
+import software.amazon.app.platform.inject.metro.compile
+import software.amazon.app.platform.inject.metro.graphInterface
+import software.amazon.app.platform.inject.metro.newTestRobotGraph
+import software.amazon.app.platform.ksp.capitalize
+import software.amazon.app.platform.ksp.isAnnotatedWith
+import software.amazon.app.platform.metro.METRO_LOOKUP_PACKAGE
+import software.amazon.app.platform.renderer.metro.RobotKey
+import software.amazon.app.platform.robot.Robot
+
+class ContributesRobotGeneratorTest {
+
+  @Test
+  fun `a graph interface is generated without @Inject constructor`() {
+    compile(
+      """
+      package software.amazon.test
+
+      import software.amazon.app.platform.inject.robot.ContributesRobot
+      import software.amazon.app.platform.robot.Robot
+      import dev.zacsweers.metro.AppScope
+
+      @ContributesRobot(AppScope::class)
+      class TestRobot : Robot
+      """,
+      graphInterfaceSource,
+    ) {
+      val robotGraph = testRobot.graph
+
+      assertThat(robotGraph.getAnnotation(ContributesTo::class.java).scope)
+        .isEqualTo(AppScope::class)
+
+      with(robotGraph.declaredMethods.single { it.name == "provideTestRobot" }) {
+        assertThat(parameters).isEmpty()
+        assertThat(returnType).isEqualTo(testRobot)
+        assertThat(this).isAnnotatedWith(Provides::class)
+        assertThat(getAnnotation(SingleIn::class.java)).isNull()
+      }
+
+      with(robotGraph.declaredMethods.single { it.name == "provideTestRobotIntoMap" }) {
+        assertThat(parameters.single().type).isEqualTo(Provider::class.java)
+        assertThat(returnType).isEqualTo(Robot::class.java)
+        assertThat(this).isAnnotatedWith(Provides::class)
+        assertThat(this).isAnnotatedWith(IntoMap::class)
+        assertThat(getAnnotation(RobotKey::class.java).value.java).isEqualTo(testRobot)
+      }
+
+      assertThat(graphInterface.newTestRobotGraph().robots.keys).containsOnly(testRobot.kotlin)
+    }
+  }
+
+  @Test
+  fun `a graph interface is generated with @Inject constructor`() {
+    compile(
+      """
+      package software.amazon.test
+
+      import software.amazon.app.platform.inject.robot.ContributesRobot
+      import software.amazon.app.platform.robot.Robot
+      import dev.zacsweers.metro.AppScope
+      import dev.zacsweers.metro.Inject
+
+      @Inject
+      @ContributesRobot(AppScope::class)
+      class TestRobot : Robot
+      """,
+      graphInterfaceSource,
+    ) {
+      val robotGraph = testRobot.graph
+
+      assertThat(robotGraph.getAnnotation(ContributesTo::class.java).scope)
+        .isEqualTo(AppScope::class)
+
+      assertThat(robotGraph.declaredMethods.singleOrNull { it.name == "provideTestRobot" }).isNull()
+
+      with(robotGraph.declaredMethods.single { it.name == "provideTestRobotIntoMap" }) {
+        assertThat(parameters.single().type).isEqualTo(Provider::class.java)
+        assertThat(returnType).isEqualTo(Robot::class.java)
+        assertThat(this).isAnnotatedWith(Provides::class)
+        assertThat(this).isAnnotatedWith(IntoMap::class)
+        assertThat(getAnnotation(RobotKey::class.java).value.java).isEqualTo(testRobot)
+      }
+
+      assertThat(graphInterface.newTestRobotGraph().robots.keys).containsOnly(testRobot.kotlin)
+    }
+  }
+
+  @Test
+  fun `a graph interface is generated without direct super type`() {
+    compile(
+      """
+      package software.amazon.test
+
+      import software.amazon.app.platform.inject.robot.ContributesRobot
+      import software.amazon.app.platform.robot.Robot
+      import dev.zacsweers.metro.AppScope
+
+      interface BaseRobot1 : Robot
+      abstract class BaseRobot2 : BaseRobot1
+
+      @ContributesRobot(AppScope::class)
+      class TestRobot : BaseRobot2()
+      """
+    ) {
+      assertThat(testRobot.graph).isNotNull()
+    }
+  }
+
+  @Test
+  fun `the robot class must be a super type`() {
+    compile(
+      """
+      package software.amazon.test
+
+      import software.amazon.app.platform.inject.robot.ContributesRobot
+      import software.amazon.app.platform.robot.Robot
+      import dev.zacsweers.metro.AppScope
+
+      interface BaseRobot1
+      abstract class BaseRobot2 : BaseRobot1
+
+      @ContributesRobot(AppScope::class)
+      class TestRobot : BaseRobot2()
+      """,
+      exitCode = COMPILATION_ERROR,
+    ) {
+      assertThat(messages)
+        .contains(
+          "In order to use @ContributesRobot, TestRobot must implement " +
+            "software.amazon.app.platform.robot.Robot."
+        )
+    }
+  }
+
+  @Test
+  fun `a Robot must not be a singleton`() {
+    compile(
+      """
+      package software.amazon.test
+
+      import software.amazon.app.platform.inject.robot.ContributesRobot
+      import software.amazon.app.platform.robot.Robot
+      import dev.zacsweers.metro.AppScope
+      import dev.zacsweers.metro.Inject
+      import dev.zacsweers.metro.SingleIn
+
+      @Inject
+      @SingleIn(AppScope::class)
+      @ContributesRobot(AppScope::class)
+      class TestRobot : Robot
+      """,
+      exitCode = COMPILATION_ERROR,
+    ) {
+      assertThat(messages)
+        .contains(
+          "It's not allowed allowed for a robot to be a singleton, because " +
+            "the lifetime of the robot is scoped to the robot() factory function. " +
+            "Remove the @SingleIn annotation."
+        )
+    }
+  }
+
+  @Test
+  fun `only the app scope is supported for now`() {
+    compile(
+      """
+      package software.amazon.test
+
+      import software.amazon.app.platform.inject.robot.ContributesRobot
+      import software.amazon.app.platform.robot.Robot
+      import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+
+      @ContributesRobot(String::class)
+      class TestRobot : Robot
+              """,
+      exitCode = COMPILATION_ERROR,
+    ) {
+      assertThat(messages)
+        .contains(
+          "Robots can only be contributed to the AppScope for now. " +
+            "Scope kotlin.String is unsupported."
+        )
+    }
+  }
+
+  @Language("kotlin")
+  private val graphInterfaceSource =
+    """
+        package software.amazon.test
+
+        import dev.zacsweers.metro.AppScope
+        import dev.zacsweers.metro.createGraph
+        import dev.zacsweers.metro.DependencyGraph
+        import dev.zacsweers.metro.SingleIn
+        import software.amazon.app.platform.renderer.RendererGraph
+        import software.amazon.test.TestRendererGraph
+
+        @DependencyGraph(AppScope::class, excludes = [RendererGraph::class])
+        @SingleIn(AppScope::class)
+        interface GraphInterface : TestRobotGraph {
+            companion object {
+                fun create(): GraphInterface = createGraph<GraphInterface>()
+            }
+        }
+    """
+
+  private val JvmCompilationResult.testRobot: Class<*>
+    get() = classLoader.loadClass("software.amazon.test.TestRobot")
+
+  private val Class<*>.graph: Class<*>
+    get() =
+      classLoader.loadClass(
+        "$METRO_LOOKUP_PACKAGE.$packageName." +
+          canonicalName.substringAfter(packageName).substring(1).split(".").joinToString(
+            separator = ""
+          ) {
+            it.capitalize()
+          } +
+          "Graph"
+      )
+}

--- a/metro-extensions/contribute/impl-code-generators/src/test/kotlin/software/amazon/test/TestRobotGraph.kt
+++ b/metro-extensions/contribute/impl-code-generators/src/test/kotlin/software/amazon/test/TestRobotGraph.kt
@@ -1,0 +1,9 @@
+package software.amazon.test
+
+import dev.zacsweers.metro.Provider
+import kotlin.reflect.KClass
+import software.amazon.app.platform.robot.Robot
+
+interface TestRobotGraph {
+  val robots: Map<KClass<*>, Provider<Robot>>
+}

--- a/metro/public/api/android/public.api
+++ b/metro/public/api/android/public.api
@@ -2,6 +2,10 @@ public abstract interface annotation class software/amazon/app/platform/renderer
 	public abstract fun value ()Ljava/lang/Class;
 }
 
+public abstract interface annotation class software/amazon/app/platform/renderer/metro/RobotKey : java/lang/annotation/Annotation {
+	public abstract fun value ()Ljava/lang/Class;
+}
+
 public final class software/amazon/app/platform/scope/di/metro/MetroServiceKt {
 	public static final field METRO_DEPENDENCY_GRAPH_KEY Ljava/lang/String;
 	public static final fun addMetroDependencyGraph (Lsoftware/amazon/app/platform/scope/Scope$Builder;Ljava/lang/Object;)V

--- a/metro/public/api/desktop/public.api
+++ b/metro/public/api/desktop/public.api
@@ -2,6 +2,10 @@ public abstract interface annotation class software/amazon/app/platform/renderer
 	public abstract fun value ()Ljava/lang/Class;
 }
 
+public abstract interface annotation class software/amazon/app/platform/renderer/metro/RobotKey : java/lang/annotation/Annotation {
+	public abstract fun value ()Ljava/lang/Class;
+}
+
 public final class software/amazon/app/platform/scope/di/metro/MetroServiceKt {
 	public static final field METRO_DEPENDENCY_GRAPH_KEY Ljava/lang/String;
 	public static final fun addMetroDependencyGraph (Lsoftware/amazon/app/platform/scope/Scope$Builder;Ljava/lang/Object;)V

--- a/metro/public/src/commonMain/kotlin/software/amazon/app/platform/renderer/metro/RobotKey.kt
+++ b/metro/public/src/commonMain/kotlin/software/amazon/app/platform/renderer/metro/RobotKey.kt
@@ -1,0 +1,13 @@
+package software.amazon.app.platform.renderer.metro
+
+import dev.zacsweers.metro.MapKey
+import kotlin.reflect.KClass
+
+/**
+ * DO NOT USE DIRECTLY.
+ *
+ * This is a multibindings key used in Metro for identifying robots by their type. This key is used
+ * by our custom code generator for `@ContributesRobot`. [value] refers to the concrete `Robot`
+ * type.
+ */
+@MapKey public annotation class RobotKey(val value: KClass<*>)


### PR DESCRIPTION
Add a new KSP code generator that generates the code for `@ContributesRobot` using Metro. The implementation is almost equivalent to the kotlin-inject implementation, except for that it's using Metro APIs. The big difference is that kotlin-inject implements map-multibindings by returning a `Pair<Abc, Def>` whereas Metro uses a `@ClassKey` annotation similar to Dagger 2. Therefore, we had to introduce the `@RobotKey` annotation specifically for Metro.

See #115