### PR TITLE
Robot bindings for Metro

### DIFF
--- a/robot-compose-multiplatform/public/build.gradle
+++ b/robot-compose-multiplatform/public/build.gradle
@@ -4,7 +4,6 @@ plugins {
 
 appPlatformBuildSrc {
     enableCompose true
-    enableKotlinInject true
     enablePublishing true
 }
 
@@ -15,7 +14,9 @@ dependencies {
 
     commonMainImplementation project(':robot-internal:public')
 
+    commonTestApi project(':metro:public')
     commonTestApi project(':scope:testing')
+    commonTestApi libs.metro.runtime
 
     desktopTestImplementation compose.material
     iosTestImplementation compose.material

--- a/robot-compose-multiplatform/public/src/appleAndDesktopTest/kotlin/software/amazon/app/platform/robot/ComposeRobotTest.kt
+++ b/robot-compose-multiplatform/public/src/appleAndDesktopTest/kotlin/software/amazon/app/platform/robot/ComposeRobotTest.kt
@@ -14,10 +14,12 @@ import assertk.assertThat
 import assertk.assertions.isFalse
 import assertk.assertions.isTrue
 import assertk.assertions.messageContains
+import dev.zacsweers.metro.Provider
+import dev.zacsweers.metro.provider
 import kotlin.reflect.KClass
 import kotlin.test.Test
 import software.amazon.app.platform.scope.Scope
-import software.amazon.app.platform.scope.di.addKotlinInjectComponent
+import software.amazon.app.platform.scope.di.metro.addMetroDependencyGraph
 
 // Note that this class has to be duplicated and cannot be moved into commonTest, because Android
 // unit tests don't have access to `runComposeUiTest`.
@@ -61,7 +63,7 @@ class ComposeRobotTest {
   }
 
   private fun rootScope(vararg robots: Robot): Scope =
-    Scope.buildRootScope { addKotlinInjectComponent(Component(*robots)) }
+    Scope.buildRootScope { addMetroDependencyGraph(Component(*robots)) }
 
   private fun ComposeUiTest.interactionProvider(): ComposeInteractionsProvider {
     val interactionsProvider = this
@@ -71,9 +73,9 @@ class ComposeRobotTest {
     }
   }
 
-  private class Component(vararg robots: Robot) : RobotComponent {
-    override val robots: Map<KClass<out Robot>, () -> Robot> =
-      robots.map { robot -> robot::class to { robot } }.toMap()
+  private class Component(vararg robots: Robot) : RobotGraph {
+    override val robots: Map<KClass<*>, Provider<Robot>> =
+      robots.associate { robot -> robot::class to provider { robot } }
   }
 
   private class TestRobot : ComposeRobot() {

--- a/robot/public/api/android/public.api
+++ b/robot/public/api/android/public.api
@@ -26,6 +26,17 @@ public abstract interface class software/amazon/app/platform/robot/RobotComponen
 	public abstract fun getRobots ()Ljava/util/Map;
 }
 
+public abstract interface class software/amazon/app/platform/robot/RobotGraph {
+	public abstract fun getRobots ()Ljava/util/Map;
+}
+
+public abstract interface class software/amazon/app/platform/robot/RobotGraph$$$MetroContributionToAppScope : software/amazon/app/platform/robot/RobotGraph {
+}
+
+public final class software/amazon/app/platform/robot/RobotKt {
+	public static final fun getAllRobots (Lsoftware/amazon/app/platform/scope/Scope;)Ljava/util/Map;
+}
+
 public abstract interface class software/amazon/app/platform/robot/RootMatcherProvider {
 	public abstract fun getRootMatcher ()Lorg/hamcrest/Matcher;
 }

--- a/robot/public/api/desktop/public.api
+++ b/robot/public/api/desktop/public.api
@@ -10,6 +10,17 @@ public abstract interface class software/amazon/app/platform/robot/RobotComponen
 	public abstract fun getRobots ()Ljava/util/Map;
 }
 
+public abstract interface class software/amazon/app/platform/robot/RobotGraph {
+	public abstract fun getRobots ()Ljava/util/Map;
+}
+
+public abstract interface class software/amazon/app/platform/robot/RobotGraph$$$MetroContributionToAppScope : software/amazon/app/platform/robot/RobotGraph {
+}
+
+public final class software/amazon/app/platform/robot/RobotKt {
+	public static final fun getAllRobots (Lsoftware/amazon/app/platform/scope/Scope;)Ljava/util/Map;
+}
+
 public final class software/amazon/app/platform/robot/WaiterKt {
 	public static final fun waitFor-vLdBGDU (Ljava/lang/String;JJLkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public static synthetic fun waitFor-vLdBGDU$default (Ljava/lang/String;JJLkotlin/jvm/functions/Function0;ILjava/lang/Object;)Ljava/lang/Object;

--- a/robot/public/build.gradle
+++ b/robot/public/build.gradle
@@ -4,6 +4,7 @@ plugins {
 
 appPlatformBuildSrc {
     enableKotlinInject true
+    enableMetro true
     enablePublishing true
 }
 

--- a/robot/public/src/commonMain/kotlin/software/amazon/app/platform/robot/RobotGraph.kt
+++ b/robot/public/src/commonMain/kotlin/software/amazon/app/platform/robot/RobotGraph.kt
@@ -1,0 +1,13 @@
+package software.amazon.app.platform.robot
+
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Provider
+import kotlin.reflect.KClass
+
+/** Graph that provides all contributed [Robot] instances from the Metro dependency graph. */
+@ContributesTo(AppScope::class)
+public interface RobotGraph {
+  /** All [Robot]s provided in the Metro dependency graph. */
+  public val robots: Map<KClass<*>, Provider<Robot>>
+}

--- a/robot/public/src/commonTest/kotlin/software/amazon/app/platform/robot/RobotTest.kt
+++ b/robot/public/src/commonTest/kotlin/software/amazon/app/platform/robot/RobotTest.kt
@@ -3,8 +3,11 @@ package software.amazon.app.platform.robot
 import assertk.assertThat
 import assertk.assertions.contains
 import assertk.assertions.isFalse
+import assertk.assertions.isNotNull
 import assertk.assertions.isNotSameInstanceAs
 import assertk.assertions.isTrue
+import dev.zacsweers.metro.Provider
+import dev.zacsweers.metro.provider
 import kotlin.reflect.KClass
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
@@ -12,15 +15,19 @@ import software.amazon.app.platform.internal.Platform
 import software.amazon.app.platform.internal.platform
 import software.amazon.app.platform.scope.Scope
 import software.amazon.app.platform.scope.di.addKotlinInjectComponent
+import software.amazon.app.platform.scope.di.metro.addMetroDependencyGraph
 
 class RobotTest {
 
   @Test
   fun `if no robot can be found in the component then a proper error is thrown`() {
-    val exception = assertFailsWith<IllegalStateException> { robot<TestRobot>(rootScope()) {} }
+    val exception =
+      assertFailsWith<IllegalStateException> {
+        robot<KiTestRobot>(rootScope(kiRobot = null, metroRobot = null)) {}
+      }
 
     val message =
-      exception.message?.replace("RobotTest\$TestRobot", "RobotTest.TestRobot").toString()
+      exception.message?.replace("RobotTest\$KiTestRobot", "RobotTest.KiTestRobot").toString()
 
     when (platform) {
       Platform.JVM,
@@ -28,11 +35,11 @@ class RobotTest {
         assertThat(message)
           .contains(
             "Could not find Robot of type class software.amazon.app.platform." +
-              "robot.RobotTest.TestRobot"
+              "robot.RobotTest.KiTestRobot"
           )
       }
       Platform.Web -> {
-        assertThat(message).contains("Could not find Robot of type class TestRobot")
+        assertThat(message).contains("Could not find Robot of type class KiTestRobot")
       }
     }
     assertThat(message).contains("Did you forget to add the @ContributesRobot annotation?")
@@ -40,10 +47,10 @@ class RobotTest {
 
   @Test
   fun `the close function is called after the lambda is invoked`() {
-    val rootScope = rootScope(TestRobot())
+    val rootScope = rootScope(KiTestRobot())
 
-    lateinit var robot: TestRobot
-    robot<TestRobot>(rootScope) {
+    lateinit var robot: KiTestRobot
+    robot<KiTestRobot>(rootScope) {
       robot = this
       assertThat(closeCalled).isFalse()
     }
@@ -58,37 +65,99 @@ class RobotTest {
         addKotlinInjectComponent(
           object : RobotComponent {
             override val robots: Map<KClass<out Robot>, () -> Robot> =
-              mapOf(TestRobot::class to { TestRobot() })
+              mapOf(KiTestRobot::class to { KiTestRobot() })
           }
         )
       }
 
-    lateinit var robot1: TestRobot
-    lateinit var robot2: TestRobot
+    lateinit var robot1: KiTestRobot
+    lateinit var robot2: KiTestRobot
 
-    robot<TestRobot>(rootScope) { robot1 = this }
-    robot<TestRobot>(rootScope) { robot2 = this }
+    robot<KiTestRobot>(rootScope) { robot1 = this }
+    robot<KiTestRobot>(rootScope) { robot2 = this }
 
     assertThat(robot1).isNotSameInstanceAs(robot2)
 
-    robot<TestRobot>(rootScope) {
+    robot<KiTestRobot>(rootScope) {
       val robot1Inner = this
-      robot<TestRobot>(rootScope) {
+      robot<KiTestRobot>(rootScope) {
         val robot2Inner = this
         assertThat(robot1Inner).isNotSameInstanceAs(robot2Inner)
       }
     }
   }
 
-  private fun rootScope(vararg robots: Robot): Scope =
-    Scope.buildRootScope { addKotlinInjectComponent(Component(*robots)) }
+  @Test
+  fun `a robot is provided for kotlin-inject alone`() {
+    val rootScope = rootScope(kiRobot = KiTestRobot(), metroRobot = null)
+
+    var kiRobot: KiTestRobot? = null
+    robot<KiTestRobot>(rootScope) { kiRobot = this }
+
+    assertFailsWith<Exception> { robot<MetroTestRobot>(rootScope) {} }
+
+    assertThat(kiRobot).isNotNull()
+  }
+
+  @Test
+  fun `a robot is provided for metro alone`() {
+    val rootScope = rootScope(kiRobot = null, metroRobot = MetroTestRobot())
+
+    assertFailsWith<Exception> { robot<KiTestRobot>(rootScope) {} }
+
+    var metroRobot: MetroTestRobot? = null
+    robot<MetroTestRobot>(rootScope) { metroRobot = this }
+
+    assertThat(metroRobot).isNotNull()
+  }
+
+  @Test
+  fun `a robot is provided for kotlin-inject and metro simultaneously`() {
+    val rootScope = rootScope(kiRobot = KiTestRobot(), metroRobot = MetroTestRobot())
+
+    var kiRobot: KiTestRobot? = null
+    robot<KiTestRobot>(rootScope) { kiRobot = this }
+
+    var metroRobot: MetroTestRobot? = null
+    robot<MetroTestRobot>(rootScope) { metroRobot = this }
+
+    assertThat(kiRobot).isNotNull()
+    assertThat(metroRobot).isNotNull()
+  }
+
+  private fun rootScope(
+    kiRobot: Robot? = KiTestRobot(),
+    metroRobot: Robot? = MetroTestRobot(),
+  ): Scope =
+    Scope.buildRootScope {
+      if (kiRobot != null) {
+        addKotlinInjectComponent(Component(kiRobot))
+      }
+      if (metroRobot != null) {
+        addMetroDependencyGraph(Graph(metroRobot))
+      }
+    }
 
   private class Component(vararg robots: Robot) : RobotComponent {
     override val robots: Map<KClass<out Robot>, () -> Robot> =
       robots.associate { robot -> robot::class to { robot } }
   }
 
-  private class TestRobot : Robot {
+  private class Graph(vararg robots: Robot) : RobotGraph {
+    override val robots: Map<KClass<*>, Provider<Robot>> =
+      robots.associate { robot -> robot::class to provider { robot } }
+  }
+
+  private class KiTestRobot : Robot {
+    var closeCalled = false
+      private set
+
+    override fun close() {
+      closeCalled = true
+    }
+  }
+
+  private class MetroTestRobot : Robot {
     var closeCalled = false
       private set
 


### PR DESCRIPTION
Create a `Robot` dependency graph for Metro and combine it with the `Robot` component from kotlin-inject. This allows for an easier migration from kotlin-inject to Metro and eventually mixing both dependency injection frameworks if needed.

See #119

