### PR TITLE
Disallow changing the parent View for renderers

### DIFF
--- a/renderer-android-view/public/src/androidInstrumentedTest/kotlin/software/amazon/app/platform/renderer/ViewRendererTest.kt
+++ b/renderer-android-view/public/src/androidInstrumentedTest/kotlin/software/amazon/app/platform/renderer/ViewRendererTest.kt
@@ -7,12 +7,14 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.TextView
 import androidx.test.ext.junit.rules.ActivityScenarioRule
+import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isNotSameInstanceAs
 import assertk.assertions.isNull
 import assertk.assertions.isTrue
+import assertk.assertions.messageContains
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.isActive
 import org.junit.Rule
@@ -210,6 +212,26 @@ class ViewRendererTest {
       assertThat(renderer.inflateCalled).isEqualTo(1)
       assertThat(renderer.renderCalled).isEqualTo(2)
       assertThat(renderer.onDetachCalled).isEqualTo(1)
+    }
+  }
+
+  @Test
+  fun it_is_forbidden_to_change_the_parent() {
+    activityRule.scenario.onActivity { activity ->
+      val parent1 = FrameLayout(activity)
+      val parent2 = FrameLayout(activity)
+
+      val renderer = TestViewRenderer()
+
+      renderer.init(activity, parent1)
+      // It is allowed to change the parent before the view gets created.
+      renderer.init(activity, parent2)
+
+      // This creates the view.
+      renderer.render(TestModel(1))
+
+      assertFailure { renderer.init(activity, parent1) }
+        .messageContains("A ViewRenderer should ever be only attached to one parent view.")
     }
   }
 

--- a/renderer-android-view/public/src/androidMain/kotlin/software/amazon/app/platform/renderer/AndroidRendererFactory.kt
+++ b/renderer-android-view/public/src/androidMain/kotlin/software/amazon/app/platform/renderer/AndroidRendererFactory.kt
@@ -51,7 +51,11 @@ public open class AndroidRendererFactory(
     parent: ViewGroup,
     rendererId: Int = 0,
   ): Renderer<T> {
-    val renderer = super.getRenderer(modelType, rendererId)
+    // For different parents we must return unique renderers. Therefore, include the parent in the
+    // rendererId.
+    val finalRendererId = parent.hashCode() + rendererId
+
+    val renderer = super.getRenderer(modelType, finalRendererId)
 
     if (renderer is BaseAndroidViewRenderer<*>) {
       renderer.init(activity, parent)
@@ -106,6 +110,11 @@ public fun <T : BaseModel> RendererFactory.getRenderer(
  * and their identity is determined by the position in the layout or on other words by the [parent]
  * view.
  */
+@Deprecated(
+  message = "getRenderer() takes the parent into account for caching.",
+  replaceWith = ReplaceWith("getRenderer(modelType, parent)"),
+  level = DeprecationLevel.WARNING,
+)
 public fun <T : BaseModel> RendererFactory.getChildRendererForParent(
   modelType: KClass<out T>,
   parent: ViewGroup,
@@ -131,7 +140,12 @@ public fun <T : BaseModel> RendererFactory.getChildRendererForParent(
  * and their identity is determined by the position in the layout or on other words by the [parent]
  * view.
  */
+@Deprecated(
+  message = "getRenderer() takes the parent into account for caching.",
+  replaceWith = ReplaceWith("getRenderer(model, parent)"),
+  level = DeprecationLevel.WARNING,
+)
 public fun <T : BaseModel> RendererFactory.getChildRendererForParent(
   model: T,
   parent: ViewGroup,
-): Renderer<T> = getChildRendererForParent(model::class, parent)
+): Renderer<T> = getRenderer(model::class, parent)

--- a/renderer-android-view/public/src/androidMain/kotlin/software/amazon/app/platform/renderer/RecyclerViewViewHolderRenderer.kt
+++ b/renderer-android-view/public/src/androidMain/kotlin/software/amazon/app/platform/renderer/RecyclerViewViewHolderRenderer.kt
@@ -92,7 +92,7 @@ public abstract class RecyclerViewViewHolderRenderer<ModelT : BaseModel> :
       // memory will be reclaimed when the RecyclerView is removed from the view hierarchy.
       @Suppress("UseCheckOrError")
       throw IllegalStateException(
-        "A RecyclerViewViewHolderRenderer should only be reused with the same " + "parent view."
+        "A RecyclerViewViewHolderRenderer should only be reused with the same parent view."
       )
     }
   }


### PR DESCRIPTION
Until now it was allowed to change the parent view for a `Renderer` and this would remove and re-add the view at the new position. However, this scenario could lead to confusing results and race conditions. The new behavior is to create a unique `Renderer` for each parent and create distinct view hierarchies.

A side-effect of this change can be that parent `Renderers` embedding child `Renderers` now must actively remove views from the child `Renderers`, if the child `Renderer` position changed. If not, stale UI might be visible.

Helps with #136
