### PR TITLE
Introduce `@ContributesScoped` for Metro

### DIFF
--- a/metro-extensions/contribute/impl-code-generators/src/main/kotlin/software/amazon/app/platform/metro/MetroExtensionSymbolProcessorProvider.kt
+++ b/metro-extensions/contribute/impl-code-generators/src/main/kotlin/software/amazon/app/platform/metro/MetroExtensionSymbolProcessorProvider.kt
@@ -7,11 +7,12 @@ import com.google.devtools.ksp.processing.SymbolProcessorProvider
 import software.amazon.app.platform.ksp.CompositeSymbolProcessor
 import software.amazon.app.platform.metro.processor.ContributesRendererProcessor
 import software.amazon.app.platform.metro.processor.ContributesRobotProcessor
+import software.amazon.app.platform.metro.processor.ContributesScopedProcessor
 
 /** Entry point for KSP to pick up our [SymbolProcessor]. */
 @AutoService(SymbolProcessorProvider::class)
 @Suppress("unused")
-public class KotlinInjectExtensionSymbolProcessorProvider : SymbolProcessorProvider {
+public class MetroExtensionSymbolProcessorProvider : SymbolProcessorProvider {
   override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
     return CompositeSymbolProcessor(
       ContributesRendererProcessor(
@@ -19,6 +20,10 @@ public class KotlinInjectExtensionSymbolProcessorProvider : SymbolProcessorProvi
         logger = environment.logger,
       ),
       ContributesRobotProcessor(
+        codeGenerator = environment.codeGenerator,
+        logger = environment.logger,
+      ),
+      ContributesScopedProcessor(
         codeGenerator = environment.codeGenerator,
         logger = environment.logger,
       ),

--- a/metro-extensions/contribute/impl-code-generators/src/main/kotlin/software/amazon/app/platform/metro/processor/ContributesScopedProcessor.kt
+++ b/metro-extensions/contribute/impl-code-generators/src/main/kotlin/software/amazon/app/platform/metro/processor/ContributesScopedProcessor.kt
@@ -1,0 +1,160 @@
+package software.amazon.app.platform.metro.processor
+
+import com.google.devtools.ksp.KspExperimental
+import com.google.devtools.ksp.getAllSuperTypes
+import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.ksp.addOriginatingKSFile
+import com.squareup.kotlinpoet.ksp.toClassName
+import com.squareup.kotlinpoet.ksp.writeTo
+import dev.zacsweers.metro.Binds
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.ForScope
+import dev.zacsweers.metro.IntoSet
+import software.amazon.app.platform.inject.metro.ContributesScoped
+import software.amazon.app.platform.metro.METRO_LOOKUP_PACKAGE
+import software.amazon.app.platform.metro.MetroContextAware
+
+/**
+ * Generates the necessary code in order to support [ContributesScoped].
+ *
+ * ```
+ * package app.platform.inject.metro.software.amazon.test
+ *
+ * @ContributesTo(scope = AbcScope::class)
+ * public interface TestClassGraph {
+ *
+ *   @Binds
+ *   val TestClass.bindSuperType: SuperType
+ *
+ *   @Binds @IntoSet @ForScope(UserScope::class)
+ *   val TestClass.bindScoped: Scoped
+ * }
+ * ```
+ */
+@OptIn(KspExperimental::class)
+internal class ContributesScopedProcessor(
+  private val codeGenerator: CodeGenerator,
+  override val logger: KSPLogger,
+) : SymbolProcessor, MetroContextAware {
+
+  override fun process(resolver: Resolver): List<KSAnnotated> {
+    resolver
+      .getSymbolsWithAnnotation(ContributesScoped::class)
+      .filterIsInstance<KSClassDeclaration>()
+      .onEach {
+        checkIsPublic(it)
+        checkHasInjectAnnotation(it)
+        checkImplementsScoped(it)
+        checkSuperType(it)
+      }
+      .forEach { generateGraph(it) }
+
+    resolver
+      .getSymbolsWithAnnotation(ContributesBinding::class)
+      .filterIsInstance<KSClassDeclaration>()
+      .forEach { checkDoesNotImplementScoped(it) }
+
+    return emptyList()
+  }
+
+  private fun generateGraph(clazz: KSClassDeclaration) {
+    val packageName = "${METRO_LOOKUP_PACKAGE}.${clazz.packageName.asString()}"
+    val graphClassName = ClassName(packageName, "${clazz.innerClassNames()}Graph")
+    val scopeClassName = clazz.scope().type.toClassName()
+
+    val fileSpec =
+      FileSpec.builder(graphClassName)
+        .addType(
+          TypeSpec.interfaceBuilder(graphClassName)
+            .addOriginatingKSFile(clazz.requireContainingFile())
+            .addAnnotation(
+              AnnotationSpec.builder(ContributesTo::class)
+                .addMember("%T::class", scopeClassName)
+                .build()
+            )
+            .addProperties(
+              clazz.superTypes
+                .filter { it.resolve().declaration.requireQualifiedName() != scopedFqName }
+                .map {
+                  val type = it.resolve()
+                  PropertySpec.builder(
+                      "bind${type.declaration.innerClassNames()}",
+                      type.toClassName(),
+                    )
+                    .addAnnotation(Binds::class)
+                    .receiver(clazz.toClassName())
+                    .build()
+                }
+                .toList()
+            )
+            .addProperty(
+              PropertySpec.builder("bind${clazz.innerClassNames()}Scoped", scopedClassName)
+                .addAnnotation(Binds::class)
+                .addAnnotation(IntoSet::class)
+                .addAnnotation(
+                  AnnotationSpec.builder(ForScope::class)
+                    .addMember("%T::class", scopeClassName)
+                    .build()
+                )
+                .receiver(clazz.toClassName())
+                .build()
+            )
+            .build()
+        )
+        .build()
+
+    fileSpec.writeTo(codeGenerator, aggregating = false)
+  }
+
+  private fun checkHasInjectAnnotation(clazz: KSClassDeclaration) {
+    check(clazz.annotations.any { it.isAnnotation(injectFqName) }, clazz) {
+      "${clazz.simpleName.asString()} must be annotated with @Inject when " +
+        "using @ContributesScoped."
+    }
+  }
+
+  private fun checkImplementsScoped(clazz: KSClassDeclaration) {
+    val extendsScoped =
+      clazz.getAllSuperTypes().any { it.declaration.qualifiedName?.asString() == scopedFqName }
+
+    check(extendsScoped, clazz) {
+      "In order to use @ContributesScoped, ${clazz.simpleName.asString()} must " +
+        "implement $scopedFqName."
+    }
+  }
+
+  private fun checkSuperType(clazz: KSClassDeclaration) {
+    val superTypeCount =
+      clazz.superTypes
+        .filter { it.resolve().declaration.requireQualifiedName() != scopedFqName }
+        .count()
+
+    check(superTypeCount < 2, clazz) {
+      "In order to use @ContributesScoped, ${clazz.simpleName.asString()} is allowed to have only one " +
+        "other super type besides Scoped."
+    }
+  }
+
+  private fun checkDoesNotImplementScoped(clazz: KSClassDeclaration) {
+    check(
+      clazz.superTypes.none { it.resolve().declaration.requireQualifiedName() == scopedFqName },
+      clazz,
+    ) {
+      "${clazz.simpleName.asString()} implements Scoped, but uses @ContributesBinding instead " +
+        "of @ContributesScoped. When implementing Scoped the annotation @ContributesScoped " +
+        "must be used instead of @ContributesBinding to bind both super types correctly. It's " +
+        "not necessary to use @ContributesBinding."
+    }
+  }
+}

--- a/metro-extensions/contribute/impl-code-generators/src/test/kotlin/software/amazon/app/platform/inject/metro/CommonSourceCode.kt
+++ b/metro-extensions/contribute/impl-code-generators/src/test/kotlin/software/amazon/app/platform/inject/metro/CommonSourceCode.kt
@@ -4,26 +4,16 @@ package software.amazon.app.platform.inject.metro
 
 import com.tschuchort.compiletesting.JvmCompilationResult
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
-import software.amazon.test.TestRendererGraph
-import software.amazon.test.TestRobotGraph
 
 internal val JvmCompilationResult.graphInterface: Class<*>
   get() = classLoader.loadClass("software.amazon.test.GraphInterface")
 
-internal fun Class<*>.newTestRendererGraph(): TestRendererGraph {
+internal fun <T : Any> Class<*>.newMetroGraph(): T {
   val companionObject = fields.single().get(null)
+  @Suppress("UNCHECKED_CAST")
   return classes
     .single { it.simpleName == "Companion" }
     .declaredMethods
     .single { it.name == "create" }
-    .invoke(companionObject) as TestRendererGraph
-}
-
-internal fun Class<*>.newTestRobotGraph(): TestRobotGraph {
-  val companionObject = fields.single().get(null)
-  return classes
-    .single { it.simpleName == "Companion" }
-    .declaredMethods
-    .single { it.name == "create" }
-    .invoke(companionObject) as TestRobotGraph
+    .invoke(companionObject) as T
 }

--- a/metro-extensions/contribute/impl-code-generators/src/test/kotlin/software/amazon/app/platform/inject/metro/processor/ContributesRendererProcessorTest.kt
+++ b/metro-extensions/contribute/impl-code-generators/src/test/kotlin/software/amazon/app/platform/inject/metro/processor/ContributesRendererProcessorTest.kt
@@ -23,13 +23,14 @@ import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.junit.jupiter.api.Test
 import software.amazon.app.platform.inject.metro.compile
 import software.amazon.app.platform.inject.metro.graphInterface
-import software.amazon.app.platform.inject.metro.newTestRendererGraph
+import software.amazon.app.platform.inject.metro.newMetroGraph
 import software.amazon.app.platform.ksp.inner
 import software.amazon.app.platform.ksp.isAnnotatedWith
 import software.amazon.app.platform.metro.METRO_LOOKUP_PACKAGE
 import software.amazon.app.platform.renderer.Renderer
 import software.amazon.app.platform.renderer.RendererScope
 import software.amazon.app.platform.renderer.metro.RendererKey
+import software.amazon.test.TestRendererGraph
 
 class ContributesRendererProcessorTest {
 
@@ -90,12 +91,13 @@ class ContributesRendererProcessorTest {
         assertThat(getAnnotation(RendererKey::class.java).value).isEqualTo(model)
       }
 
-      assertThat(graphInterface.newTestRendererGraph().renderers.keys).containsOnly(model)
-
-      assertThat(graphInterface.newTestRendererGraph().modelToRendererMapping.keys)
+      assertThat(graphInterface.newMetroGraph<TestRendererGraph>().renderers.keys)
         .containsOnly(model)
 
-      assertThat(graphInterface.newTestRendererGraph().modelToRendererMapping.values)
+      assertThat(graphInterface.newMetroGraph<TestRendererGraph>().modelToRendererMapping.keys)
+        .containsOnly(model)
+
+      assertThat(graphInterface.newMetroGraph<TestRendererGraph>().modelToRendererMapping.values)
         .containsOnly(testRenderer.kotlin)
     }
   }
@@ -148,7 +150,8 @@ class ContributesRendererProcessorTest {
         assertThat(getAnnotation(RendererKey::class.java).value).isEqualTo(model)
       }
 
-      assertThat(graphInterface.newTestRendererGraph().renderers.keys).containsOnly(model)
+      assertThat(graphInterface.newMetroGraph<TestRendererGraph>().renderers.keys)
+        .containsOnly(model)
     }
   }
 
@@ -197,7 +200,7 @@ class ContributesRendererProcessorTest {
         assertThat(this).isAnnotatedWith(IntoMap::class)
       }
 
-      assertThat(graphInterface.newTestRendererGraph().renderers.keys)
+      assertThat(graphInterface.newMetroGraph<TestRendererGraph>().renderers.keys)
         .containsOnly(presenter.model.kotlin)
     }
   }
