### PR TITLE
docs: fix occured typo in SwiftUiRootPresenterView fatalError

### DIFF
--- a/recipes/recipesIosApp/recipesIosApp/SwiftUI/SwiftUiRootPresenterView.swift
+++ b/recipes/recipesIosApp/recipesIosApp/SwiftUI/SwiftUiRootPresenterView.swift
@@ -17,7 +17,7 @@ struct SwiftUiRootPresenterView: View {
             presenter: homePresenter,
             viewModelType: BaseModel.self,
             handleViewModelError: { error in
-                fatalError("View model error occured: \(error)")
+                fatalError("View model error occurred: \(error)")
             }
         )
     }


### PR DESCRIPTION
Fix "occured" -> "occurred" in the fatalError message of SwiftUiRootPresenterView.swift.