### PR TITLE
Don't attempt to deploy docs in forks

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -70,6 +70,7 @@ jobs:
 
   deploy-mkdocs:
     needs: build-mkdocs
+    if: github.repository == 'amzn/app-platform'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Don't run the job that attempts to deploy docs in forked repositories. It always fails. The same check is already in place for publishing snapshots and releases.