@@ -222,7 +225,8 @@ class ContributesRendererProcessorTest {
       """,
       graphInterfaceSource,
     ) {
-      assertThat(graphInterface.newTestRendererGraph().renderers.keys).containsOnly(model)
+      assertThat(graphInterface.newMetroGraph<TestRendererGraph>().renderers.keys)
+        .containsOnly(model)
     }
   }
 
@@ -371,7 +375,7 @@ class ContributesRendererProcessorTest {
         assertThat(it).isAnnotatedWith(RendererKey::class)
       }
 
-      assertThat(graphInterface.newTestRendererGraph().renderers.keys)
+      assertThat(graphInterface.newMetroGraph<TestRendererGraph>().renderers.keys)
         .containsExactlyInAnyOrder(
           presenter.model.kotlin,
           presenter.model.inner.kotlin,
@@ -402,7 +406,7 @@ class ContributesRendererProcessorTest {
         assertThat(it).isAnnotatedWith(ForScope::class)
       }
 
-      assertThat(graphInterface.newTestRendererGraph().modelToRendererMapping.keys)
+      assertThat(graphInterface.newMetroGraph<TestRendererGraph>().modelToRendererMapping.keys)
         .containsExactlyInAnyOrder(
           presenter.model.kotlin,
           presenter.model.inner.kotlin,
@@ -411,7 +415,9 @@ class ContributesRendererProcessorTest {
           presenter.model.model2.kotlin,
         )
 
-      assertThat(graphInterface.newTestRendererGraph().modelToRendererMapping.values.distinct())
+      assertThat(
+          graphInterface.newMetroGraph<TestRendererGraph>().modelToRendererMapping.values.distinct()
+        )
         .containsOnly(testRenderer.kotlin)
     }
   }
@@ -459,13 +465,13 @@ class ContributesRendererProcessorTest {
         )
         .containsOnly("provideSoftwareAmazonTestTestRendererPresenterModelKey")
 
-      assertThat(graphInterface.newTestRendererGraph().renderers.keys)
+      assertThat(graphInterface.newMetroGraph<TestRendererGraph>().renderers.keys)
         .containsOnly(presenter.model.kotlin)
 
-      assertThat(graphInterface.newTestRendererGraph().modelToRendererMapping.keys)
+      assertThat(graphInterface.newMetroGraph<TestRendererGraph>().modelToRendererMapping.keys)
         .containsOnly(presenter.model.kotlin)
 
-      assertThat(graphInterface.newTestRendererGraph().modelToRendererMapping.values)
+      assertThat(graphInterface.newMetroGraph<TestRendererGraph>().modelToRendererMapping.values)
         .containsOnly(testRenderer.kotlin)
     }
   }
@@ -501,7 +507,8 @@ class ContributesRendererProcessorTest {
           "provideSoftwareAmazonTestTestRendererModelKey",
         )
 
-      assertThat(graphInterface.newTestRendererGraph().renderers.keys).containsOnly(model)
+      assertThat(graphInterface.newMetroGraph<TestRendererGraph>().renderers.keys)
+        .containsOnly(model)
     }
   }
 

--- a/metro-extensions/contribute/impl-code-generators/src/test/kotlin/software/amazon/app/platform/inject/metro/processor/ContributesRobotGeneratorTest.kt
+++ b/metro-extensions/contribute/impl-code-generators/src/test/kotlin/software/amazon/app/platform/inject/metro/processor/ContributesRobotGeneratorTest.kt
@@ -22,12 +22,13 @@ import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.junit.jupiter.api.Test
 import software.amazon.app.platform.inject.metro.compile
 import software.amazon.app.platform.inject.metro.graphInterface
-import software.amazon.app.platform.inject.metro.newTestRobotGraph
+import software.amazon.app.platform.inject.metro.newMetroGraph
 import software.amazon.app.platform.ksp.capitalize
 import software.amazon.app.platform.ksp.isAnnotatedWith
 import software.amazon.app.platform.metro.METRO_LOOKUP_PACKAGE
 import software.amazon.app.platform.renderer.metro.RobotKey
 import software.amazon.app.platform.robot.Robot
+import software.amazon.test.TestRobotGraph
 
 class ContributesRobotGeneratorTest {
 
@@ -66,7 +67,8 @@ class ContributesRobotGeneratorTest {
         assertThat(getAnnotation(RobotKey::class.java).value.java).isEqualTo(testRobot)
       }
 
-      assertThat(graphInterface.newTestRobotGraph().robots.keys).containsOnly(testRobot.kotlin)
+      assertThat(graphInterface.newMetroGraph<TestRobotGraph>().robots.keys)
+        .containsOnly(testRobot.kotlin)
     }
   }
 
@@ -102,7 +104,8 @@ class ContributesRobotGeneratorTest {
         assertThat(getAnnotation(RobotKey::class.java).value.java).isEqualTo(testRobot)
       }
 
-      assertThat(graphInterface.newTestRobotGraph().robots.keys).containsOnly(testRobot.kotlin)
+      assertThat(graphInterface.newMetroGraph<TestRobotGraph>().robots.keys)
+        .containsOnly(testRobot.kotlin)
     }
   }
 
@@ -213,10 +216,8 @@ class ContributesRobotGeneratorTest {
         import dev.zacsweers.metro.createGraph
         import dev.zacsweers.metro.DependencyGraph
         import dev.zacsweers.metro.SingleIn
-        import software.amazon.app.platform.renderer.RendererGraph
-        import software.amazon.test.TestRendererGraph
 
-        @DependencyGraph(AppScope::class, excludes = [RendererGraph::class])
+        @DependencyGraph(AppScope::class)
         @SingleIn(AppScope::class)
         interface GraphInterface : TestRobotGraph {
             companion object {

--- a/metro-extensions/contribute/impl-code-generators/src/test/kotlin/software/amazon/app/platform/inject/metro/processor/ContributesScopedProcessorTest.kt
+++ b/metro-extensions/contribute/impl-code-generators/src/test/kotlin/software/amazon/app/platform/inject/metro/processor/ContributesScopedProcessorTest.kt
@@ -1,0 +1,369 @@
+@file:OptIn(ExperimentalCompilerApi::class)
+
+package software.amazon.app.platform.inject.metro.processor
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.hasSize
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import com.tschuchort.compiletesting.JvmCompilationResult
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesTo
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.jupiter.api.Test
+import software.amazon.app.platform.inject.metro.compile
+import software.amazon.app.platform.inject.metro.graphInterface
+import software.amazon.app.platform.inject.metro.newMetroGraph
+import software.amazon.app.platform.ksp.capitalize
+import software.amazon.app.platform.ksp.inner
+import software.amazon.app.platform.metro.METRO_LOOKUP_PACKAGE
+import software.amazon.app.platform.scope.Scoped
+
+class ContributesScopedProcessorTest {
+
+  @Test
+  fun `a graph interface is generated`() {
+    compile(
+      """
+      package software.amazon.test
+
+      import software.amazon.app.platform.inject.metro.ContributesScoped
+      import software.amazon.app.platform.scope.Scoped
+      import dev.zacsweers.metro.AppScope
+      import dev.zacsweers.metro.createGraph
+      import dev.zacsweers.metro.DependencyGraph
+      import dev.zacsweers.metro.ForScope
+      import dev.zacsweers.metro.Inject
+      import dev.zacsweers.metro.SingleIn
+
+      interface SuperType
+
+      @Inject
+      @SingleIn(AppScope::class)
+      @ContributesScoped(AppScope::class)
+      class TestClass : SuperType, Scoped
+
+      @DependencyGraph(AppScope::class)
+      @SingleIn(AppScope::class)
+      interface GraphInterface {
+        val superTypeInstance: SuperType
+        
+        @ForScope(AppScope::class)
+        val allScoped: Set<Scoped>
+      
+        companion object {
+          fun create(): GraphInterface = createGraph<GraphInterface>()
+        }
+      }
+      """
+    ) {
+      val scopedGraph = testClass.graph
+
+      assertThat(scopedGraph.getAnnotation(ContributesTo::class.java).scope)
+        .isEqualTo(AppScope::class)
+
+      // The annotations for these functions are defined in other kotlinc generated classes.
+      // Instead of relying on reflection, we verify them by running the Metro compiler and
+      // instantiating the Metro graph below.
+      with(scopedGraph.declaredMethods.single { it.name == "getBindSuperType" }) {
+        assertThat(parameters.single().type).isEqualTo(testClass)
+        assertThat(returnType).isEqualTo(superType)
+      }
+
+      with(scopedGraph.declaredMethods.single { it.name == "getBindTestClassScoped" }) {
+        assertThat(parameters.single().type).isEqualTo(testClass)
+        assertThat(returnType).isEqualTo(Scoped::class.java)
+      }
+
+      val graph = graphInterface.newMetroGraph<Any>()
+
+      @Suppress("UNCHECKED_CAST")
+      val scopedInstances =
+        graphInterface.declaredMethods.single { it.name == "getAllScoped" }.invoke(graph)
+          as Set<Scoped>
+      assertThat(scopedInstances.single()::class.java).isEqualTo(testClass)
+
+      @Suppress("UNCHECKED_CAST")
+      assertThat(
+          graphInterface.declaredMethods
+              .single { it.name == "getSuperTypeInstance" }
+              .invoke(graph)::class
+            .java
+        )
+        .isEqualTo(testClass)
+    }
+  }
+
+  @Test
+  fun `a graph interface is generated for an inner class`() {
+    compile(
+      """
+      package software.amazon.test
+
+      import software.amazon.app.platform.inject.metro.ContributesScoped
+      import software.amazon.app.platform.scope.Scoped
+      import dev.zacsweers.metro.AppScope
+      import dev.zacsweers.metro.Inject
+      import dev.zacsweers.metro.SingleIn
+
+      interface SuperType
+
+      interface TestClass {
+        @Inject
+        @SingleIn(AppScope::class)
+        @ContributesScoped(AppScope::class)
+        class Inner : SuperType, Scoped
+      }
+      """
+    ) {
+      val scopedGraph = testClass.inner.graph
+
+      assertThat(scopedGraph.getAnnotation(ContributesTo::class.java).scope)
+        .isEqualTo(AppScope::class)
+
+      with(scopedGraph.declaredMethods.single { it.name == "getBindSuperType" }) {
+        assertThat(parameters.single().type).isEqualTo(testClass.inner)
+        assertThat(returnType).isEqualTo(superType)
+      }
+
+      with(scopedGraph.declaredMethods.single { it.name == "getBindTestClassInnerScoped" }) {
+        assertThat(parameters.single().type).isEqualTo(testClass.inner)
+        assertThat(returnType).isEqualTo(Scoped::class.java)
+      }
+    }
+  }
+
+  @Test
+  fun `a graph interface is generated when only Scoped is implemented`() {
+    compile(
+      """
+      package software.amazon.test
+
+      import software.amazon.app.platform.inject.metro.ContributesScoped
+      import software.amazon.app.platform.scope.Scoped
+      import dev.zacsweers.metro.AppScope
+      import dev.zacsweers.metro.Inject
+      import dev.zacsweers.metro.SingleIn
+
+      @Inject
+      @SingleIn(AppScope::class)
+      @ContributesScoped(AppScope::class)
+      class TestClass : Scoped
+      """
+    ) {
+      val scopedGraph = testClass.graph
+
+      assertThat(scopedGraph.getAnnotation(ContributesTo::class.java).scope)
+        .isEqualTo(AppScope::class)
+
+      assertThat(scopedGraph.declaredMethods).hasSize(1)
+
+      with(scopedGraph.declaredMethods.single { it.name == "getBindTestClassScoped" }) {
+        assertThat(parameters.single().type).isEqualTo(testClass)
+        assertThat(returnType).isEqualTo(Scoped::class.java)
+      }
+    }
+  }
+
+  @Test
+  fun `it's an error when there is no super type`() {
+    compile(
+      """
+      package software.amazon.test
+
+      import software.amazon.app.platform.inject.metro.ContributesScoped
+      import dev.zacsweers.metro.AppScope
+      import dev.zacsweers.metro.Inject
+      import dev.zacsweers.metro.SingleIn
+
+      @Inject
+      @SingleIn(AppScope::class)
+      @ContributesScoped(AppScope::class)
+      class TestClass
+      """,
+      exitCode = COMPILATION_ERROR,
+    ) {
+      assertThat(messages)
+        .contains(
+          "In order to use @ContributesScoped, TestClass must implement software.amazon.app.platform.scope.Scoped."
+        )
+    }
+  }
+
+  @Test
+  fun `it's an error when Scoped is not implemented`() {
+    compile(
+      """
+      package software.amazon.test
+
+      import software.amazon.app.platform.inject.metro.ContributesScoped
+      import dev.zacsweers.metro.AppScope
+      import dev.zacsweers.metro.Inject
+      import dev.zacsweers.metro.SingleIn
+
+      @Inject
+      @SingleIn(AppScope::class)
+      @ContributesScoped(AppScope::class)
+      class TestClass : SuperType
+      """,
+      exitCode = COMPILATION_ERROR,
+    ) {
+      assertThat(messages)
+        .contains(
+          "In order to use @ContributesScoped, TestClass must implement software.amazon.app.platform.scope.Scoped."
+        )
+    }
+  }
+
+  @Test
+  fun `it's an error when there are multiple super types`() {
+    compile(
+      """
+      package software.amazon.test
+
+      import software.amazon.app.platform.inject.metro.ContributesScoped
+      import software.amazon.app.platform.scope.Scoped
+      import dev.zacsweers.metro.AppScope
+      import dev.zacsweers.metro.Inject
+      import dev.zacsweers.metro.SingleIn
+
+      interface SuperType
+      interface SuperType2
+
+      @Inject
+      @SingleIn(AppScope::class)
+      @ContributesScoped(AppScope::class)
+      class TestClass : SuperType, SuperType2, Scoped
+      """,
+      exitCode = COMPILATION_ERROR,
+    ) {
+      assertThat(messages)
+        .contains(
+          "In order to use @ContributesScoped, TestClass is allowed to have only one other super type besides Scoped."
+        )
+    }
+  }
+
+  @Test
+  fun `Scoped can be implemented through another type`() {
+    compile(
+      """
+      package software.amazon.test
+
+      import software.amazon.app.platform.inject.metro.ContributesScoped
+      import software.amazon.app.platform.scope.Scoped
+      import dev.zacsweers.metro.AppScope
+      import dev.zacsweers.metro.Inject
+      import dev.zacsweers.metro.SingleIn
+
+      interface SuperType2 : Scoped
+      interface SuperType3 : SuperType2
+
+      @Inject
+      @SingleIn(AppScope::class)
+      @ContributesScoped(AppScope::class)
+      class TestClass : SuperType2
+      """
+    ) {
+      assertThat(testClass.graph).isNotNull()
+    }
+  }
+
+  @Test
+  fun `using @ContributesBinding when implementing Scoped is an error`() {
+    compile(
+      """
+      package software.amazon.test
+
+      import software.amazon.app.platform.scope.Scoped
+      import dev.zacsweers.metro.AppScope
+      import dev.zacsweers.metro.ContributesBinding
+      import dev.zacsweers.metro.Inject
+      import dev.zacsweers.metro.SingleIn
+
+      interface SuperType
+
+      @Inject
+      @SingleIn(AppScope::class)
+      @ContributesBinding(AppScope::class)
+      class TestClass : SuperType, Scoped
+      """,
+      exitCode = COMPILATION_ERROR,
+    ) {
+      assertThat(messages)
+        .contains(
+          "TestClass implements Scoped, but uses @ContributesBinding instead of " +
+            "@ContributesScoped. When implementing Scoped the annotation @ContributesScoped " +
+            "must be used instead of @ContributesBinding to bind both super types correctly. " +
+            "It's not necessary to use @ContributesBinding."
+        )
+    }
+  }
+
+  // This test should fail. Unfortunately, Metro doesn't support this yet and the generated
+  // interface needs to be excluded explicitly.
+  @Test
+  fun `classes using @ContributesScoped cannot be excluded`() {
+    compile(
+      """
+      package software.amazon.test
+
+      import software.amazon.app.platform.inject.metro.ContributesScoped
+      import software.amazon.app.platform.scope.Scoped
+      import dev.zacsweers.metro.AppScope
+      import dev.zacsweers.metro.createGraph
+      import dev.zacsweers.metro.DependencyGraph
+      import dev.zacsweers.metro.ForScope
+      import dev.zacsweers.metro.Inject
+      import dev.zacsweers.metro.SingleIn
+
+      interface SuperType
+
+      @Inject
+      @SingleIn(AppScope::class)
+      @ContributesScoped(AppScope::class)
+      class TestClass : SuperType, Scoped
+
+      @DependencyGraph(AppScope::class, excludes = [TestClass::class])
+      @SingleIn(AppScope::class)
+      interface GraphInterface {
+        val superTypeInstance: SuperType
+        
+        @ForScope(AppScope::class)
+        val allScoped: Set<Scoped>
+      
+        companion object {
+          fun create(): GraphInterface = createGraph<GraphInterface>()
+        }
+      }
+      """
+      //      exitCode = COMPILATION_ERROR,
+    ) {
+      //      assertThat(messages)
+      //        .contains(
+      //          "Cannot find an @Inject constructor or @Provides-annotated " +
+      //            "function/property for: software.amazon.test.SuperType"
+      //        )
+    }
+  }
+
+  private val JvmCompilationResult.testClass: Class<*>
+    get() = classLoader.loadClass("software.amazon.test.TestClass")
+
+  private val JvmCompilationResult.superType: Class<*>
+    get() = classLoader.loadClass("software.amazon.test.SuperType")
+
+  private val Class<*>.graph: Class<*>
+    get() =
+      classLoader.loadClass(
+        "$METRO_LOOKUP_PACKAGE.$packageName." +
+          canonicalName.substringAfter(packageName).substring(1).split(".").joinToString(
+            separator = ""
+          ) {
+            it.capitalize()
+          } +
+          "Graph"
+      )
+}

--- a/metro/public/api/android/public.api
+++ b/metro/public/api/android/public.api
@@ -1,3 +1,7 @@
+public abstract interface annotation class software/amazon/app/platform/inject/metro/ContributesScoped : java/lang/annotation/Annotation {
+	public abstract fun scope ()Ljava/lang/Class;
+}
+
 public abstract interface annotation class software/amazon/app/platform/renderer/metro/RendererKey : java/lang/annotation/Annotation {
 	public abstract fun value ()Ljava/lang/Class;
 }

--- a/metro/public/api/desktop/public.api
+++ b/metro/public/api/desktop/public.api
@@ -1,3 +1,7 @@
+public abstract interface annotation class software/amazon/app/platform/inject/metro/ContributesScoped : java/lang/annotation/Annotation {
+	public abstract fun scope ()Ljava/lang/Class;
+}
+
 public abstract interface annotation class software/amazon/app/platform/renderer/metro/RendererKey : java/lang/annotation/Annotation {
 	public abstract fun value ()Ljava/lang/Class;
 }

--- a/metro/public/src/commonMain/kotlin/software/amazon/app/platform/inject/metro/ContributesScoped.kt
+++ b/metro/public/src/commonMain/kotlin/software/amazon/app/platform/inject/metro/ContributesScoped.kt
@@ -1,0 +1,41 @@
+package software.amazon.app.platform.inject.metro
+
+import kotlin.annotation.AnnotationTarget.CLASS
+import kotlin.reflect.KClass
+import software.amazon.app.platform.scope.Scoped
+
+/**
+ * Used to contribute a class implementing the [Scoped] interface to the given [scope], e.g.
+ *
+ * ```
+ * @Inject
+ * @SingleIn(AppScope::class)
+ * @ContributesScoped(AppScope::class)
+ * class MyClass(..) : SuperType, Scoped
+ * ```
+ *
+ * This annotation is a shortcut for using `@ContributesBinding` and `@ContributesIntoSet`, but with
+ * a qualifier for the multibinding alone. This can in Metro only be expressed with a contributed
+ * graph:
+ * ```
+ * @Inject
+ * @SingleIn(AppScope::class)
+ * class MyClass(..) : SuperType, Scoped
+ *
+ * @ContributesTo(AppScope::class)
+ * interface MyClassGraph {
+ *   @Binds val MyClass.bindSuperType: SuperType
+ *
+ *   @Binds @IntoSet @ForScope(AppScope::class) val MyClass.bindScoped: Scoped
+ * }
+ * ```
+ *
+ * Note that this annotation is only applicable for Metro and not kotlin-inject, because for
+ * kotlin-inject we provide a custom code generator out of the box when using `@ContributesBinding`
+ * that can handle the [Scoped] multibinding interface.
+ */
+@Target(CLASS)
+public annotation class ContributesScoped(
+  /** The scope in which to include this contributed binding. */
+  val scope: KClass<*>
+)

--- a/renderer/public/api/android/public.api
+++ b/renderer/public/api/android/public.api
@@ -38,6 +38,11 @@ public abstract interface class software/amazon/app/platform/renderer/RendererGr
 	public abstract fun getRenderers ()Ljava/util/Map;
 }
 
+public abstract class software/amazon/app/platform/renderer/RendererGraph$$$BindsMirror {
+	public abstract fun modelToRendererMapping9894420054205200196 ()Ljava/util/Map;
+	public abstract fun renderers4205200196 ()Ljava/util/Map;
+}
+
 public abstract interface class software/amazon/app/platform/renderer/RendererGraph$Factory {
 	public abstract fun createRendererGraph (Lsoftware/amazon/app/platform/renderer/RendererFactory;)Lsoftware/amazon/app/platform/renderer/RendererGraph;
 }

--- a/renderer/public/api/desktop/public.api
+++ b/renderer/public/api/desktop/public.api
@@ -38,6 +38,11 @@ public abstract interface class software/amazon/app/platform/renderer/RendererGr
 	public abstract fun getRenderers ()Ljava/util/Map;
 }
 
+public abstract class software/amazon/app/platform/renderer/RendererGraph$$$BindsMirror {
+	public abstract fun modelToRendererMapping9894420054205200196 ()Ljava/util/Map;
+	public abstract fun renderers4205200196 ()Ljava/util/Map;
+}
+
 public abstract interface class software/amazon/app/platform/renderer/RendererGraph$Factory {
 	public abstract fun createRendererGraph (Lsoftware/amazon/app/platform/renderer/RendererFactory;)Lsoftware/amazon/app/platform/renderer/RendererGraph;
 }

--- a/renderer/public/src/commonMain/kotlin/software/amazon/app/platform/renderer/RendererGraph.kt
+++ b/renderer/public/src/commonMain/kotlin/software/amazon/app/platform/renderer/RendererGraph.kt
@@ -4,6 +4,7 @@ import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.ForScope
 import dev.zacsweers.metro.GraphExtension
+import dev.zacsweers.metro.Multibinds
 import dev.zacsweers.metro.Provider
 import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.SingleIn
@@ -15,6 +16,7 @@ import software.amazon.app.platform.presenter.BaseModel
 @SingleIn(RendererScope::class)
 public interface RendererGraph {
   /** All [Renderer]s provided in the dependency graph. */
+  @Multibinds(allowEmpty = true)
   public val renderers: Map<KClass<out BaseModel>, Provider<Renderer<*>>>
 
   /**
@@ -28,6 +30,7 @@ public interface RendererGraph {
    * all keys pointing to the same renderer class.
    */
   @ForScope(RendererScope::class)
+  @Multibinds(allowEmpty = true)
   public val modelToRendererMapping: Map<KClass<out BaseModel>, KClass<out Renderer<*>>>
 
   /** The parent interface to create a [RendererGraph]. */

--- a/robot/public/api/android/public.api
+++ b/robot/public/api/android/public.api
@@ -30,6 +30,10 @@ public abstract interface class software/amazon/app/platform/robot/RobotGraph {
 	public abstract fun getRobots ()Ljava/util/Map;
 }
 
+public abstract class software/amazon/app/platform/robot/RobotGraph$$$BindsMirror {
+	public abstract fun robots4205200196 ()Ljava/util/Map;
+}
+
 public abstract interface class software/amazon/app/platform/robot/RobotGraph$$$MetroContributionToAppScope : software/amazon/app/platform/robot/RobotGraph {
 }
 

--- a/robot/public/api/desktop/public.api
+++ b/robot/public/api/desktop/public.api
@@ -14,6 +14,10 @@ public abstract interface class software/amazon/app/platform/robot/RobotGraph {
 	public abstract fun getRobots ()Ljava/util/Map;
 }
 
+public abstract class software/amazon/app/platform/robot/RobotGraph$$$BindsMirror {
+	public abstract fun robots4205200196 ()Ljava/util/Map;
+}
+
 public abstract interface class software/amazon/app/platform/robot/RobotGraph$$$MetroContributionToAppScope : software/amazon/app/platform/robot/RobotGraph {
 }
 

--- a/robot/public/src/commonMain/kotlin/software/amazon/app/platform/robot/RobotGraph.kt
+++ b/robot/public/src/commonMain/kotlin/software/amazon/app/platform/robot/RobotGraph.kt
@@ -2,6 +2,7 @@ package software.amazon.app.platform.robot
 
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Multibinds
 import dev.zacsweers.metro.Provider
 import kotlin.reflect.KClass
 
@@ -9,5 +10,5 @@ import kotlin.reflect.KClass
 @ContributesTo(AppScope::class)
 public interface RobotGraph {
   /** All [Robot]s provided in the Metro dependency graph. */
-  public val robots: Map<KClass<*>, Provider<Robot>>
+  @Multibinds(allowEmpty = true) public val robots: Map<KClass<*>, Provider<Robot>>
 }


### PR DESCRIPTION
In kotlin-inject-anvil we provide a custom code generator for `@ContributesBinding` when the class implements `Scoped`. The custom code generator handles all super type bindings properly.
```kotlin
@Inject
@SingleIn(AppScope::class)
@ContributesBinding(AppScope::class)
class Abc : Def, Scoped
```

Metro doesn't provide this kind of integration and it's required to create a graph interface:
```kotlin
@Inject
@SingleIn(AppScope::class)
class Abc : Def, Scoped

@ContributesTo(AppScope::class)
interface AbcGraph {
  @Binds
  val Abc.bindDef: Def

  @Binds @IntoSet @ForScope(AppScope::class)
  val Abc.bindScoped: Scoped
}
```

That's a lot of boilerplate. Therefore, we introduce `@ContributesScoped` to generate the code and restore the behavior from kotlin-inject-anvil.
```kotlin
@Inject
@SingleIn(AppScope::class)
@ContributesScoped(AppScope::class)
class Abc : Def, Scoped
```

Fixes #132


