### PR TITLE
Remove Apple x86_64 targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Removed
 
+- Removed Apple x86_64 targets from the repository builds by dropping `iosX64` where it was still configured, aligning with Compose Multiplatform's removal of Apple x86_64 target support: https://kotlinlang.org/docs/multiplatform/whats-new-compose-111.html#dropped-support-for-apple-x86-64-targets
+
 ### Fixed
 
 ### Security

--- a/blueprints/starter/app/build.gradle.kts
+++ b/blueprints/starter/app/build.gradle.kts
@@ -41,7 +41,6 @@ kotlin {
     }
   }
 
-  iosX64()
   iosArm64()
   iosSimulatorArm64()
 

--- a/blueprints/starter/navigation/impl/build.gradle.kts
+++ b/blueprints/starter/navigation/impl/build.gradle.kts
@@ -32,7 +32,6 @@ kotlin {
     }
   }
 
-  iosX64()
   iosArm64()
   iosSimulatorArm64()
 

--- a/blueprints/starter/navigation/public/build.gradle.kts
+++ b/blueprints/starter/navigation/public/build.gradle.kts
@@ -30,7 +30,6 @@ kotlin {
     }
   }
 
-  iosX64()
   iosArm64()
   iosSimulatorArm64()
 

--- a/blueprints/starter/navigation/testing/build.gradle.kts
+++ b/blueprints/starter/navigation/testing/build.gradle.kts
@@ -30,7 +30,6 @@ kotlin {
     }
   }
 
-  iosX64()
   iosArm64()
   iosSimulatorArm64()
 

--- a/blueprints/starter/templates/impl/build.gradle.kts
+++ b/blueprints/starter/templates/impl/build.gradle.kts
@@ -32,7 +32,6 @@ kotlin {
     }
   }
 
-  iosX64()
   iosArm64()
   iosSimulatorArm64()
 

--- a/blueprints/starter/templates/public/build.gradle.kts
+++ b/blueprints/starter/templates/public/build.gradle.kts
@@ -31,7 +31,6 @@ kotlin {
     }
   }
 
-  iosX64()
   iosArm64()
   iosSimulatorArm64()
 

--- a/buildSrc/src/main/kotlin/software/amazon/app/platform/gradle/buildsrc/Platform.kt
+++ b/buildSrc/src/main/kotlin/software/amazon/app/platform/gradle/buildsrc/Platform.kt
@@ -149,13 +149,6 @@ internal sealed interface Platform {
     override val target: KotlinNativeTarget by lazy { project.kmpExtension.iosArm64() }
   }
 
-  private class IosX64(override val project: Project) : Ios() {
-
-    override val unitTestTaskName: String = "iosX64Test"
-
-    override val target: KotlinNativeTarget by lazy { project.kmpExtension.iosX64() }
-  }
-
   private class Wasm(private val project: Project) : Platform {
     override val unitTestTaskName: String = "wasmJsTest"
 
@@ -183,7 +176,6 @@ internal sealed interface Platform {
 
         add(IosSimulatorArm64(project = this@allPlatforms))
         add(IosArm64(project = this@allPlatforms))
-        add(IosX64(project = this@allPlatforms))
 
         add(Wasm(project = this@allPlatforms))
 


### PR DESCRIPTION
Drop iosX64 from the shared platform setup and starter blueprint modules to match Compose Multiplatform support.

Reference: https://kotlinlang.org/docs/multiplatform/whats-new-compose-111.html#dropped-support-for-apple-x86-64-targets


