### PR TITLE
Fix potential error in renderer documentation

### DIFF
--- a/docs/renderer.md
+++ b/docs/renderer.md
@@ -3,7 +3,7 @@
 !!! note
 
     App Platform has a generic `Renderer` interface that can be used for multiple UI layer implementations.
-    Compose Multiplatform and Android Views are stable and supported out of the box. However, Compose Multiplatform is
+    Compose Multiplatform and Android Views are stable and supported out of the box. However, Compose UI is
     an opt-in feature through the Gradle DSL and must be explicitly enabled. The default value is `false`.
 
     ```groovy


### PR DESCRIPTION
The current documentation educates the reader that Compose Multiplatform and Android Views are supported out of the box by the 'Renderer'. However, this is contradicted by saying that Compose Multiplatform requires an opt-in in the next line. The PR changes this to Compose UI, in line with the Gradle DSL config `enableComposeUi`.

*Description of changes:*
- Updates top note in Renderer documentation to mention Compose UI instead of Compose Multiplatform.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
