### PR TITLE
Fix multi-child ViewRenderer NPE when removing Android Views

### DIFF
--- a/renderer-android-view/public/src/androidMain/kotlin/software/amazon/app/platform/renderer/ViewRenderer.kt
+++ b/renderer-android-view/public/src/androidMain/kotlin/software/amazon/app/platform/renderer/ViewRenderer.kt
@@ -3,6 +3,8 @@ package software.amazon.app.platform.renderer
 import android.app.Activity
 import android.app.Application
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -145,9 +147,13 @@ public abstract class ViewRenderer<in ModelT : BaseModel> : BaseAndroidViewRende
     lastModel = null
 
     // Remove the view from the parent. In case the Renderer is reused we inflate a new
-    // View and add it to the parent.
-    if (view.parent === parent) {
-      parent.removeView(view)
+    // View and add it to the parent. This action must run after all currently queued main
+    // thread operations finish. This is needed because we cannot remove views from parents in
+    // the onDetach callback as this may lead to inconsistent view state and trigger crashes.
+    Handler(Looper.getMainLooper()).post {
+      if (view.parent === parent) {
+        parent.removeView(view)
+      }
     }
   }
 


### PR DESCRIPTION
With features such as a backstack that may render multiple children under a parent view, we are seeing crashes like this on activity destruction:

```
java.lang.RuntimeException: Unable to destroy activity {software.amazon.app.platform.demo/software.amazon.app.platform.recipes.FeatureActivity}:
    java.lang.NullPointerException: Attempt to invoke virtual method 'void android.view.View.dispatchDetachedFromWindow()' on a null object reference
    at android.app.ActivityThread.performDestroyActivity(ActivityThread.java:6269)
    at android.app.ActivityThread.handleDestroyActivity(ActivityThread.java:6301)
    at android.app.servertransaction.DestroyActivityItem.execute(DestroyActivityItem.java:52)
    at android.app.servertransaction.ActivityTransactionItem.execute(ActivityTransactionItem.java:63)
    at android.app.servertransaction.TransactionExecutor.executeLifecycleItem(TransactionExecutor.java:169)
    at android.app.servertransaction.TransactionExecutor.executeTransactionItems(TransactionExecutor.java:101)
    at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:80)
```

This happens in any instance where there are multiple child views under a parent ViewGroup, and the hosting Activity is destroyed. We manually remove children from the parent, but this mutates the child sequence within the parent and results in an NPE when Android tries to do cleanup on its end. Adjust the child view removal logic to run on the main thread, so it is sequential with any cleanup Android does.
