### PR TITLE
Upgrade Metro

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,7 +46,7 @@ kotlinx-binaryCompatibilityValidator = "0.18.1"
 ktfmt-gradle = "0.23.0"
 ksp = "2.2.10-2.0.2"
 maven-publish = "0.34.0"
-metro = "0.6.3"
+metro = "0.6.5"
 molecule = "2.1.0"
 navigation3 = "1.0.0-alpha06"
 #noinspection GradleDependency

--- a/metro-extensions/contribute/impl-code-generators/src/main/kotlin/software/amazon/app/platform/metro/Util.kt
+++ b/metro-extensions/contribute/impl-code-generators/src/main/kotlin/software/amazon/app/platform/metro/Util.kt
@@ -1,4 +1,17 @@
 package software.amazon.app.platform.metro
 
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.ksp.toClassName
+import dev.zacsweers.metro.Origin
+
 /** The package in which the App Platform extensions generate code. */
 internal const val METRO_LOOKUP_PACKAGE = "app.platform.inject.metro"
+
+internal fun TypeSpec.Builder.addMetroOriginAnnotation(
+  clazz: KSClassDeclaration
+): TypeSpec.Builder =
+  addAnnotation(
+    AnnotationSpec.builder(Origin::class).addMember("%T::class", clazz.toClassName()).build()
+  )

--- a/metro-extensions/contribute/impl-code-generators/src/main/kotlin/software/amazon/app/platform/metro/processor/ContributesRendererProcessor.kt
+++ b/metro-extensions/contribute/impl-code-generators/src/main/kotlin/software/amazon/app/platform/metro/processor/ContributesRendererProcessor.kt
@@ -34,6 +34,7 @@ import kotlin.reflect.KClass
 import software.amazon.app.platform.inject.ContributesRenderer
 import software.amazon.app.platform.metro.METRO_LOOKUP_PACKAGE
 import software.amazon.app.platform.metro.MetroContextAware
+import software.amazon.app.platform.metro.addMetroOriginAnnotation
 import software.amazon.app.platform.renderer.metro.RendererKey
 
 /**
@@ -149,6 +150,7 @@ internal class ContributesRendererProcessor(
         .addType(
           TypeSpec.interfaceBuilder(graphClassName)
             .addOriginatingKSFile(clazz.requireContainingFile())
+            .addMetroOriginAnnotation(clazz)
             .addAnnotation(
               AnnotationSpec.builder(ContributesTo::class)
                 .addMember("%T::class", rendererScope)

--- a/metro-extensions/contribute/impl-code-generators/src/main/kotlin/software/amazon/app/platform/metro/processor/ContributesRobotProcessor.kt
+++ b/metro-extensions/contribute/impl-code-generators/src/main/kotlin/software/amazon/app/platform/metro/processor/ContributesRobotProcessor.kt
@@ -29,6 +29,7 @@ import software.amazon.app.platform.inject.robot.ContributesRobot
 import software.amazon.app.platform.ksp.decapitalize
 import software.amazon.app.platform.metro.METRO_LOOKUP_PACKAGE
 import software.amazon.app.platform.metro.MetroContextAware
+import software.amazon.app.platform.metro.addMetroOriginAnnotation
 import software.amazon.app.platform.renderer.metro.RobotKey
 
 /**
@@ -90,6 +91,7 @@ internal class ContributesRobotProcessor(
         .addType(
           TypeSpec.interfaceBuilder(graphClassName)
             .addOriginatingKSFile(clazz.requireContainingFile())
+            .addMetroOriginAnnotation(clazz)
             .addAnnotation(
               AnnotationSpec.builder(ContributesTo::class)
                 .addMember("%T::class", clazz.scope().type.toClassName())

--- a/metro-extensions/contribute/impl-code-generators/src/main/kotlin/software/amazon/app/platform/metro/processor/ContributesScopedProcessor.kt
+++ b/metro-extensions/contribute/impl-code-generators/src/main/kotlin/software/amazon/app/platform/metro/processor/ContributesScopedProcessor.kt
@@ -24,6 +24,7 @@ import dev.zacsweers.metro.IntoSet
 import software.amazon.app.platform.inject.metro.ContributesScoped
 import software.amazon.app.platform.metro.METRO_LOOKUP_PACKAGE
 import software.amazon.app.platform.metro.MetroContextAware
+import software.amazon.app.platform.metro.addMetroOriginAnnotation
 
 /**
  * Generates the necessary code in order to support [ContributesScoped].
@@ -78,6 +79,7 @@ internal class ContributesScopedProcessor(
         .addType(
           TypeSpec.interfaceBuilder(graphClassName)
             .addOriginatingKSFile(clazz.requireContainingFile())
+            .addMetroOriginAnnotation(clazz)
             .addAnnotation(
               AnnotationSpec.builder(ContributesTo::class)
                 .addMember("%T::class", scopeClassName)

--- a/metro-extensions/contribute/impl-code-generators/src/test/kotlin/software/amazon/app/platform/inject/metro/processor/ContributesScopedProcessorTest.kt
+++ b/metro-extensions/contribute/impl-code-generators/src/test/kotlin/software/amazon/app/platform/inject/metro/processor/ContributesScopedProcessorTest.kt
@@ -302,10 +302,8 @@ class ContributesScopedProcessorTest {
     }
   }
 
-  // This test should fail. Unfortunately, Metro doesn't support this yet and the generated
-  // interface needs to be excluded explicitly.
   @Test
-  fun `classes using @ContributesScoped cannot be excluded`() {
+  fun `classes using @ContributesScoped can be excluded`() {
     compile(
       """
       package software.amazon.test
@@ -338,14 +336,14 @@ class ContributesScopedProcessorTest {
           fun create(): GraphInterface = createGraph<GraphInterface>()
         }
       }
-      """
-      //      exitCode = COMPILATION_ERROR,
+      """,
+      exitCode = COMPILATION_ERROR,
     ) {
-      //      assertThat(messages)
-      //        .contains(
-      //          "Cannot find an @Inject constructor or @Provides-annotated " +
-      //            "function/property for: software.amazon.test.SuperType"
-      //        )
+      assertThat(messages)
+        .contains(
+          "Cannot find an @Inject constructor or @Provides-annotated " +
+            "function/property for: software.amazon.test.SuperType"
+        )
     }
   }
 


### PR DESCRIPTION
The new version of Metro comes with the `@Origin` annotation to link generated code back to that source that triggered generating the file. This ties into Metro's merge algorithm to correctly exclude and replace contributions.

