### PR TITLE
Add Modifier support to Compose renderers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- **Breaking change:** Added an optional `Modifier` parameter to `BaseComposeRenderer.renderCompose()` and forwarded it to `ComposeRenderer.Compose()` so callers can apply standard Compose modifiers at the renderer boundary.
+
 ### Deprecated
 
 ### Removed

--- a/docs/presenter.md
+++ b/docs/presenter.md
@@ -458,7 +458,7 @@ class RootPresenterRenderer(
   private val backGestureDispatcherPresenter: BackGestureDispatcherPresenter,
 ) : ComposeRenderer<Model>() {
   @Composable
-  override fun Compose(model: Model) {
+  override fun Compose(model: Model, modifier: Modifier) {
     backGestureDispatcherPresenter.ForwardBackPressEventsToPresenters()
 
     // Call other child renderers.
@@ -946,7 +946,7 @@ for each position in the stack and the individual `Renderer` for each `Model` is
 @ContributesRenderer
 class Navigation3HomeRenderer(private val rendererFactory: RendererFactory) : ComposeRenderer<Model>() {
   @Composable
-  override fun Compose(model: Model) {
+  override fun Compose(model: Model, modifier: Modifier) {
     // Use the position of the model in the backstack as key for `NavDisplay`. This way
     // we can update models without Navigation 3 treating those changes as a new screen.
     val backstack = model.backstack.mapIndexed { index, _ -> index }
@@ -985,7 +985,7 @@ With this integration handling of the backstack is managed in the `Presenter` an
       private val rendererFactory: RendererFactory,
     ) : ComposeRenderer<Model>() {
       @Composable
-      override fun Compose(model: Model) {
+      override fun Compose(model: Model, modifier: Modifier) {
         val backstack = remember { mutableStateListOf<Any>(List) }
 
         NavDisplay(

--- a/docs/renderer.md
+++ b/docs/renderer.md
@@ -34,11 +34,11 @@ implementation for iOS is missing.
 @ContributesRenderer
 class LoginRenderer : ComposeRenderer<Model>() {
   @Composable
-  override fun Compose(model: Model) {
+  override fun Compose(model: Model, modifier: Modifier) {
     if (model.loginInProgress) {
-      CircularProgressIndicator()
+      CircularProgressIndicator(modifier = modifier)
     } else {
-      Text("Login")
+      Text("Login", modifier = modifier)
     }
   }
 }
@@ -72,11 +72,16 @@ class LoginRenderer : ViewRenderer<Model>() {
 
     ```kotlin
     @Composable
-    fun renderCompose(model: ModelT)
+    fun renderCompose(model: ModelT, modifier: Modifier = Modifier)
     ```
 
     In practice this is less of a concern, because the `render(model)` function is deprecated and hidden and callers
-    only see the `renderCompose(model)` function.
+    only see the `renderCompose(model, modifier)` function. The `modifier` parameter defaults to `Modifier`, so simple
+    call sites can continue to use `renderCompose(model)`.
+
+`ComposeRenderer.Compose()` also receives the `Modifier` from `renderCompose()`. Renderer implementations should apply
+this value to their root composable, matching the usual Compose convention for UI-emitting functions. This lets parents
+and platform entrypoints attach layout, testing, accessibility, or pointer-input behavior at the renderer boundary.
 
 Renderers are composable and can build hierarchies similar to `Presenters`. The parent renderer is responsible for
 calling `render()` on the child renderer:
@@ -106,9 +111,10 @@ A `Renderer` sends events back to the `Presenter` through the `onEvent` lambda o
 @ContributesRenderer
 class LoginRenderer : ComposeRenderer<Model>() {
   @Composable
-  override fun Compose(model: Model) {
+  override fun Compose(model: Model, modifier: Modifier) {
     Button(
       onClick = { model.onEvent(LoginPresenter.Event.Login("Demo")) },
+      modifier = modifier,
     ) {
       Text("Login")
     }
@@ -262,14 +268,15 @@ fun mainViewController(rootScopeProvider: RootScopeProvider): UIViewController =
     val model = presenter.present(Unit)
 
     val renderer = factory.getComposeRenderer(model)
-    renderer.renderCompose(model)
+    renderer.renderCompose(model, modifier = Modifier.fillMaxSize())
   }
 ```
 
 !!! note
 
     Note that `getRenderer()` for `ComposeRendererFactory` returns a `ComposeRenderer`. For a `ComposeRenderer` the
-    `renderCompose(model)` function must be called and not `render(model)`.
+    `renderCompose(model, modifier)` function must be called and not `render(model)`. The `modifier` argument is
+    optional.
 
 ```kotlin title="Android Activity"
 class MainActivity : ComponentActivity() {
@@ -308,9 +315,11 @@ class SampleRenderer(
 ) : ComposeRenderer<Model>() {
 
   @Composable
-  override fun Compose(model: Model) {
-    val childRenderer = rendererFactory.getComposeRenderer(model.childModel)
-    childRenderer.renderCompose(model.childModel)
+  override fun Compose(model: Model, modifier: Modifier) {
+    Column(modifier = modifier) {
+      val childRenderer = rendererFactory.getComposeRenderer(model.childModel)
+      childRenderer.renderCompose(model.childModel)
+    }
   }
 }
 ```

--- a/docs/template.md
+++ b/docs/template.md
@@ -91,10 +91,12 @@ class ComposeSampleAppTemplateRenderer(
 ) : ComposeRenderer<SampleAppTemplate>() {
 
   @Composable
-  override fun Compose(model: SampleAppTemplate) {
-    when (model) {
-      is SampleAppTemplate.FullScreenTemplate -> FullScreen(model)
-      is SampleAppTemplate.ListDetailTemplate -> ListDetail(model)
+  override fun Compose(model: SampleAppTemplate, modifier: Modifier) {
+    Box(modifier = modifier) {
+      when (model) {
+        is SampleAppTemplate.FullScreenTemplate -> FullScreen(model)
+        is SampleAppTemplate.ListDetailTemplate -> ListDetail(model)
+      }
     }
   }
 

--- a/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/appbar/menu/MenuPresenter.kt
+++ b/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/appbar/menu/MenuPresenter.kt
@@ -72,7 +72,7 @@ class MenuPresenter : MoleculePresenter<Unit, Model> {
 @ContributesRenderer
 class MenuRenderer : ComposeRenderer<Model>() {
   @Composable
-  override fun Compose(model: Model) {
+  override fun Compose(model: Model, modifier: Modifier) {
     Column(
       modifier = Modifier.fillMaxSize().padding(top = 12.dp),
       horizontalAlignment = Alignment.CenterHorizontally,

--- a/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/backstack/CrossSlideBackstackRenderer.kt
+++ b/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/backstack/CrossSlideBackstackRenderer.kt
@@ -35,7 +35,7 @@ class CrossSlideBackstackRenderer(private val rendererFactory: RendererFactory) 
   ComposeRenderer<Model>() {
 
   @Composable
-  override fun Compose(model: Model) {
+  override fun Compose(model: Model, modifier: Modifier) {
     Column(modifier = Modifier.fillMaxSize()) {
       CrossSlide(
         targetState = model.delegate,

--- a/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/backstack/presenter/BackstackChildPresenter.kt
+++ b/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/backstack/presenter/BackstackChildPresenter.kt
@@ -68,7 +68,7 @@ class BackstackChildPresenter(private val index: Int) : MoleculePresenter<Unit, 
 @ContributesRenderer
 class BackstackChildRenderer : ComposeRenderer<Model>() {
   @Composable
-  override fun Compose(model: Model) {
+  override fun Compose(model: Model, modifier: Modifier) {
     Column(
       modifier = Modifier.fillMaxSize().padding(top = 12.dp),
       horizontalAlignment = Alignment.CenterHorizontally,

--- a/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/landing/LandingRenderer.kt
+++ b/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/landing/LandingRenderer.kt
@@ -17,7 +17,7 @@ import software.amazon.app.platform.renderer.ComposeRenderer
 @ContributesRenderer
 class LandingRenderer : ComposeRenderer<Model>() {
   @Composable
-  override fun Compose(model: Model) {
+  override fun Compose(model: Model, modifier: Modifier) {
     Column(
       modifier = Modifier.fillMaxSize().padding(top = 12.dp),
       horizontalAlignment = Alignment.CenterHorizontally,

--- a/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/nav3/Navigation3ChildRenderer.kt
+++ b/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/nav3/Navigation3ChildRenderer.kt
@@ -19,8 +19,8 @@ import software.amazon.app.platform.renderer.ComposeRenderer
 @ContributesRenderer
 class Navigation3ChildRenderer : ComposeRenderer<Model>() {
   @Composable
-  override fun Compose(model: Model) {
-    Box(modifier = Modifier.Companion.fillMaxSize().background(Color(model.color))) {
+  override fun Compose(model: Model, modifier: Modifier) {
+    Box(modifier = Modifier.fillMaxSize().background(Color(model.color))) {
       Column {
         Text("Index: ${model.index}")
         Text("Count: ${model.counter}")
@@ -28,7 +28,7 @@ class Navigation3ChildRenderer : ComposeRenderer<Model>() {
 
       Button(
         onClick = { model.onEvent(Navigation3ChildPresenter.Event.AddPresenter) },
-        modifier = Modifier.Companion.align(Alignment.Companion.Center),
+        modifier = Modifier.align(Alignment.Center),
       ) {
         Text("Add Presenter")
       }

--- a/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/nav3/Navigation3HomeRenderer.kt
+++ b/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/nav3/Navigation3HomeRenderer.kt
@@ -1,6 +1,7 @@
 package software.amazon.app.platform.recipes.nav3
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.ui.NavDisplay
 import me.tatarka.inject.annotations.Inject
@@ -21,7 +22,7 @@ import software.amazon.app.platform.renderer.getComposeRenderer
 class Navigation3HomeRenderer(private val rendererFactory: RendererFactory) :
   ComposeRenderer<Model>() {
   @Composable
-  override fun Compose(model: Model) {
+  override fun Compose(model: Model, modifier: Modifier) {
     // Use the position of the model in the backstack as key for `NavDisplay`. This way
     // we can update models without Navigation 3 treating those changes as a new screen.
     val backstack = model.backstack.mapIndexed { index, _ -> index }

--- a/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/template/RootPresenterRenderer.kt
+++ b/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/template/RootPresenterRenderer.kt
@@ -51,7 +51,7 @@ class RootPresenterRenderer(
   private val backGestureDispatcherPresenter: BackGestureDispatcherPresenter,
 ) : ComposeRenderer<RecipesAppTemplate>() {
   @Composable
-  override fun Compose(model: RecipesAppTemplate) {
+  override fun Compose(model: RecipesAppTemplate, modifier: Modifier) {
     backGestureDispatcherPresenter.ForwardBackPressEventsToPresenters()
 
     when (model) {

--- a/renderer-compose-multiplatform/public/api/android/public.api
+++ b/renderer-compose-multiplatform/public/api/android/public.api
@@ -3,7 +3,11 @@ public final class software/amazon/app/platform/presenter/molecule/backgesture/B
 }
 
 public abstract interface class software/amazon/app/platform/renderer/BaseComposeRenderer {
-	public abstract fun renderCompose (Lsoftware/amazon/app/platform/presenter/BaseModel;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun renderCompose (Lsoftware/amazon/app/platform/presenter/BaseModel;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
+}
+
+public final class software/amazon/app/platform/renderer/BaseComposeRenderer$ComposeDefaultImpls {
+	public static final fun renderCompose$default (Lsoftware/amazon/app/platform/presenter/BaseModel;Landroidx/compose/ui/Modifier;Lsoftware/amazon/app/platform/renderer/BaseComposeRenderer;Landroidx/compose/runtime/Composer;II)V
 }
 
 public abstract interface class software/amazon/app/platform/renderer/ComposeAndroidRendererFactory : software/amazon/app/platform/renderer/RendererFactory {
@@ -18,10 +22,10 @@ public final class software/amazon/app/platform/renderer/ComposeAndroidRendererF
 public abstract class software/amazon/app/platform/renderer/ComposeRenderer : software/amazon/app/platform/renderer/BaseComposeRenderer, software/amazon/app/platform/renderer/Renderer {
 	public static final field $stable I
 	public fun <init> ()V
-	protected abstract fun Compose (Lsoftware/amazon/app/platform/presenter/BaseModel;Landroidx/compose/runtime/Composer;I)V
+	protected abstract fun Compose (Lsoftware/amazon/app/platform/presenter/BaseModel;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
 	public final synthetic fun render (Lsoftware/amazon/app/platform/presenter/BaseModel;)Ljava/lang/Void;
 	public synthetic fun render (Lsoftware/amazon/app/platform/presenter/BaseModel;)V
-	public final fun renderCompose (Lsoftware/amazon/app/platform/presenter/BaseModel;Landroidx/compose/runtime/Composer;I)V
+	public final fun renderCompose (Lsoftware/amazon/app/platform/presenter/BaseModel;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
 }
 
 public final class software/amazon/app/platform/renderer/ComposeRendererFactory : software/amazon/app/platform/renderer/BaseRendererFactory {

--- a/renderer-compose-multiplatform/public/api/desktop/public.api
+++ b/renderer-compose-multiplatform/public/api/desktop/public.api
@@ -3,16 +3,20 @@ public final class software/amazon/app/platform/presenter/molecule/backgesture/B
 }
 
 public abstract interface class software/amazon/app/platform/renderer/BaseComposeRenderer {
-	public abstract fun renderCompose (Lsoftware/amazon/app/platform/presenter/BaseModel;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun renderCompose (Lsoftware/amazon/app/platform/presenter/BaseModel;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
+}
+
+public final class software/amazon/app/platform/renderer/BaseComposeRenderer$ComposeDefaultImpls {
+	public static final fun renderCompose$default (Lsoftware/amazon/app/platform/presenter/BaseModel;Landroidx/compose/ui/Modifier;Lsoftware/amazon/app/platform/renderer/BaseComposeRenderer;Landroidx/compose/runtime/Composer;II)V
 }
 
 public abstract class software/amazon/app/platform/renderer/ComposeRenderer : software/amazon/app/platform/renderer/BaseComposeRenderer, software/amazon/app/platform/renderer/Renderer {
 	public static final field $stable I
 	public fun <init> ()V
-	protected abstract fun Compose (Lsoftware/amazon/app/platform/presenter/BaseModel;Landroidx/compose/runtime/Composer;I)V
+	protected abstract fun Compose (Lsoftware/amazon/app/platform/presenter/BaseModel;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
 	public final synthetic fun render (Lsoftware/amazon/app/platform/presenter/BaseModel;)Ljava/lang/Void;
 	public synthetic fun render (Lsoftware/amazon/app/platform/presenter/BaseModel;)V
-	public final fun renderCompose (Lsoftware/amazon/app/platform/presenter/BaseModel;Landroidx/compose/runtime/Composer;I)V
+	public final fun renderCompose (Lsoftware/amazon/app/platform/presenter/BaseModel;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
 }
 
 public final class software/amazon/app/platform/renderer/ComposeRendererFactory : software/amazon/app/platform/renderer/BaseRendererFactory {

--- a/renderer-compose-multiplatform/public/src/androidInstrumentedTest/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/ForwardBackPressEventsToPresentersComposeTest.kt
+++ b/renderer-compose-multiplatform/public/src/androidInstrumentedTest/kotlin/software/amazon/app/platform/presenter/molecule/backgesture/ForwardBackPressEventsToPresentersComposeTest.kt
@@ -59,7 +59,7 @@ class ForwardBackPressEventsToPresentersComposeTest {
     private val testRenderer: TestRenderer,
   ) : ComposeRenderer<Model>() {
     @Composable
-    override fun Compose(model: Model) {
+    override fun Compose(model: Model, modifier: Modifier) {
       backGestureDispatcherPresenter.ForwardBackPressEventsToPresenters()
 
       testRenderer.renderCompose(model)
@@ -87,7 +87,7 @@ class ForwardBackPressEventsToPresentersComposeTest {
 
   private class TestRenderer : ComposeRenderer<Model>() {
     @Composable
-    override fun Compose(model: Model) {
+    override fun Compose(model: Model, modifier: Modifier) {
       BasicText(text = "Count: ${model.backPressCount}", modifier = Modifier.testTag("count"))
     }
   }

--- a/renderer-compose-multiplatform/public/src/androidInstrumentedTest/kotlin/software/amazon/app/platform/renderer/ComposeAndroidRendererFactoryDeviceTest.kt
+++ b/renderer-compose-multiplatform/public/src/androidInstrumentedTest/kotlin/software/amazon/app/platform/renderer/ComposeAndroidRendererFactoryDeviceTest.kt
@@ -405,7 +405,7 @@ class ComposeAndroidRendererFactoryDeviceTest {
     }
 
     @Composable
-    override fun Compose(model: ComposeModel) {
+    override fun Compose(model: ComposeModel, modifier: Modifier) {
       Column {
         BasicText(text = "Compose test: ${model.value}", modifier = Modifier.testTag("testCompose"))
 

--- a/renderer-compose-multiplatform/public/src/androidMain/kotlin/software/amazon/app/platform/renderer/AndroidViewWithinComposeRenderer.kt
+++ b/renderer-compose-multiplatform/public/src/androidMain/kotlin/software/amazon/app/platform/renderer/AndroidViewWithinComposeRenderer.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
 import software.amazon.app.platform.presenter.BaseModel
 
@@ -41,7 +42,7 @@ internal class AndroidViewWithinComposeRenderer<in ModelT : BaseModel>(
 
   @Suppress("ComposableNaming")
   @Composable
-  override fun renderCompose(model: ModelT) {
+  override fun renderCompose(model: ModelT, modifier: Modifier) {
     AndroidView(
       factory = { context ->
         // Create a FrameLayout as parent. It's technically not needed, but the

--- a/renderer-compose-multiplatform/public/src/androidMain/kotlin/software/amazon/app/platform/renderer/BaseComposeWithinAndroidViewRenderer.kt
+++ b/renderer-compose-multiplatform/public/src/androidMain/kotlin/software/amazon/app/platform/renderer/BaseComposeWithinAndroidViewRenderer.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import kotlinx.coroutines.flow.MutableStateFlow
 import software.amazon.app.platform.presenter.BaseModel
@@ -46,7 +47,7 @@ internal abstract class BaseComposeWithinAndroidViewRenderer<in ModelT : BaseMod
 
   @Suppress("ComposableNaming")
   @Composable
-  final override fun renderCompose(model: ModelT) {
+  final override fun renderCompose(model: ModelT, modifier: Modifier) {
     Compose(model)
   }
 

--- a/renderer-compose-multiplatform/public/src/androidUnitTest/kotlin/software/amazon/app/platform/renderer/ComposeAndroidRendererFactoryTest.kt
+++ b/renderer-compose-multiplatform/public/src/androidUnitTest/kotlin/software/amazon/app/platform/renderer/ComposeAndroidRendererFactoryTest.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.isInstanceOf
@@ -89,7 +90,7 @@ class ComposeAndroidRendererFactoryTest {
   private class UnsupportedModel : BaseModel
 
   private class TestComposeRenderer : ComposeRenderer<ComposeModel>() {
-    @Composable override fun Compose(model: ComposeModel) = Unit
+    @Composable override fun Compose(model: ComposeModel, modifier: Modifier) = Unit
   }
 
   private class TestAndroidRenderer : ViewRenderer<AndroidModel>() {

--- a/renderer-compose-multiplatform/public/src/commonMain/kotlin/software/amazon/app/platform/renderer/BaseComposeRenderer.kt
+++ b/renderer-compose-multiplatform/public/src/commonMain/kotlin/software/amazon/app/platform/renderer/BaseComposeRenderer.kt
@@ -25,7 +25,7 @@ import software.amazon.app.platform.presenter.BaseModel
 // vs this BaseComposeRenderer API. Note that BaseComposeRenderer is not extending the Renderer
 // interface. This distinction is similar to Presenter and MoleculePresenter.
 public interface BaseComposeRenderer<in ModelT : BaseModel> {
-  /** Render the given [model] on screen using Compose UI. */
+  /** Render the given [model] on screen using Compose UI with the provided [modifier]. */
   // Android Lint will complain that this function should start with an uppercase letter, but
   // the name "renderCompose" was chosen to align it with the "render" function from the
   // Renderer interface. Implementations will usually have a separate "Compose()" function, see

--- a/renderer-compose-multiplatform/public/src/commonMain/kotlin/software/amazon/app/platform/renderer/BaseComposeRenderer.kt
+++ b/renderer-compose-multiplatform/public/src/commonMain/kotlin/software/amazon/app/platform/renderer/BaseComposeRenderer.kt
@@ -1,6 +1,7 @@
 package software.amazon.app.platform.renderer
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import software.amazon.app.platform.presenter.BaseModel
 
 /**
@@ -24,11 +25,10 @@ import software.amazon.app.platform.presenter.BaseModel
 // vs this BaseComposeRenderer API. Note that BaseComposeRenderer is not extending the Renderer
 // interface. This distinction is similar to Presenter and MoleculePresenter.
 public interface BaseComposeRenderer<in ModelT : BaseModel> {
-
   /** Render the given [model] on screen using Compose UI. */
   // Android Lint will complain that this function should start with an uppercase letter, but
   // the name "renderCompose" was chosen to align it with the "render" function from the
   // Renderer interface. Implementations will usually have a separate "Compose()" function, see
   // ComposeRenderer for example.
-  @Composable public fun renderCompose(model: ModelT)
+  @Composable public fun renderCompose(model: ModelT, modifier: Modifier = Modifier)
 }

--- a/renderer-compose-multiplatform/public/src/commonMain/kotlin/software/amazon/app/platform/renderer/ComposeRenderer.kt
+++ b/renderer-compose-multiplatform/public/src/commonMain/kotlin/software/amazon/app/platform/renderer/ComposeRenderer.kt
@@ -1,6 +1,7 @@
 package software.amazon.app.platform.renderer
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import software.amazon.app.platform.presenter.BaseModel
 
 /**
@@ -58,14 +59,16 @@ public abstract class ComposeRenderer<in ModelT : BaseModel> :
   }
 
   @Composable
-  final override fun renderCompose(model: ModelT) {
+  final override fun renderCompose(model: ModelT, modifier: Modifier) {
     // This function seems redundant and implementations could implement it instead of the
     // separate Compose() function. However, it will allow us to intercept rendering calls
     // in the platform for future use cases. Compare this with ViewRenderer.render() and
     // ViewRenderer.renderModel().
-    Compose(model)
+    Compose(model, modifier)
   }
 
   /** Render the given [model] on screen using Compose UI. */
-  @Suppress("FunctionName") @Composable protected abstract fun Compose(model: ModelT)
+  @Suppress("FunctionName")
+  @Composable
+  protected abstract fun Compose(model: ModelT, modifier: Modifier)
 }

--- a/renderer-compose-multiplatform/public/src/commonMain/kotlin/software/amazon/app/platform/renderer/ComposeRenderer.kt
+++ b/renderer-compose-multiplatform/public/src/commonMain/kotlin/software/amazon/app/platform/renderer/ComposeRenderer.kt
@@ -15,9 +15,10 @@ import software.amazon.app.platform.presenter.BaseModel
  * @ContributesRenderer
  * class MyRenderer : ComposeRenderer<MyModel>() {
  *     @Composable
- *     override fun Compose(model: MyModel) {
+ *     override fun Compose(model: MyModel, modifier: Modifier) {
  *         Text(
  *             text = "MyModel value: ${model.value}",
+ *             modifier = modifier,
  *         )
  *     }
  * }
@@ -29,7 +30,7 @@ import software.amazon.app.platform.presenter.BaseModel
  * ```
  * // Do this
  * @Composable
- * override fun Compose(model: MyModel) {
+ * override fun Compose(model: MyModel, modifier: Modifier) {
  *     var string by remember { mutableStateOf(..) }
  * }
  *
@@ -37,7 +38,7 @@ import software.amazon.app.platform.presenter.BaseModel
  * private var string: String? = null
  *
  * @Composable
- * override fun Compose(model: MyModel) {
+ * override fun Compose(model: MyModel, modifier: Modifier) {
  *     string = ...
  * }
  * ```

--- a/renderer-compose-multiplatform/public/src/desktopTest/kotlin/software/amazon/app/platform/renderer/ComposeRendererFactoryTest.kt
+++ b/renderer-compose-multiplatform/public/src/desktopTest/kotlin/software/amazon/app/platform/renderer/ComposeRendererFactoryTest.kt
@@ -1,6 +1,7 @@
 package software.amazon.app.platform.renderer
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import assertk.all
 import assertk.assertFailure
 import assertk.assertThat
@@ -92,7 +93,7 @@ class ComposeRendererFactoryTest {
   private class AndroidModel : BaseModel
 
   private class TestComposeRenderer : ComposeRenderer<ComposeModel>() {
-    @Composable override fun Compose(model: ComposeModel) = Unit
+    @Composable override fun Compose(model: ComposeModel, modifier: Modifier) = Unit
   }
 
   private class AndroidRenderer : Renderer<AndroidModel> {

--- a/renderer-compose-multiplatform/public/src/desktopTest/kotlin/software/amazon/app/platform/renderer/ComposeRendererTest.kt
+++ b/renderer-compose-multiplatform/public/src/desktopTest/kotlin/software/amazon/app/platform/renderer/ComposeRendererTest.kt
@@ -41,6 +41,17 @@ class ComposeRendererTest {
   }
 
   @Test
+  fun `renderCompose forwards its modifier to Compose`() {
+    runComposeUiTest {
+      val renderer = ModifierRenderer()
+
+      setContent { renderer.renderCompose(Model(1), Modifier.testTag("forwarded-modifier")) }
+
+      onNodeWithTag("forwarded-modifier").assertTextEquals("Argument 1")
+    }
+  }
+
+  @Test
   fun `a ComposeRenderer can nest other ComposeRenderers`() {
     runComposeUiTest {
       val renderer = OuterRenderer(TestRenderer())
@@ -64,14 +75,21 @@ class ComposeRendererTest {
 
   private class TestRenderer : ComposeRenderer<Model>() {
     @Composable
-    override fun Compose(model: Model) {
+    override fun Compose(model: Model, modifier: Modifier) {
       Text(text = "Argument ${model.value}", modifier = Modifier.testTag("text"))
+    }
+  }
+
+  private class ModifierRenderer : ComposeRenderer<Model>() {
+    @Composable
+    override fun Compose(model: Model, modifier: Modifier) {
+      Text(text = "Argument ${model.value}", modifier = modifier)
     }
   }
 
   private class OuterRenderer(private val testRenderer: TestRenderer) : ComposeRenderer<Model>() {
     @Composable
-    override fun Compose(model: Model) {
+    override fun Compose(model: Model, modifier: Modifier) {
       Column {
         Text(text = "Outer ${model.value}", modifier = Modifier.testTag("text-outer"))
         testRenderer.renderCompose(model)

--- a/sample/login/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/login/LoginRenderer.kt
+++ b/sample/login/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/login/LoginRenderer.kt
@@ -20,7 +20,7 @@ import software.amazon.app.platform.sample.login.LoginPresenter.Model
 @ContributesRenderer
 class LoginRenderer : ComposeRenderer<Model>() {
   @Composable
-  override fun Compose(model: Model) {
+  override fun Compose(model: Model, modifier: Modifier) {
     Column(
       modifier = Modifier.fillMaxSize(),
       verticalArrangement = Arrangement.Center,

--- a/sample/templates/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/template/ComposeSampleAppTemplateRenderer.kt
+++ b/sample/templates/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/template/ComposeSampleAppTemplateRenderer.kt
@@ -38,7 +38,7 @@ class ComposeSampleAppTemplateRenderer(
 ) : ComposeRenderer<SampleAppTemplate>() {
 
   @Composable
-  override fun Compose(model: SampleAppTemplate) {
+  override fun Compose(model: SampleAppTemplate, modifier: Modifier) {
     backGestureDispatcherPresenter.ForwardBackPressEventsToPresenters()
 
     Box(Modifier.windowInsetsPadding(WindowInsets.safeDrawing)) {

--- a/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserPageDetailRenderer.kt
+++ b/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserPageDetailRenderer.kt
@@ -40,7 +40,7 @@ import software.amazon.app.platform.sample.user.UserPageDetailPresenter.Model
 class UserPageDetailRenderer : ComposeRenderer<Model>() {
 
   @Composable
-  override fun Compose(model: Model) {
+  override fun Compose(model: Model, modifier: Modifier) {
     if (model.showPictureFullscreen) {
       ProfilePicture(model)
     } else {

--- a/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserPageListRenderer.kt
+++ b/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserPageListRenderer.kt
@@ -28,7 +28,7 @@ import software.amazon.app.platform.sample.user.UserPageListPresenter.Model
 class UserPageListRenderer : ComposeRenderer<Model>() {
 
   @Composable
-  override fun Compose(model: Model) {
+  override fun Compose(model: Model, modifier: Modifier) {
     Column(modifier = Modifier.fillMaxWidth().fillMaxHeight()) {
       Text(
         text = "User: ${model.userId}",


### PR DESCRIPTION
Add an optional Modifier parameter to `BaseComposeRenderer.renderCompose()` and forward it through `ComposeRenderer.Compose()`, updating renderer implementations, tests, API dumps, and the changelog for the new signature.

Compose UI-emitting functions conventionally accept a Modifier so callers can attach layout, test tags, accessibility, and other modifier behavior at the call site. The default Modifier keeps simple `renderCompose()` calls concise while still making the renderer boundary customizable when needed.
