### PR TITLE
Try to fix strange issues with ViewRenderer.resetView

### DIFF
--- a/renderer-android-view/public/src/androidMain/kotlin/software/amazon/app/platform/renderer/ViewRenderer.kt
+++ b/renderer-android-view/public/src/androidMain/kotlin/software/amazon/app/platform/renderer/ViewRenderer.kt
@@ -89,7 +89,9 @@ public abstract class ViewRenderer<in ModelT : BaseModel> : BaseAndroidViewRende
     // View and add it to the parent.
     view?.let {
       try {
-        parent.removeView(it)
+        if (parent === it.parent) {
+          parent.removeView(it)
+        }
       } catch (_: NullPointerException) {
         // This shouldn't happen, yet it does sporadically.
         // Specifically:
@@ -101,11 +103,11 @@ public abstract class ViewRenderer<in ModelT : BaseModel> : BaseAndroidViewRende
         // at android.view.ViewGroup.removeViewInternal(ViewGroup.java:5531)
         // at android.view.ViewGroup.removeView(ViewGroup.java:5462)
         // at software.amazon.app.platform.renderer.ViewRenderer.resetView(ViewRenderer.kt:101)
+      } finally {
+        // Allows us to reclaim the memory.
+        view = null
       }
     }
-
-    // Allows us to reclaim the memory.
-    view = null
   }
 
   final override fun render(model: ModelT) {


### PR DESCRIPTION


IndexOutOfBoundsException

```
2025-08-09 05:34:19.716 28337 28337 E com.amazon.device.crashmanager.AppFileArtifactSource: CRASH HAS OCCURRED
2025-08-09 05:34:19.716 28337 28337 E com.amazon.device.crashmanager.AppFileArtifactSource: java.lang.IndexOutOfBoundsException
2025-08-09 05:34:19.716 28337 28337 E com.amazon.device.crashmanager.AppFileArtifactSource: 	at android.view.ViewGroup.removeFromArray(ViewGroup.java:5665)
2025-08-09 05:34:19.716 28337 28337 E com.amazon.device.crashmanager.AppFileArtifactSource: 	at android.view.ViewGroup.removeViewInternal(ViewGroup.java:5853)
2025-08-09 05:34:19.716 28337 28337 E com.amazon.device.crashmanager.AppFileArtifactSource: 	at android.view.ViewGroup.removeViewInternal(ViewGroup.java:5815)
2025-08-09 05:34:19.716 28337 28337 E com.amazon.device.crashmanager.AppFileArtifactSource: 	at android.view.ViewGroup.removeView(ViewGroup.java:5746)
2025-08-09 05:34:19.716 28337 28337 E com.amazon.device.crashmanager.AppFileArtifactSource: 	at software.amazon.app.platform.renderer.ViewRenderer.resetView(ViewRenderer.kt:100)
2025-08-09 05:34:19.716 28337 28337 E com.amazon.device.crashmanager.AppFileArtifactSource: 	at software.amazon.app.platform.renderer.ViewRenderer.access$resetView(ViewRenderer.kt:63)
2025-08-09 05:34:19.716 28337 28337 E com.amazon.device.crashmanager.AppFileArtifactSource: 	at software.amazon.app.platform.renderer.ViewRenderer$render$lambda$4$$inlined$doOnDetach$1.onViewDetachedFromWindow(View.kt:436)
2025-08-09 05:34:19.716 28337 28337 E com.amazon.device.crashmanager.AppFileArtifactSource: 	at android.view.View.dispatchDetachedFromWindow(View.java:23314)
```