### PR TITLE
Make `@Inject` optional for Metro contributions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - `@ContributesRobot` no longer requires `@Inject` for robots with constructor parameters. The generated contribution now provides a constructor-calling `@Provides` function that injects the same arguments.
 - `@ContributesRenderer` no longer requires `@Inject` for renderers with constructor parameters. The generated contribution now provides a constructor-calling `@Provides` function and reports an error when multiple constructors make that provider ambiguous.
+- `@ContributesScoped` no longer requires `@Inject` for classes with constructor parameters. The generated contribution now provides a constructor-calling `@Provides` function and reports an error when multiple constructors make that provider ambiguous.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 - `@ContributesRobot` no longer requires `@Inject` for robots with constructor parameters. The generated contribution now provides a constructor-calling `@Provides` function that injects the same arguments.
+- `@ContributesRenderer` no longer requires `@Inject` for renderers with constructor parameters. The generated contribution now provides a constructor-calling `@Provides` function and reports an error when multiple constructors make that provider ambiguous.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- `@ContributesRobot` no longer requires `@Inject` for robots with constructor parameters. The generated contribution now provides a constructor-calling `@Provides` function that injects the same arguments.
+
 ### Deprecated
 
 ### Removed

--- a/docs/di.md
+++ b/docs/di.md
@@ -117,7 +117,6 @@ interface LocationProvider
 === "Android"
 
     ```kotlin title="androidMain"
-    @Inject
     @SingleIn(AppScope::class)
     @ContributesBinding(AppScope::class)
     class AndroidLocationProvider(
@@ -128,7 +127,6 @@ interface LocationProvider
 === "iOS"
 
     ```kotlin title="iosMain"
-    @Inject
     @SingleIn(AppScope::class)
     @ContributesBinding(AppScope::class)
     class IosLocationProvider(
@@ -139,7 +137,6 @@ interface LocationProvider
 === "Desktop"
 
     ```kotlin title="desktopMain"
-    @Inject
     @SingleIn(AppScope::class)
     @ContributesBinding(AppScope::class)
     class DesktopLocationProvider(
@@ -150,7 +147,6 @@ interface LocationProvider
 === "WasmJs"
 
     ```kotlin title="wasmJsMain"
-    @Inject
     @SingleIn(AppScope::class)
     @ContributesBinding(AppScope::class)
     class WasmLocationProvider(
@@ -298,8 +294,7 @@ multi-bindings for the `Scoped` interface. This is a lot of boilerplate to write
 `@ContributesScoped` instead. When using `@ContributesScoped`, all bindings are generated and `@ContributesBinding`
 doesn't need to be added. A typical implementation looks like this:
 
-```kotlin hl_lines="3"
-@Inject
+```kotlin hl_lines="2"
 @SingleIn(AppScope::class)
 @ContributesScoped(AppScope::class)
 class AndroidLocationProvider : LocationProvider, Scoped

--- a/docs/presenter.md
+++ b/docs/presenter.md
@@ -102,7 +102,6 @@ interface LoginPresenter : MoleculePresenter<Unit, Model> {
 A concrete implementation of `LoginPresenter` could look like this:
 
 ```kotlin
-@Inject
 @ContributesBinding(AppScope::class)
 class AmazonLoginPresenter : LoginPresenter {
   @Composable
@@ -124,10 +123,12 @@ class AmazonLoginPresenter : LoginPresenter {
 
 !!! note
 
-    `MoleculePresenters` are never singletons. While they use Metro or `kotlin-inject-anvil` for constructor injection and
-    automatically bind the concrete implementation to an API using `@ContributesBinding`, they don't use the
-    `@SingleIn` annotation. `MoleculePresenters` manage their state in the `@Composable` function with the Compose
-    runtime. Therefore, it's strongly discouraged to have any class properties.
+    `MoleculePresenters` are never singletons. They are automatically bound to an API using
+    `@ContributesBinding`, but they don't use the `@SingleIn` annotation. Metro can instantiate a
+    contributed presenter with a single constructor without `@Inject`; `kotlin-inject-anvil` users
+    should still use `@Inject` for constructor injection. `MoleculePresenters` manage their state in
+    the `@Composable` function with the Compose runtime. Therefore, it's strongly discouraged to have
+    any class properties.
 
 ## Model driven navigation
 
@@ -452,7 +453,6 @@ The last step is to forward back gestures from the UI layer to `Presenters` to i
 `Presenters`. Here again it's recommended to do this from within the root `Renderer`:
 
 ```kotlin hl_lines="4 8"
-@Inject
 @ContributesRenderer
 class RootPresenterRenderer(
   private val backGestureDispatcherPresenter: BackGestureDispatcherPresenter,
@@ -942,7 +942,6 @@ wraps the backstack in a `NavDisplay` and forwards back gestures to the `Present
 for each position in the stack and the individual `Renderer` for each `Model` is invoked:
 
 ```kotlin
-@Inject
 @ContributesRenderer
 class Navigation3HomeRenderer(private val rendererFactory: RendererFactory) : ComposeRenderer<Model>() {
   @Composable
@@ -977,7 +976,6 @@ With this integration handling of the backstack is managed in the `Presenter` an
     data object List
     data object Detail
 
-    @Inject
     @ContributesRenderer
     class Navigation3Renderer(
       private val listPresenter: ListPresenter,

--- a/docs/renderer.md
+++ b/docs/renderer.md
@@ -153,11 +153,11 @@ different implementations:
 ### `@ContributesRenderer`
 
 All factory implementations rely on Metro or `kotlin-inject-anvil` to discover and initialize
-renderers. When the factory is created, it builds the generated renderer graph or component, whose
-parent is the app graph or component. That generated type lazily provides all renderers using the
+renderers. When the factory is created, it builds the generated renderer bindings, whose parent is
+the app graph or component. Those generated bindings lazily provide all renderers using the
 multibindings feature. To participate in the lookup, renderers must tell Metro or
-`kotlin-inject-anvil` which models they can render. This is done through a generated graph or
-component interface, which is automatically added to the renderer scope by using the
+`kotlin-inject-anvil` which models they can render. This is done through generated bindings, which
+are automatically added to the renderer scope by using the
 [`@ContributesRenderer` annotation](https://github.com/amzn/app-platform/blob/main/kotlin-inject-extensions/contribute/public/src/commonMain/kotlin/software/amazon/app/platform/inject/ContributesRenderer.kt).
 
 Which `Model` type is used for the binding is determined based on the super type. In the following example
@@ -176,20 +176,25 @@ class LoginRenderer : ComposeRenderer<LoginPresenter.Model>()
     
         ```kotlin
         @ContributesTo(RendererScope::class)
-        interface LoginRendererGraph {
-          @Provides
-          public fun provideSoftwareAmazonAppPlatformSampleLoginLoginRenderer(): LoginRenderer = LoginRenderer()
-    
-          @Provides
+        @BindingContainer
+        @Origin(LoginRenderer::class)
+        interface LoginRendererContribution {
+          @Binds
           @IntoMap
           @RendererKey(LoginPresenter.Model::class)
-          public fun provideSoftwareAmazonAppPlatformSampleLoginLoginRendererLoginPresenterModel(renderer: () -> LoginRenderer): Renderer<*> = renderer()
-    
-          @Provides
-          @IntoMap
-          @ForScope(scope = RendererScope::class)
-          @RendererKey(LoginPresenter.Model::class)
-          public fun provideSoftwareAmazonAppPlatformSampleLoginLoginRendererLoginPresenterModelKey(): KClass<out Renderer<*>> = LoginRenderer::class
+          public fun bindLoginRendererModel(renderer: LoginRenderer): Renderer<*>
+
+          companion object {
+            @Provides
+            public fun provideLoginRenderer(): LoginRenderer = LoginRenderer()
+
+            @Provides
+            @IntoMap
+            @ForScope(scope = RendererScope::class)
+            @RendererKey(LoginPresenter.Model::class)
+            public fun provideLoginRendererModelKey(): KClass<out Renderer<*>> =
+              LoginRenderer::class
+          }
         }
         ```
 
@@ -303,12 +308,11 @@ class MainActivity : ComponentActivity() {
 
 ### Injecting `RendererFactory`
 
-The `RendererFactory` is provided in the `RendererComponent`, meaning it can be injected by any `Renderer`. This
-allows you to create child renderers without knowing the concrete type of the model and injecting the child
-renderers ahead of time:
+The `RendererFactory` is provided in the generated renderer graph or component, meaning it can be
+injected by any `Renderer`. This allows you to create child renderers without knowing the concrete
+type of the model and injecting the child renderers ahead of time:
 
 ```kotlin
-@Inject
 @ContributesRenderer
 class SampleRenderer(
   private val rendererFactory: RendererFactory
@@ -331,8 +335,9 @@ class SampleRenderer(
 
 !!! note
 
-    Whenever a `Renderer` has an injected constructor parameter like `rendererFactory` in the sample above, then
-    the class must be annotated with `@Inject` in addition to `@ContributesRenderer`.
+    A `Renderer` with a single constructor does not need `@Inject`. Constructor parameters like
+    `rendererFactory` are injected through the generated provider. Add `@Inject` only when the
+    renderer has multiple constructors and one must be selected explicitly.
 
 ## Android support
 

--- a/docs/scope.md
+++ b/docs/scope.md
@@ -354,9 +354,8 @@ With Metro, or alternatively `kotlin-inject-anvil`, for the app scope it would b
 === "Metro"
 
     ```kotlin
-    @Inject // (1)!
-    @SingleIn(AppScope::class) // (2)!
-    @ContributesScoped(AppScope::class) //(3)!
+    @SingleIn(AppScope::class) // (1)!
+    @ContributesScoped(AppScope::class) // (2)!
     class AndroidLocationProvider(
       ...
     ) : LocationProvider, Scoped {
@@ -364,23 +363,40 @@ With Metro, or alternatively `kotlin-inject-anvil`, for the app scope it would b
     }
     ```
 
-    1.  This annotation is required to support constructor injection.
-    2.  This annotation ensures that there is only ever a single instance of `AndroidLocationProvider` in the `AppScope`.
-    3.  This annotation ensures that when somebody injects `LocationProvider`, then they get the singleton instance of `AndroidLocationProvider`.
+    1.  This annotation ensures that there is only ever a single instance of `AndroidLocationProvider` in the `AppScope`.
+    2.  This annotation ensures that when somebody injects `LocationProvider`, then they get the singleton instance of `AndroidLocationProvider`.
 
     ??? note "`@ContributesScoped` will generate and contribute bindings"
 
-        The `@ContributesScoped` annotation will generate a graph interface with bindings for `LocationProvider`
-        and `Scoped`. The generated interface will be added automatically to the `AppScope`. No further manual step
+        The `@ContributesScoped` annotation will generate a binding container with bindings for `LocationProvider`
+        and `Scoped`. The generated container will be added automatically to the `AppScope`. No further manual step
         is needed.
 
         ```kotlin
-        @Binds
-        val AndroidLocationProvider.binds: LocationProvider
+        @ContributesTo(AppScope::class)
+        @BindingContainer
+        @Origin(AndroidLocationProvider::class)
+        interface AndroidLocationProviderContribution {
+          @Binds
+          fun bindAndroidLocationProvider(instance: AndroidLocationProvider): LocationProvider
 
-        @Binds @IntoSet @ForScope(AppScope::class)
-        val AndroidLocationProvider.bindsScoped: Scoped
+          @Binds
+          @IntoSet
+          @ForScope(AppScope::class)
+          fun bindAndroidLocationProviderScoped(instance: AndroidLocationProvider): Scoped
+
+          companion object {
+            @Provides
+            fun provideAndroidLocationProvider(
+              locationManager: LocationManager
+            ): AndroidLocationProvider = AndroidLocationProvider(locationManager)
+          }
+        }
         ```
+
+        If the class has an `@Inject` constructor, the generated constructor provider is skipped
+        and only the bindings are generated. If it has multiple constructors, annotate the
+        constructor to use with `@Inject`.
 
 === "kotlin-inject-anvil"
 
@@ -423,7 +439,6 @@ With Metro, or alternatively `kotlin-inject-anvil`, for the app scope it would b
     the user logs in and `onExitScope()` when the user logs out.
 
     ```kotlin
-    @Inject
     @SingleIn(UserScope::class)
     @ContributesScoped(UserScope::class) // Use @ContributesBinding with kotlin-inject-anvil.
     class SessionTimeout(...) : Scoped {
@@ -522,7 +537,6 @@ not create a property in the class itself. This callback notifies you when the `
 === "Metro"
 
     ```kotlin
-    @Inject
     @SingleIn(AppScope::class)
     @ContributesScoped(AppScope::class)
     class MyClass(private val application: Application) : Scoped {

--- a/docs/template.md
+++ b/docs/template.md
@@ -84,7 +84,6 @@ The `TemplateRenderer` receives the specific `Template`, lays out necessary cont
 models in these layers. The renderer often injects `RendererFactory` to create renderers for the models, e.g.
 
 ```kotlin
-@Inject
 @ContributesRenderer
 class ComposeSampleAppTemplateRenderer(
   private val rendererFactory: RendererFactory

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -218,7 +218,6 @@ class ConnectionRobot : Robot {
     Android Views. To obtain an instance of such a robot use the `robot<Type>()` function:
 
     ```kotlin
-    @Inject
     @ContributesRobot(AppScope::class)
     class MetricsRobot(
       private val metricsService: FakeMetricsService
@@ -308,14 +307,16 @@ or `kotlin-inject-anvil` dependency graph.
 
         ```kotlin
         @ContributesTo(AppScope::class)
-        public interface LoginRobotGraph {
-          @Provides public fun provideLoginRobot(): LoginRobot = LoginRobot()
+        public interface MetricsRobotGraph {
+          @Provides
+          public fun provideMetricsRobot(metricsService: FakeMetricsService): MetricsRobot =
+            MetricsRobot(metricsService)
     
           @Provides
           @IntoMap
-          @RobotKey(LoginRobot::class)
-          public fun provideLoginRobotIntoMap(
-            robot: () -> LoginRobot
+          @RobotKey(MetricsRobot::class)
+          public fun provideMetricsRobotIntoMap(
+            robot: () -> MetricsRobot
           ): Robot = robot()
         }
         ```
@@ -324,23 +325,24 @@ or `kotlin-inject-anvil` dependency graph.
 
         ```kotlin
         @ContributesTo(AppScope::class)
-        public interface LoginRobotComponent {
-          @Provides public fun provideLoginRobot(): LoginRobot = LoginRobot()
+        public interface MetricsRobotComponent {
+          @Provides
+          public fun provideMetricsRobot(metricsService: FakeMetricsService): MetricsRobot =
+            MetricsRobot(metricsService)
 
           @Provides
           @IntoMap
-          public fun provideLoginRobotIntoMap(
-            robot: () -> LoginRobot
-          ): Pair<KClass<out Robot>, () -> Robot> = LoginRobot::class to robot
+          public fun provideMetricsRobotIntoMap(
+            robot: () -> MetricsRobot
+          ): Pair<KClass<out Robot>, () -> Robot> = MetricsRobot::class to robot
         }
         ```
 
 
-If a `Robot` needs to inject other types such a fake implementations, then it needs to be additionally annotated with
-`@Inject`, e.g.
+If a `Robot` needs other types such as fake implementations, declare them as constructor parameters. `@ContributesRobot`
+generates a provider that injects the constructor parameters and calls the robot constructor, so `@Inject` is optional.
 
 ```kotlin
-@Inject
 @ContributesRobot(AppScope::class)
 class MetricsRobot(
   private val metricsService: FakeMetricsService

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -307,17 +307,19 @@ or `kotlin-inject-anvil` dependency graph.
 
         ```kotlin
         @ContributesTo(AppScope::class)
-        public interface MetricsRobotGraph {
-          @Provides
-          public fun provideMetricsRobot(metricsService: FakeMetricsService): MetricsRobot =
-            MetricsRobot(metricsService)
-    
-          @Provides
+        @BindingContainer
+        @Origin(MetricsRobot::class)
+        public interface MetricsRobotContribution {
+          @Binds
           @IntoMap
           @RobotKey(MetricsRobot::class)
-          public fun provideMetricsRobotIntoMap(
-            robot: () -> MetricsRobot
-          ): Robot = robot()
+          public fun bindMetricsRobotIntoMap(robot: MetricsRobot): Robot
+
+          companion object {
+            @Provides
+            public fun provideMetricsRobot(metricsService: FakeMetricsService): MetricsRobot =
+              MetricsRobot(metricsService)
+          }
         }
         ```
 

--- a/kotlin-inject-extensions/contribute/impl-code-generators/src/main/kotlin/software/amazon/app/platform/inject/processor/ContributesRendererProcessor.kt
+++ b/kotlin-inject-extensions/contribute/impl-code-generators/src/main/kotlin/software/amazon/app/platform/inject/processor/ContributesRendererProcessor.kt
@@ -10,19 +10,25 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSValueParameter
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.LambdaTypeName
+import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.STAR
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.WildcardTypeName
 import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.ksp.addOriginatingKSFile
+import com.squareup.kotlinpoet.ksp.toAnnotationSpec
 import com.squareup.kotlinpoet.ksp.toClassName
+import com.squareup.kotlinpoet.ksp.toTypeName
 import com.squareup.kotlinpoet.ksp.writeTo
 import kotlin.reflect.KClass
 import me.tatarka.inject.annotations.Inject
@@ -73,6 +79,7 @@ import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
  * }
  * ```
  */
+@OptIn(KspExperimental::class)
 internal class ContributesRendererProcessor(
   private val codeGenerator: CodeGenerator,
   override val logger: KSPLogger,
@@ -97,23 +104,17 @@ internal class ContributesRendererProcessor(
       .onEach {
         checkIsPublic(it)
         checkNoSingleton(it)
+        checkNoZeroArgInjectConstructor(it)
+        checkSingleConstructorOrInject(it)
       }
       .forEach { generateComponentInterface(it) }
 
     return emptyList()
   }
 
-  @OptIn(KspExperimental::class)
   private fun generateComponentInterface(clazz: KSClassDeclaration) {
     val packageName = "${APP_PLATFORM_LOOKUP_PACKAGE}.${clazz.packageName.asString()}"
     val componentClassName = ClassName(packageName, "${clazz.innerClassNames()}Component")
-    val hasInjectAnnotation = clazz.isAnnotationPresent(Inject::class)
-
-    if (hasInjectAnnotation) {
-      checkNoZeroArgConstructor(clazz)
-    } else {
-      checkZeroArgConstructor(clazz)
-    }
 
     val includeSealedSubtypes =
       try {
@@ -154,12 +155,13 @@ internal class ContributesRendererProcessor(
                 .build()
             )
             .apply {
-              if (!hasInjectAnnotation) {
+              if (!clazz.hasInjectAnnotation()) {
                 addFunction(
                   FunSpec.builder("provide${clazz.safeClassName}")
                     .addAnnotation(Provides::class)
                     .returns(clazz.toClassName())
-                    .addStatement("return %T()", clazz.toClassName())
+                    .addParameters(clazz.constructorParameters().map { it.toParameterSpec() })
+                    .addCode(clazz.constructorCall())
                     .build()
                 )
               }
@@ -275,20 +277,70 @@ internal class ContributesRendererProcessor(
     }
   }
 
-  private fun checkNoZeroArgConstructor(clazz: KSClassDeclaration) {
-    val parameterCount = clazz.primaryConstructor?.parameters?.size ?: 0
-    check(parameterCount > 0, clazz) {
-      "It's redundant to use @Inject when using " +
-        "@ContributesRenderer for a Renderer with a zero-arg constructor."
+  private fun checkNoZeroArgInjectConstructor(clazz: KSClassDeclaration) {
+    if (clazz.hasInjectAnnotation()) {
+      check(clazz.injectConstructorParameters().isNotEmpty(), clazz) {
+        "It's redundant to use @Inject when using " +
+          "@ContributesRenderer for a Renderer with a zero-arg constructor."
+      }
     }
   }
 
-  private fun checkZeroArgConstructor(clazz: KSClassDeclaration) {
-    val parameterCount = clazz.primaryConstructor?.parameters?.size ?: 0
-    check(parameterCount == 0, clazz) {
-      "When using @ContributesRenderer and you need to inject types in the constructor, " +
-        "then it's necessary to add the @Inject annotation."
+  private fun checkSingleConstructorOrInject(clazz: KSClassDeclaration) {
+    if (!clazz.hasInjectAnnotation() && clazz.constructors().count() > 1) {
+      check(false, clazz) {
+        "${clazz.simpleName.asString()} has multiple constructors. Annotate the constructor " +
+          "to use with @Inject, or remove the extra constructors so @ContributesRenderer can " +
+          "generate a provider."
+      }
     }
+  }
+
+  private fun KSClassDeclaration.constructorParameters(): List<KSValueParameter> {
+    return providerConstructor()?.parameters.orEmpty()
+  }
+
+  private fun KSClassDeclaration.injectConstructorParameters(): List<KSValueParameter> {
+    return constructors().firstOrNull { it.isAnnotationPresent(Inject::class) }?.parameters
+      ?: constructorParameters()
+  }
+
+  private fun KSClassDeclaration.providerConstructor(): KSFunctionDeclaration? {
+    return primaryConstructor ?: constructors().singleOrNull()
+  }
+
+  private fun KSClassDeclaration.hasInjectAnnotation(): Boolean {
+    return isAnnotationPresent(Inject::class) ||
+      constructors().any { it.isAnnotationPresent(Inject::class) }
+  }
+
+  private fun KSClassDeclaration.constructors(): Sequence<KSFunctionDeclaration> {
+    return declarations.filterIsInstance<KSFunctionDeclaration>().filter {
+      it.simpleName.asString() == "<init>"
+    }
+  }
+
+  private fun KSValueParameter.toParameterSpec(): ParameterSpec {
+    val parameterName = name?.asString() ?: "parameter"
+    return ParameterSpec.builder(parameterName, type.toTypeName())
+      .addAnnotations(annotations.map { it.toAnnotationSpec() }.toList())
+      .build()
+  }
+
+  private fun KSClassDeclaration.constructorCall(): CodeBlock {
+    return CodeBlock.builder()
+      .add("return %T(", toClassName())
+      .apply {
+        constructorParameters().forEachIndexed { index, parameter ->
+          if (index > 0) {
+            add(", ")
+          }
+          val parameterName = parameter.name?.asString() ?: "parameter"
+          add("%N = %N", parameterName, parameterName)
+        }
+      }
+      .add(")\n")
+      .build()
   }
 
   private fun KSType.extendsBaseModel(): Boolean {

--- a/kotlin-inject-extensions/contribute/impl-code-generators/src/main/kotlin/software/amazon/app/platform/inject/processor/ContributesRobotProcessor.kt
+++ b/kotlin-inject-extensions/contribute/impl-code-generators/src/main/kotlin/software/amazon/app/platform/inject/processor/ContributesRobotProcessor.kt
@@ -9,17 +9,23 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSValueParameter
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.LambdaTypeName
+import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.WildcardTypeName
 import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.ksp.addOriginatingKSFile
+import com.squareup.kotlinpoet.ksp.toAnnotationSpec
 import com.squareup.kotlinpoet.ksp.toClassName
+import com.squareup.kotlinpoet.ksp.toTypeName
 import com.squareup.kotlinpoet.ksp.writeTo
 import kotlin.reflect.KClass
 import me.tatarka.inject.annotations.Inject
@@ -70,10 +76,10 @@ internal class ContributesRobotProcessor(
       .filterIsInstance<KSClassDeclaration>()
       .onEach {
         checkIsPublic(it)
-        checkHasInjectAnnotation(it)
         checkNotSingleton(it)
         checkSuperType(it)
         checkAppScope(it)
+        checkSingleConstructorOrInject(it)
       }
       .forEach { generateComponentInterface(it) }
 
@@ -96,12 +102,13 @@ internal class ContributesRobotProcessor(
                 .build()
             )
             .apply {
-              if (!clazz.isAnnotationPresent(Inject::class)) {
+              if (!clazz.hasInjectAnnotation()) {
                 addFunction(
                   FunSpec.builder("provide${clazz.innerClassNames()}")
                     .addAnnotation(Provides::class)
                     .returns(clazz.toClassName())
-                    .addStatement("return %T()", clazz.toClassName())
+                    .addParameters(clazz.constructorParameters().map { it.toParameterSpec() })
+                    .addCode(clazz.constructorCall())
                     .build()
                 )
               }
@@ -135,15 +142,6 @@ internal class ContributesRobotProcessor(
     fileSpec.writeTo(codeGenerator, aggregating = false)
   }
 
-  private fun checkHasInjectAnnotation(clazz: KSClassDeclaration) {
-    if (clazz.primaryConstructor?.parameters?.isNotEmpty() == true) {
-      check(clazz.annotations.any { it.isAnnotation(injectFqName) }, clazz) {
-        "${clazz.simpleName.asString()} must be annotated with @Inject when " +
-          "injecting arguments into a robot."
-      }
-    }
-  }
-
   private fun checkNotSingleton(clazz: KSClassDeclaration) {
     check(clazz.annotations.none { it.isKotlinInjectScopeAnnotation() }, clazz) {
       "It's not allowed allowed for a robot to be a singleton, because the lifetime " +
@@ -168,5 +166,53 @@ internal class ContributesRobotProcessor(
     check(scope == AppScope::class.requireQualifiedName(), clazz) {
       "Robots can only be contributed to the AppScope for now. Scope $scope is unsupported."
     }
+  }
+
+  private fun checkSingleConstructorOrInject(clazz: KSClassDeclaration) {
+    if (!clazz.hasInjectAnnotation() && clazz.constructors().count() > 1) {
+      check(false, clazz) {
+        "${clazz.simpleName.asString()} has multiple constructors. Annotate the constructor " +
+          "to use with @Inject, or remove the extra constructors so @ContributesRobot can " +
+          "generate a provider."
+      }
+    }
+  }
+
+  private fun KSClassDeclaration.constructorParameters(): List<KSValueParameter> {
+    return primaryConstructor?.parameters.orEmpty()
+  }
+
+  private fun KSClassDeclaration.hasInjectAnnotation(): Boolean {
+    return isAnnotationPresent(Inject::class) ||
+      constructors().any { it.isAnnotationPresent(Inject::class) }
+  }
+
+  private fun KSClassDeclaration.constructors(): Sequence<KSFunctionDeclaration> {
+    return declarations.filterIsInstance<KSFunctionDeclaration>().filter {
+      it.simpleName.asString() == "<init>"
+    }
+  }
+
+  private fun KSValueParameter.toParameterSpec(): ParameterSpec {
+    val parameterName = name?.asString() ?: "parameter"
+    return ParameterSpec.builder(parameterName, type.toTypeName())
+      .addAnnotations(annotations.map { it.toAnnotationSpec() }.toList())
+      .build()
+  }
+
+  private fun KSClassDeclaration.constructorCall(): CodeBlock {
+    return CodeBlock.builder()
+      .add("return %T(", toClassName())
+      .apply {
+        constructorParameters().forEachIndexed { index, parameter ->
+          if (index > 0) {
+            add(", ")
+          }
+          val parameterName = parameter.name?.asString() ?: "parameter"
+          add("%N = %N", parameterName, parameterName)
+        }
+      }
+      .add(")\n")
+      .build()
   }
 }

--- a/kotlin-inject-extensions/contribute/impl-code-generators/src/test/kotlin/software/amazon/app/platform/inject/processor/ContributesRendererProcessorTest.kt
+++ b/kotlin-inject-extensions/contribute/impl-code-generators/src/test/kotlin/software/amazon/app/platform/inject/processor/ContributesRendererProcessorTest.kt
@@ -39,7 +39,7 @@ class ContributesRendererProcessorTest {
     compile(
       """
             package software.amazon.test
-    
+
             import software.amazon.app.platform.presenter.BaseModel
             import software.amazon.app.platform.renderer.Renderer
             import software.amazon.app.platform.inject.ContributesRenderer
@@ -109,7 +109,7 @@ class ContributesRendererProcessorTest {
     compile(
       """
             package software.amazon.test
-    
+
             import software.amazon.app.platform.presenter.BaseModel
             import software.amazon.app.platform.renderer.Renderer
             import software.amazon.app.platform.inject.ContributesRenderer
@@ -163,7 +163,7 @@ class ContributesRendererProcessorTest {
     compile(
       """
             package software.amazon.test
-    
+
             import software.amazon.app.platform.presenter.BaseModel
             import software.amazon.app.platform.renderer.Renderer
             import software.amazon.app.platform.inject.ContributesRenderer
@@ -217,7 +217,7 @@ class ContributesRendererProcessorTest {
     compile(
       """
             package software.amazon.test
-    
+
             import software.amazon.app.platform.inject.ContributesRenderer
             import software.amazon.app.platform.presenter.BaseModel
             import software.amazon.app.platform.renderer.Renderer
@@ -242,13 +242,13 @@ class ContributesRendererProcessorTest {
     compile(
       """
             package software.amazon.test
-    
+
             import software.amazon.app.platform.inject.ContributesRenderer
             import software.amazon.app.platform.presenter.BaseModel
             import software.amazon.app.platform.renderer.Renderer
 
             class Model : BaseModel
-            
+
             interface OtherRenderer : Renderer<Model>
 
             @ContributesRenderer
@@ -266,18 +266,18 @@ class ContributesRendererProcessorTest {
     compile(
       """
             package software.amazon.test
-    
+
             import software.amazon.app.platform.inject.ContributesRenderer
             import software.amazon.app.platform.presenter.BaseModel
             import software.amazon.app.platform.renderer.Renderer
 
             class Model : BaseModel
-            
+
             interface OtherRenderer<S : Any, T : BaseModel, U : CharSequence> : Renderer<T>
             interface OtherRenderer2<S : BaseModel, T : Any> : OtherRenderer<T, S, String>
             interface OtherRenderer3 : OtherRenderer2<Model, Any>
             interface OtherRenderer4 : OtherRenderer3
-    
+
 
             @ContributesRenderer
             class TestRenderer : OtherRenderer4 {
@@ -294,14 +294,14 @@ class ContributesRendererProcessorTest {
     compile(
       """
             package software.amazon.test
-    
+
             import software.amazon.app.platform.inject.ContributesRenderer
             import software.amazon.app.platform.presenter.BaseModel
             import software.amazon.app.platform.renderer.Renderer
 
             class Model1 : BaseModel
             class Model2 : BaseModel
-            
+
             interface OtherRenderer<S : BaseModel, T : BaseModel> : Renderer<S>
 
             @ContributesRenderer
@@ -324,7 +324,7 @@ class ContributesRendererProcessorTest {
     compile(
       """
             package software.amazon.test
-    
+
             import software.amazon.app.platform.presenter.BaseModel
             import software.amazon.app.platform.renderer.Renderer
             import software.amazon.app.platform.inject.ContributesRenderer
@@ -440,7 +440,7 @@ class ContributesRendererProcessorTest {
     compile(
       """
             package software.amazon.test
-    
+
             import software.amazon.app.platform.presenter.BaseModel
             import software.amazon.app.platform.renderer.Renderer
             import software.amazon.app.platform.inject.ContributesRenderer
@@ -494,7 +494,7 @@ class ContributesRendererProcessorTest {
     compile(
       """
             package software.amazon.test
-    
+
             import software.amazon.app.platform.inject.ContributesRenderer
             import software.amazon.app.platform.presenter.BaseModel
             import software.amazon.app.platform.renderer.Renderer
@@ -527,11 +527,51 @@ class ContributesRendererProcessorTest {
   }
 
   @Test
+  fun `the component skips the provider for a renderer with an @Inject secondary constructor`() {
+    compile(
+      """
+            package software.amazon.test
+
+            import software.amazon.app.platform.inject.ContributesRenderer
+            import software.amazon.app.platform.presenter.BaseModel
+            import software.amazon.app.platform.renderer.Renderer
+            import me.tatarka.inject.annotations.Inject
+
+            class Model : BaseModel
+
+            @ContributesRenderer
+            class TestRenderer private constructor(
+                val string: String,
+                val marker: String,
+            ) : Renderer<Model> {
+                @Inject constructor(string: String) : this(string, "injected")
+
+                override fun render(model: Model) = Unit
+
+                fun value(): String = "${'$'}string ${'$'}marker"
+            }
+            """,
+      componentInterfaceSource,
+    ) {
+      val generatedComponent = testRenderer.rendererComponent
+
+      assertThat(generatedComponent.declaredNonSyntheticMethods.map { it.name })
+        .containsOnly(
+          "provideSoftwareAmazonTestTestRendererModel",
+          "provideSoftwareAmazonTestTestRendererModelKey",
+        )
+
+      val renderer = componentInterface.newComponent<RendererComponent>().renderers[model]!!()
+      assertThat(testRenderer.getMethod("value").invoke(renderer)).isEqualTo("abc injected")
+    }
+  }
+
+  @Test
   fun `when using @SingleIn(RendererScope_class) then a warning is printed`() {
     compile(
       """
             package software.amazon.test
-    
+
             import software.amazon.app.platform.inject.ContributesRenderer
             import software.amazon.app.platform.presenter.BaseModel
             import software.amazon.app.platform.renderer.Renderer
@@ -565,7 +605,7 @@ class ContributesRendererProcessorTest {
     compile(
       """
             package software.amazon.test
-    
+
             import software.amazon.app.platform.inject.ContributesRenderer
             import software.amazon.app.platform.presenter.BaseModel
             import software.amazon.app.platform.renderer.Renderer
@@ -591,11 +631,11 @@ class ContributesRendererProcessorTest {
   }
 
   @Test
-  fun `it is required to use @Inject for a non-zero arg constructor`() {
+  fun `a component interface is generated for constructor parameters without @Inject`() {
     compile(
       """
             package software.amazon.test
-    
+
             import software.amazon.app.platform.inject.ContributesRenderer
             import software.amazon.app.platform.presenter.BaseModel
             import software.amazon.app.platform.renderer.Renderer
@@ -603,7 +643,47 @@ class ContributesRendererProcessorTest {
             class Model : BaseModel
 
             @ContributesRenderer
-            class TestRenderer(@Suppress("unused") val string: String) : Renderer<Model> {
+            class TestRenderer(val string: String) : Renderer<Model> {
+                override fun render(model: Model) = Unit
+
+                fun value(): String = string
+            }
+            """,
+      componentInterfaceSource,
+    ) {
+      val generatedComponent = testRenderer.rendererComponent
+
+      with(
+        generatedComponent.declaredNonSyntheticMethods.single {
+          it.name == "provideSoftwareAmazonTestTestRenderer"
+        }
+      ) {
+        assertThat(parameters.single().type).isEqualTo(String::class.java)
+        assertThat(returnType).isEqualTo(testRenderer)
+        assertThat(this).isAnnotatedWith(Provides::class)
+      }
+
+      val renderer = componentInterface.newComponent<RendererComponent>().renderers[model]!!()
+      assertThat(testRenderer.getMethod("value").invoke(renderer)).isEqualTo("abc")
+    }
+  }
+
+  @Test
+  fun `a renderer with multiple constructors must use @Inject`() {
+    compile(
+      """
+            package software.amazon.test
+
+            import software.amazon.app.platform.inject.ContributesRenderer
+            import software.amazon.app.platform.presenter.BaseModel
+            import software.amazon.app.platform.renderer.Renderer
+
+            class Model : BaseModel
+
+            @ContributesRenderer
+            class TestRenderer(val string: String) : Renderer<Model> {
+                constructor(string: String, marker: String) : this(string)
+
                 override fun render(model: Model) = Unit
             }
             """,
@@ -612,8 +692,9 @@ class ContributesRendererProcessorTest {
     ) {
       assertThat(messages)
         .contains(
-          "When using @ContributesRenderer and you need to inject types " +
-            "in the constructor, then it's necessary to add the @Inject annotation."
+          "TestRenderer has multiple constructors. Annotate the constructor to use with " +
+            "@Inject, or remove the extra constructors so @ContributesRenderer can generate " +
+            "a provider."
         )
     }
   }

--- a/kotlin-inject-extensions/contribute/impl-code-generators/src/test/kotlin/software/amazon/app/platform/inject/processor/ContributesRobotGeneratorTest.kt
+++ b/kotlin-inject-extensions/contribute/impl-code-generators/src/test/kotlin/software/amazon/app/platform/inject/processor/ContributesRobotGeneratorTest.kt
@@ -118,6 +118,133 @@ class ContributesRobotGeneratorTest {
   }
 
   @Test
+  fun `a component interface skips provider for an @Inject robot with constructor parameters`() {
+    compile(
+      """
+            package software.amazon.test
+
+            import software.amazon.app.platform.inject.robot.ContributesRobot
+            import software.amazon.app.platform.robot.Robot
+            import me.tatarka.inject.annotations.Inject
+            import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+
+            @Inject
+            @ContributesRobot(AppScope::class)
+            class TestRobot(
+              private val dependency: String,
+            ) : Robot {
+              fun value(): String = dependency
+            }
+            """,
+      componentInterfaceWithStringSource,
+    ) {
+      val robotComponent = testRobot.component
+
+      assertThat(
+          robotComponent.declaredNonSyntheticMethods.singleOrNull { it.name == "provideTestRobot" }
+        )
+        .isNull()
+
+      val robot = componentInterface.newComponent<RobotComponent>().robots[testRobot.kotlin]!!()
+      assertThat(testRobot.getMethod("value").invoke(robot)).isEqualTo("dependency")
+    }
+  }
+
+  @Test
+  fun `a component interface skips provider for a robot with an @Inject secondary constructor`() {
+    compile(
+      """
+            package software.amazon.test
+
+            import software.amazon.app.platform.inject.robot.ContributesRobot
+            import software.amazon.app.platform.robot.Robot
+            import me.tatarka.inject.annotations.Inject
+            import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+
+            @ContributesRobot(AppScope::class)
+            class TestRobot private constructor(
+              private val dependency: String,
+              private val marker: String,
+            ) : Robot {
+              @Inject constructor(dependency: String) : this(dependency, "injected")
+
+              fun value(): String = dependency + " " + marker
+            }
+            """,
+      componentInterfaceWithStringSource,
+    ) {
+      val robotComponent = testRobot.component
+
+      assertThat(
+          robotComponent.declaredNonSyntheticMethods.singleOrNull { it.name == "provideTestRobot" }
+        )
+        .isNull()
+
+      val robot = componentInterface.newComponent<RobotComponent>().robots[testRobot.kotlin]!!()
+      assertThat(testRobot.getMethod("value").invoke(robot)).isEqualTo("dependency injected")
+    }
+  }
+
+  @Test
+  fun `a robot with multiple constructors must use @Inject`() {
+    compile(
+      """
+            package software.amazon.test
+
+            import software.amazon.app.platform.inject.robot.ContributesRobot
+            import software.amazon.app.platform.robot.Robot
+            import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+
+            @ContributesRobot(AppScope::class)
+            class TestRobot(
+              private val dependency: String,
+            ) : Robot {
+              constructor(dependency: String, marker: String) : this(dependency)
+            }
+            """,
+      exitCode = COMPILATION_ERROR,
+    ) {
+      assertThat(messages)
+        .contains(
+          "TestRobot has multiple constructors. Annotate the constructor to use with @Inject, " +
+            "or remove the extra constructors so @ContributesRobot can generate a provider."
+        )
+    }
+  }
+
+  @Test
+  fun `a component interface is generated for constructor parameters without @Inject`() {
+    compile(
+      """
+            package software.amazon.test
+
+            import software.amazon.app.platform.inject.robot.ContributesRobot
+            import software.amazon.app.platform.robot.Robot
+            import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+
+            @ContributesRobot(AppScope::class)
+            class TestRobot(
+              private val dependency: String,
+            ) : Robot {
+              fun value(): String = dependency
+            }
+            """,
+      componentInterfaceWithStringSource,
+    ) {
+      val robotComponent = testRobot.component
+
+      with(robotComponent.declaredNonSyntheticMethods.single { it.name == "provideTestRobot" }) {
+        assertThat(parameters.single().type).isEqualTo(String::class.java)
+        assertThat(returnType).isEqualTo(testRobot)
+        assertThat(this).isAnnotatedWith(Provides::class)
+      }
+
+      val robot = componentInterface.newComponent<RobotComponent>().robots[testRobot.kotlin]!!()
+      assertThat(testRobot.getMethod("value").invoke(robot)).isEqualTo("dependency")
+    }
+  }
+
+  @Test
   fun `a component interface is generated without direct super type`() {
     compile(
       """
@@ -230,6 +357,26 @@ class ContributesRobotGeneratorTest {
         @MergeComponent(AppScope::class, exclude = [RendererComponent::class])
         @SingleIn(AppScope::class)
         interface ComponentInterface : ComponentInterfaceMerged
+    """
+
+  @Language("kotlin")
+  private val componentInterfaceWithStringSource =
+    """
+        package software.amazon.test
+
+        import software.amazon.app.platform.renderer.RendererComponent
+        import me.tatarka.inject.annotations.Component
+        import me.tatarka.inject.annotations.Provides
+        import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+        import software.amazon.lastmile.kotlin.inject.anvil.MergeComponent
+        import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
+
+        @Component
+        @MergeComponent(AppScope::class, exclude = [RendererComponent::class])
+        @SingleIn(AppScope::class)
+        interface ComponentInterface : ComponentInterfaceMerged {
+          @Provides fun provideString(): String = "dependency"
+        }
     """
 
   private val JvmCompilationResult.testRobot: Class<*>

--- a/metro-extensions/contribute/impl-code-generators/src/main/kotlin/software/amazon/app/platform/metro/processor/ContributesRendererProcessor.kt
+++ b/metro-extensions/contribute/impl-code-generators/src/main/kotlin/software/amazon/app/platform/metro/processor/ContributesRendererProcessor.kt
@@ -10,19 +10,25 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSValueParameter
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.LambdaTypeName
+import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.STAR
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.WildcardTypeName
 import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.ksp.addOriginatingKSFile
+import com.squareup.kotlinpoet.ksp.toAnnotationSpec
 import com.squareup.kotlinpoet.ksp.toClassName
+import com.squareup.kotlinpoet.ksp.toTypeName
 import com.squareup.kotlinpoet.ksp.writeTo
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.ForScope
@@ -75,6 +81,7 @@ import software.amazon.app.platform.renderer.metro.RendererKey
  * }
  * ```
  */
+@OptIn(KspExperimental::class)
 internal class ContributesRendererProcessor(
   private val codeGenerator: CodeGenerator,
   override val logger: KSPLogger,
@@ -100,23 +107,17 @@ internal class ContributesRendererProcessor(
       .onEach {
         checkIsPublic(it)
         checkNoSingleton(it)
+        checkNoZeroArgInjectConstructor(it)
+        checkSingleConstructorOrInject(it)
       }
       .forEach { generateGraphInterface(it) }
 
     return emptyList()
   }
 
-  @OptIn(KspExperimental::class)
   private fun generateGraphInterface(clazz: KSClassDeclaration) {
     val packageName = "${METRO_LOOKUP_PACKAGE}.${clazz.packageName.asString()}"
     val graphClassName = ClassName(packageName, "${clazz.innerClassNames()}Graph")
-    val hasInjectAnnotation = clazz.isAnnotationPresent(Inject::class)
-
-    if (hasInjectAnnotation) {
-      checkNoZeroArgConstructor(clazz)
-    } else {
-      checkZeroArgConstructor(clazz)
-    }
 
     val includeSealedSubtypes =
       try {
@@ -157,12 +158,13 @@ internal class ContributesRendererProcessor(
                 .build()
             )
             .apply {
-              if (!hasInjectAnnotation) {
+              if (!clazz.hasInjectAnnotation()) {
                 addFunction(
                   FunSpec.builder("provide${clazz.safeClassName}")
                     .addAnnotation(Provides::class)
                     .returns(clazz.toClassName())
-                    .addStatement("return %T()", clazz.toClassName())
+                    .addParameters(clazz.constructorParameters().map { it.toParameterSpec() })
+                    .addCode(clazz.constructorCall())
                     .build()
                 )
               }
@@ -269,20 +271,70 @@ internal class ContributesRendererProcessor(
     }
   }
 
-  private fun checkNoZeroArgConstructor(clazz: KSClassDeclaration) {
-    val parameterCount = clazz.primaryConstructor?.parameters?.size ?: 0
-    check(parameterCount > 0, clazz) {
-      "It's redundant to use @Inject when using " +
-        "@ContributesRenderer for a Renderer with a zero-arg constructor."
+  private fun checkNoZeroArgInjectConstructor(clazz: KSClassDeclaration) {
+    if (clazz.hasInjectAnnotation()) {
+      check(clazz.injectConstructorParameters().isNotEmpty(), clazz) {
+        "It's redundant to use @Inject when using " +
+          "@ContributesRenderer for a Renderer with a zero-arg constructor."
+      }
     }
   }
 
-  private fun checkZeroArgConstructor(clazz: KSClassDeclaration) {
-    val parameterCount = clazz.primaryConstructor?.parameters?.size ?: 0
-    check(parameterCount == 0, clazz) {
-      "When using @ContributesRenderer and you need to inject types in the constructor, " +
-        "then it's necessary to add the @Inject annotation."
+  private fun checkSingleConstructorOrInject(clazz: KSClassDeclaration) {
+    if (!clazz.hasInjectAnnotation() && clazz.constructors().count() > 1) {
+      check(false, clazz) {
+        "${clazz.simpleName.asString()} has multiple constructors. Annotate the constructor " +
+          "to use with @Inject, or remove the extra constructors so @ContributesRenderer can " +
+          "generate a provider."
+      }
     }
+  }
+
+  private fun KSClassDeclaration.constructorParameters(): List<KSValueParameter> {
+    return providerConstructor()?.parameters.orEmpty()
+  }
+
+  private fun KSClassDeclaration.injectConstructorParameters(): List<KSValueParameter> {
+    return constructors().firstOrNull { it.isAnnotationPresent(Inject::class) }?.parameters
+      ?: constructorParameters()
+  }
+
+  private fun KSClassDeclaration.providerConstructor(): KSFunctionDeclaration? {
+    return primaryConstructor ?: constructors().singleOrNull()
+  }
+
+  private fun KSClassDeclaration.hasInjectAnnotation(): Boolean {
+    return isAnnotationPresent(Inject::class) ||
+      constructors().any { it.isAnnotationPresent(Inject::class) }
+  }
+
+  private fun KSClassDeclaration.constructors(): Sequence<KSFunctionDeclaration> {
+    return declarations.filterIsInstance<KSFunctionDeclaration>().filter {
+      it.simpleName.asString() == "<init>"
+    }
+  }
+
+  private fun KSValueParameter.toParameterSpec(): ParameterSpec {
+    val parameterName = name?.asString() ?: "parameter"
+    return ParameterSpec.builder(parameterName, type.toTypeName())
+      .addAnnotations(annotations.map { it.toAnnotationSpec() }.toList())
+      .build()
+  }
+
+  private fun KSClassDeclaration.constructorCall(): CodeBlock {
+    return CodeBlock.builder()
+      .add("return %T(", toClassName())
+      .apply {
+        constructorParameters().forEachIndexed { index, parameter ->
+          if (index > 0) {
+            add(", ")
+          }
+          val parameterName = parameter.name?.asString() ?: "parameter"
+          add("%N = %N", parameterName, parameterName)
+        }
+      }
+      .add(")\n")
+      .build()
   }
 
   private fun KSType.extendsBaseModel(): Boolean {

--- a/metro-extensions/contribute/impl-code-generators/src/main/kotlin/software/amazon/app/platform/metro/processor/ContributesRobotProcessor.kt
+++ b/metro-extensions/contribute/impl-code-generators/src/main/kotlin/software/amazon/app/platform/metro/processor/ContributesRobotProcessor.kt
@@ -9,15 +9,21 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSValueParameter
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.LambdaTypeName
+import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.ksp.addOriginatingKSFile
+import com.squareup.kotlinpoet.ksp.toAnnotationSpec
 import com.squareup.kotlinpoet.ksp.toClassName
+import com.squareup.kotlinpoet.ksp.toTypeName
 import com.squareup.kotlinpoet.ksp.writeTo
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesTo
@@ -71,10 +77,10 @@ internal class ContributesRobotProcessor(
       .filterIsInstance<KSClassDeclaration>()
       .onEach {
         checkIsPublic(it)
-        checkHasInjectAnnotation(it)
         checkNotSingleton(it)
         checkSuperType(it)
         checkAppScope(it)
+        checkSingleConstructorOrInject(it)
       }
       .forEach { generateGraph(it) }
 
@@ -97,12 +103,13 @@ internal class ContributesRobotProcessor(
                 .build()
             )
             .apply {
-              if (!clazz.isAnnotationPresent(Inject::class)) {
+              if (!clazz.hasInjectAnnotation()) {
                 addFunction(
                   FunSpec.builder("provide${clazz.innerClassNames()}")
                     .addAnnotation(Provides::class)
                     .returns(clazz.toClassName())
-                    .addStatement("return %T()", clazz.toClassName())
+                    .addParameters(clazz.constructorParameters().map { it.toParameterSpec() })
+                    .addCode(clazz.constructorCall())
                     .build()
                 )
               }
@@ -132,15 +139,6 @@ internal class ContributesRobotProcessor(
     fileSpec.writeTo(codeGenerator, aggregating = false)
   }
 
-  private fun checkHasInjectAnnotation(clazz: KSClassDeclaration) {
-    if (clazz.primaryConstructor?.parameters?.isNotEmpty() == true) {
-      check(clazz.annotations.any { it.isAnnotation(injectFqName) }, clazz) {
-        "${clazz.simpleName.asString()} must be annotated with @Inject when " +
-          "injecting arguments into a robot."
-      }
-    }
-  }
-
   private fun checkNotSingleton(clazz: KSClassDeclaration) {
     check(clazz.annotations.none { it.isMetroScopeAnnotation() }, clazz) {
       "It's not allowed allowed for a robot to be a singleton, because the lifetime " +
@@ -165,5 +163,53 @@ internal class ContributesRobotProcessor(
     check(scope == AppScope::class.requireQualifiedName(), clazz) {
       "Robots can only be contributed to the AppScope for now. Scope $scope is unsupported."
     }
+  }
+
+  private fun checkSingleConstructorOrInject(clazz: KSClassDeclaration) {
+    if (!clazz.hasInjectAnnotation() && clazz.constructors().count() > 1) {
+      check(false, clazz) {
+        "${clazz.simpleName.asString()} has multiple constructors. Annotate the constructor " +
+          "to use with @Inject, or remove the extra constructors so @ContributesRobot can " +
+          "generate a provider."
+      }
+    }
+  }
+
+  private fun KSClassDeclaration.constructorParameters(): List<KSValueParameter> {
+    return primaryConstructor?.parameters.orEmpty()
+  }
+
+  private fun KSClassDeclaration.hasInjectAnnotation(): Boolean {
+    return isAnnotationPresent(Inject::class) ||
+      constructors().any { it.isAnnotationPresent(Inject::class) }
+  }
+
+  private fun KSClassDeclaration.constructors(): Sequence<KSFunctionDeclaration> {
+    return declarations.filterIsInstance<KSFunctionDeclaration>().filter {
+      it.simpleName.asString() == "<init>"
+    }
+  }
+
+  private fun KSValueParameter.toParameterSpec(): ParameterSpec {
+    val parameterName = name?.asString() ?: "parameter"
+    return ParameterSpec.builder(parameterName, type.toTypeName())
+      .addAnnotations(annotations.map { it.toAnnotationSpec() }.toList())
+      .build()
+  }
+
+  private fun KSClassDeclaration.constructorCall(): CodeBlock {
+    return CodeBlock.builder()
+      .add("return %T(", toClassName())
+      .apply {
+        constructorParameters().forEachIndexed { index, parameter ->
+          if (index > 0) {
+            add(", ")
+          }
+          val parameterName = parameter.name?.asString() ?: "parameter"
+          add("%N = %N", parameterName, parameterName)
+        }
+      }
+      .add(")\n")
+      .build()
   }
 }

--- a/metro-extensions/contribute/impl-code-generators/src/main/kotlin/software/amazon/app/platform/metro/processor/ContributesScopedProcessor.kt
+++ b/metro-extensions/contribute/impl-code-generators/src/main/kotlin/software/amazon/app/platform/metro/processor/ContributesScopedProcessor.kt
@@ -2,25 +2,35 @@ package software.amazon.app.platform.metro.processor
 
 import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.getAllSuperTypes
+import com.google.devtools.ksp.isAnnotationPresent
 import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSValueParameter
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.ksp.addOriginatingKSFile
+import com.squareup.kotlinpoet.ksp.toAnnotationSpec
 import com.squareup.kotlinpoet.ksp.toClassName
+import com.squareup.kotlinpoet.ksp.toTypeName
 import com.squareup.kotlinpoet.ksp.writeTo
 import dev.zacsweers.metro.Binds
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.ForScope
+import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.IntoSet
+import dev.zacsweers.metro.Provides
 import software.amazon.app.platform.inject.metro.ContributesScoped
 import software.amazon.app.platform.metro.METRO_LOOKUP_PACKAGE
 import software.amazon.app.platform.metro.MetroContextAware
@@ -55,9 +65,9 @@ internal class ContributesScopedProcessor(
       .filterIsInstance<KSClassDeclaration>()
       .onEach {
         checkIsPublic(it)
-        checkHasInjectAnnotation(it)
         checkImplementsScoped(it)
         checkSuperType(it)
+        checkSingleConstructorOrInject(it)
       }
       .forEach { generateGraph(it) }
 
@@ -85,6 +95,24 @@ internal class ContributesScopedProcessor(
                 .addMember("%T::class", scopeClassName)
                 .build()
             )
+            .apply {
+              if (!clazz.hasInjectAnnotation()) {
+                addFunction(
+                  FunSpec.builder("provide${clazz.innerClassNames()}")
+                    .addAnnotation(Provides::class)
+                    .addAnnotations(
+                      clazz.annotations
+                        .filter { it.isMetroScopeAnnotation() }
+                        .map { it.toAnnotationSpec() }
+                        .toList()
+                    )
+                    .returns(clazz.toClassName())
+                    .addParameters(clazz.constructorParameters().map { it.toParameterSpec() })
+                    .addCode(clazz.constructorCall())
+                    .build()
+                )
+              }
+            }
             .addProperties(
               clazz.superTypes
                 .filter { it.resolve().declaration.requireQualifiedName() != scopedFqName }
@@ -119,13 +147,6 @@ internal class ContributesScopedProcessor(
     fileSpec.writeTo(codeGenerator, aggregating = false)
   }
 
-  private fun checkHasInjectAnnotation(clazz: KSClassDeclaration) {
-    check(clazz.annotations.any { it.isAnnotation(injectFqName) }, clazz) {
-      "${clazz.simpleName.asString()} must be annotated with @Inject when " +
-        "using @ContributesScoped."
-    }
-  }
-
   private fun checkImplementsScoped(clazz: KSClassDeclaration) {
     val extendsScoped =
       clazz.getAllSuperTypes().any { it.declaration.qualifiedName?.asString() == scopedFqName }
@@ -148,6 +169,16 @@ internal class ContributesScopedProcessor(
     }
   }
 
+  private fun checkSingleConstructorOrInject(clazz: KSClassDeclaration) {
+    if (!clazz.hasInjectAnnotation() && clazz.constructors().count() > 1) {
+      check(false, clazz) {
+        "${clazz.simpleName.asString()} has multiple constructors. Annotate the constructor " +
+          "to use with @Inject, or remove the extra constructors so @ContributesScoped can " +
+          "generate a provider."
+      }
+    }
+  }
+
   private fun checkDoesNotImplementScoped(clazz: KSClassDeclaration) {
     check(
       clazz.superTypes.none { it.resolve().declaration.requireQualifiedName() == scopedFqName },
@@ -158,5 +189,47 @@ internal class ContributesScopedProcessor(
         "must be used instead of @ContributesBinding to bind both super types correctly. It's " +
         "not necessary to use @ContributesBinding."
     }
+  }
+
+  private fun KSClassDeclaration.constructorParameters(): List<KSValueParameter> {
+    return providerConstructor()?.parameters.orEmpty()
+  }
+
+  private fun KSClassDeclaration.providerConstructor(): KSFunctionDeclaration? {
+    return primaryConstructor ?: constructors().singleOrNull()
+  }
+
+  private fun KSClassDeclaration.hasInjectAnnotation(): Boolean {
+    return isAnnotationPresent(Inject::class) ||
+      constructors().any { it.isAnnotationPresent(Inject::class) }
+  }
+
+  private fun KSClassDeclaration.constructors(): Sequence<KSFunctionDeclaration> {
+    return declarations.filterIsInstance<KSFunctionDeclaration>().filter {
+      it.simpleName.asString() == "<init>"
+    }
+  }
+
+  private fun KSValueParameter.toParameterSpec(): ParameterSpec {
+    val parameterName = name?.asString() ?: "parameter"
+    return ParameterSpec.builder(parameterName, type.toTypeName())
+      .addAnnotations(annotations.map { it.toAnnotationSpec() }.toList())
+      .build()
+  }
+
+  private fun KSClassDeclaration.constructorCall(): CodeBlock {
+    return CodeBlock.builder()
+      .add("return %T(", toClassName())
+      .apply {
+        constructorParameters().forEachIndexed { index, parameter ->
+          if (index > 0) {
+            add(", ")
+          }
+          val parameterName = parameter.name?.asString() ?: "parameter"
+          add("%N = %N", parameterName, parameterName)
+        }
+      }
+      .add(")\n")
+      .build()
   }
 }

--- a/metro-extensions/contribute/impl-code-generators/src/test/kotlin/software/amazon/app/platform/inject/metro/processor/ContributesRendererProcessorTest.kt
+++ b/metro-extensions/contribute/impl-code-generators/src/test/kotlin/software/amazon/app/platform/inject/metro/processor/ContributesRendererProcessorTest.kt
@@ -519,6 +519,46 @@ class ContributesRendererProcessorTest {
   }
 
   @Test
+  fun `the graph skips the provider for a renderer with an @Inject secondary constructor`() {
+    compile(
+      """
+      package software.amazon.test
+
+      import dev.zacsweers.metro.Inject
+      import software.amazon.app.platform.inject.ContributesRenderer
+      import software.amazon.app.platform.presenter.BaseModel
+      import software.amazon.app.platform.renderer.Renderer
+
+      class Model : BaseModel
+
+      @ContributesRenderer
+      class TestRenderer private constructor(
+        val string: String,
+        val marker: String,
+      ) : Renderer<Model> {
+        @Inject constructor(string: String) : this(string, "injected")
+
+        override fun render(model: Model) = Unit
+
+        fun value(): String = "${'$'}string ${'$'}marker"
+      }
+      """,
+      graphInterfaceSource,
+    ) {
+      val generatedGraph = testRenderer.rendererGraph
+
+      assertThat(generatedGraph.declaredNonSyntheticMethods.map { it.name })
+        .containsOnly(
+          "provideSoftwareAmazonTestTestRendererModel",
+          "provideSoftwareAmazonTestTestRendererModelKey",
+        )
+
+      val renderer = graphInterface.newMetroGraph<TestRendererGraph>().renderers[model]!!()
+      assertThat(testRenderer.getMethod("value").invoke(renderer)).isEqualTo("abc injected")
+    }
+  }
+
+  @Test
   fun `when using @SingleIn(RendererScope_class) then a warning is printed`() {
     compile(
       """
@@ -583,7 +623,7 @@ class ContributesRendererProcessorTest {
   }
 
   @Test
-  fun `it is required to use @Inject for a non-zero arg constructor`() {
+  fun `a graph interface is generated for constructor parameters without @Inject`() {
     compile(
       """
       package software.amazon.test
@@ -595,7 +635,47 @@ class ContributesRendererProcessorTest {
       class Model : BaseModel
 
       @ContributesRenderer
-      class TestRenderer(@Suppress("unused") val string: String) : Renderer<Model> {
+      class TestRenderer(val string: String) : Renderer<Model> {
+        override fun render(model: Model) = Unit
+
+        fun value(): String = string
+      }
+      """,
+      graphInterfaceSource,
+    ) {
+      val generatedGraph = testRenderer.rendererGraph
+
+      with(
+        generatedGraph.declaredNonSyntheticMethods.single {
+          it.name == "provideSoftwareAmazonTestTestRenderer"
+        }
+      ) {
+        assertThat(parameters.single().type).isEqualTo(String::class.java)
+        assertThat(returnType).isEqualTo(testRenderer)
+        assertThat(this).isAnnotatedWith(Provides::class)
+      }
+
+      val renderer = graphInterface.newMetroGraph<TestRendererGraph>().renderers[model]!!()
+      assertThat(testRenderer.getMethod("value").invoke(renderer)).isEqualTo("abc")
+    }
+  }
+
+  @Test
+  fun `a renderer with multiple constructors must use @Inject`() {
+    compile(
+      """
+      package software.amazon.test
+
+      import software.amazon.app.platform.inject.ContributesRenderer
+      import software.amazon.app.platform.presenter.BaseModel
+      import software.amazon.app.platform.renderer.Renderer
+
+      class Model : BaseModel
+
+      @ContributesRenderer
+      class TestRenderer(val string: String) : Renderer<Model> {
+        constructor(string: String, marker: String) : this(string)
+
         override fun render(model: Model) = Unit
       }
       """,
@@ -604,8 +684,9 @@ class ContributesRendererProcessorTest {
     ) {
       assertThat(messages)
         .contains(
-          "When using @ContributesRenderer and you need to inject types " +
-            "in the constructor, then it's necessary to add the @Inject annotation."
+          "TestRenderer has multiple constructors. Annotate the constructor to use with " +
+            "@Inject, or remove the extra constructors so @ContributesRenderer can generate " +
+            "a provider."
         )
     }
   }

--- a/metro-extensions/contribute/impl-code-generators/src/test/kotlin/software/amazon/app/platform/inject/metro/processor/ContributesRobotGeneratorTest.kt
+++ b/metro-extensions/contribute/impl-code-generators/src/test/kotlin/software/amazon/app/platform/inject/metro/processor/ContributesRobotGeneratorTest.kt
@@ -113,6 +113,133 @@ class ContributesRobotGeneratorTest {
   }
 
   @Test
+  fun `a graph interface skips provider for an @Inject robot with constructor parameters`() {
+    compile(
+      """
+      package software.amazon.test
+
+      import software.amazon.app.platform.inject.robot.ContributesRobot
+      import software.amazon.app.platform.robot.Robot
+      import dev.zacsweers.metro.AppScope
+      import dev.zacsweers.metro.Inject
+
+      @Inject
+      @ContributesRobot(AppScope::class)
+      class TestRobot(
+        private val dependency: String,
+      ) : Robot {
+        fun value(): String = dependency
+      }
+      """,
+      graphInterfaceWithStringSource,
+    ) {
+      val robotGraph = testRobot.graph
+
+      assertThat(
+          robotGraph.declaredNonSyntheticMethods.singleOrNull { it.name == "provideTestRobot" }
+        )
+        .isNull()
+
+      val robot = graphInterface.newMetroGraph<TestRobotGraph>().robots[testRobot.kotlin]!!()
+      assertThat(testRobot.getMethod("value").invoke(robot)).isEqualTo("dependency")
+    }
+  }
+
+  @Test
+  fun `a graph interface skips provider for a robot with an @Inject secondary constructor`() {
+    compile(
+      """
+      package software.amazon.test
+
+      import software.amazon.app.platform.inject.robot.ContributesRobot
+      import software.amazon.app.platform.robot.Robot
+      import dev.zacsweers.metro.AppScope
+      import dev.zacsweers.metro.Inject
+
+      @ContributesRobot(AppScope::class)
+      class TestRobot private constructor(
+        private val dependency: String,
+        private val marker: String,
+      ) : Robot {
+        @Inject constructor(dependency: String) : this(dependency, "injected")
+
+        fun value(): String = dependency + " " + marker
+      }
+      """,
+      graphInterfaceWithStringSource,
+    ) {
+      val robotGraph = testRobot.graph
+
+      assertThat(
+          robotGraph.declaredNonSyntheticMethods.singleOrNull { it.name == "provideTestRobot" }
+        )
+        .isNull()
+
+      val robot = graphInterface.newMetroGraph<TestRobotGraph>().robots[testRobot.kotlin]!!()
+      assertThat(testRobot.getMethod("value").invoke(robot)).isEqualTo("dependency injected")
+    }
+  }
+
+  @Test
+  fun `a robot with multiple constructors must use @Inject`() {
+    compile(
+      """
+      package software.amazon.test
+
+      import software.amazon.app.platform.inject.robot.ContributesRobot
+      import software.amazon.app.platform.robot.Robot
+      import dev.zacsweers.metro.AppScope
+
+      @ContributesRobot(AppScope::class)
+      class TestRobot(
+        private val dependency: String,
+      ) : Robot {
+        constructor(dependency: String, marker: String) : this(dependency)
+      }
+      """,
+      exitCode = COMPILATION_ERROR,
+    ) {
+      assertThat(messages)
+        .contains(
+          "TestRobot has multiple constructors. Annotate the constructor to use with @Inject, " +
+            "or remove the extra constructors so @ContributesRobot can generate a provider."
+        )
+    }
+  }
+
+  @Test
+  fun `a graph interface is generated for constructor parameters without @Inject`() {
+    compile(
+      """
+      package software.amazon.test
+
+      import software.amazon.app.platform.inject.robot.ContributesRobot
+      import software.amazon.app.platform.robot.Robot
+      import dev.zacsweers.metro.AppScope
+
+      @ContributesRobot(AppScope::class)
+      class TestRobot(
+        private val dependency: String,
+      ) : Robot {
+        fun value(): String = dependency
+      }
+      """,
+      graphInterfaceWithStringSource,
+    ) {
+      val robotGraph = testRobot.graph
+
+      with(robotGraph.declaredNonSyntheticMethods.single { it.name == "provideTestRobot" }) {
+        assertThat(parameters.single().type).isEqualTo(String::class.java)
+        assertThat(returnType).isEqualTo(testRobot)
+        assertThat(this).isAnnotatedWith(Provides::class)
+      }
+
+      val robot = graphInterface.newMetroGraph<TestRobotGraph>().robots[testRobot.kotlin]!!()
+      assertThat(testRobot.getMethod("value").invoke(robot)).isEqualTo("dependency")
+    }
+  }
+
+  @Test
   fun `a graph interface is generated without direct super type`() {
     compile(
       """
@@ -223,6 +350,28 @@ class ContributesRobotGeneratorTest {
         @DependencyGraph(AppScope::class)
         @SingleIn(AppScope::class)
         interface GraphInterface : TestRobotGraph {
+            companion object {
+                fun create(): GraphInterface = createGraph<GraphInterface>()
+            }
+        }
+    """
+
+  @Language("kotlin")
+  private val graphInterfaceWithStringSource =
+    """
+        package software.amazon.test
+
+        import dev.zacsweers.metro.AppScope
+        import dev.zacsweers.metro.createGraph
+        import dev.zacsweers.metro.DependencyGraph
+        import dev.zacsweers.metro.Provides
+        import dev.zacsweers.metro.SingleIn
+
+        @DependencyGraph(AppScope::class)
+        @SingleIn(AppScope::class)
+        interface GraphInterface : TestRobotGraph {
+            @Provides fun provideString(): String = "dependency"
+
             companion object {
                 fun create(): GraphInterface = createGraph<GraphInterface>()
             }

--- a/metro-extensions/contribute/impl-code-generators/src/test/kotlin/software/amazon/app/platform/inject/metro/processor/ContributesScopedProcessorTest.kt
+++ b/metro-extensions/contribute/impl-code-generators/src/test/kotlin/software/amazon/app/platform/inject/metro/processor/ContributesScopedProcessorTest.kt
@@ -7,10 +7,12 @@ import assertk.assertions.contains
 import assertk.assertions.hasSize
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
+import assertk.assertions.isNull
 import com.tschuchort.compiletesting.JvmCompilationResult
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Provides
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.junit.jupiter.api.Test
 import software.amazon.app.platform.inject.metro.compile
@@ -19,6 +21,7 @@ import software.amazon.app.platform.inject.metro.graphInterface
 import software.amazon.app.platform.inject.metro.newMetroGraph
 import software.amazon.app.platform.ksp.capitalize
 import software.amazon.app.platform.ksp.inner
+import software.amazon.app.platform.ksp.isAnnotatedWith
 import software.amazon.app.platform.metro.METRO_LOOKUP_PACKAGE
 import software.amazon.app.platform.scope.Scoped
 
@@ -136,6 +139,143 @@ class ContributesScopedProcessorTest {
         assertThat(parameters.single().type).isEqualTo(testClass.inner)
         assertThat(returnType).isEqualTo(Scoped::class.java)
       }
+    }
+  }
+
+  @Test
+  fun `a graph interface is generated for constructor parameters without @Inject`() {
+    compile(
+      """
+      package software.amazon.test
+
+      import software.amazon.app.platform.inject.metro.ContributesScoped
+      import software.amazon.app.platform.scope.Scoped
+      import dev.zacsweers.metro.AppScope
+      import dev.zacsweers.metro.createGraph
+      import dev.zacsweers.metro.DependencyGraph
+      import dev.zacsweers.metro.ForScope
+      import dev.zacsweers.metro.Provides
+      import dev.zacsweers.metro.SingleIn
+
+      interface SuperType
+
+      @SingleIn(AppScope::class)
+      @ContributesScoped(AppScope::class)
+      class TestClass(
+        private val dependency: String,
+      ) : SuperType, Scoped {
+        fun value(): String = dependency
+      }
+
+      @DependencyGraph(AppScope::class)
+      @SingleIn(AppScope::class)
+      interface GraphInterface {
+        val superTypeInstance: SuperType
+
+        @ForScope(AppScope::class)
+        val allScoped: Set<Scoped>
+
+        @Provides
+        fun provideString(): String = "dependency"
+
+        companion object {
+          fun create(): GraphInterface = createGraph<GraphInterface>()
+        }
+      }
+      """
+    ) {
+      val scopedGraph = testClass.graph
+
+      with(scopedGraph.declaredNonSyntheticMethods.single { it.name == "provideTestClass" }) {
+        assertThat(parameters.single().type).isEqualTo(String::class.java)
+        assertThat(returnType).isEqualTo(testClass)
+        assertThat(this).isAnnotatedWith(Provides::class)
+      }
+
+      val graph = graphInterface.newMetroGraph<Any>()
+
+      @Suppress("UNCHECKED_CAST")
+      val scoped =
+        graphInterface.declaredNonSyntheticMethods
+          .single { it.name == "getAllScoped" }
+          .invoke(graph) as Set<Scoped>
+
+      val scopedInstance = scoped.single()
+      assertThat(scopedInstance::class.java).isEqualTo(testClass)
+      assertThat(testClass.getMethod("value").invoke(scopedInstance)).isEqualTo("dependency")
+      assertThat(
+          graphInterface.declaredNonSyntheticMethods
+            .single { it.name == "getSuperTypeInstance" }
+            .invoke(graph)
+        )
+        .isEqualTo(scopedInstance)
+    }
+  }
+
+  @Test
+  fun `a graph interface skips provider for an @Inject secondary constructor`() {
+    compile(
+      """
+      package software.amazon.test
+
+      import software.amazon.app.platform.inject.metro.ContributesScoped
+      import software.amazon.app.platform.scope.Scoped
+      import dev.zacsweers.metro.AppScope
+      import dev.zacsweers.metro.createGraph
+      import dev.zacsweers.metro.DependencyGraph
+      import dev.zacsweers.metro.ForScope
+      import dev.zacsweers.metro.Inject
+      import dev.zacsweers.metro.Provides
+      import dev.zacsweers.metro.SingleIn
+
+      interface SuperType
+
+      @SingleIn(AppScope::class)
+      @ContributesScoped(AppScope::class)
+      class TestClass private constructor(
+        private val dependency: String,
+        private val marker: String,
+      ) : SuperType, Scoped {
+        @Inject constructor(dependency: String) : this(dependency, "injected")
+
+        fun value(): String = "${'$'}dependency ${'$'}marker"
+      }
+
+      @DependencyGraph(AppScope::class)
+      @SingleIn(AppScope::class)
+      interface GraphInterface {
+        val superTypeInstance: SuperType
+
+        @ForScope(AppScope::class)
+        val allScoped: Set<Scoped>
+
+        @Provides
+        fun provideString(): String = "dependency"
+
+        companion object {
+          fun create(): GraphInterface = createGraph<GraphInterface>()
+        }
+      }
+      """
+    ) {
+      val scopedGraph = testClass.graph
+
+      assertThat(
+          scopedGraph.declaredNonSyntheticMethods.singleOrNull { it.name == "provideTestClass" }
+        )
+        .isNull()
+
+      val graph = graphInterface.newMetroGraph<Any>()
+
+      @Suppress("UNCHECKED_CAST")
+      val scoped =
+        graphInterface.declaredNonSyntheticMethods
+          .single { it.name == "getAllScoped" }
+          .invoke(graph) as Set<Scoped>
+
+      val scopedInstance = scoped.single()
+      assertThat(testClass.getMethod("value").invoke(scopedInstance))
+        .isEqualTo("dependency injected")
     }
   }
 
@@ -272,6 +412,35 @@ class ContributesScopedProcessorTest {
       """
     ) {
       assertThat(testClass.graph).isNotNull()
+    }
+  }
+
+  @Test
+  fun `a scoped class with multiple constructors must use @Inject`() {
+    compile(
+      """
+      package software.amazon.test
+
+      import software.amazon.app.platform.inject.metro.ContributesScoped
+      import software.amazon.app.platform.scope.Scoped
+      import dev.zacsweers.metro.AppScope
+
+      interface SuperType
+
+      @ContributesScoped(AppScope::class)
+      class TestClass(
+        private val dependency: String,
+      ) : SuperType, Scoped {
+        constructor(dependency: String, marker: String) : this(dependency)
+      }
+      """,
+      exitCode = COMPILATION_ERROR,
+    ) {
+      assertThat(messages)
+        .contains(
+          "TestClass has multiple constructors. Annotate the constructor to use with @Inject, " +
+            "or remove the extra constructors so @ContributesScoped can generate a provider."
+        )
     }
   }
 

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/AppPlatformMetroExtensionsPluginComponentRegistrar.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/AppPlatformMetroExtensionsPluginComponentRegistrar.kt
@@ -7,6 +7,7 @@ import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrarAdapter
 import software.amazon.app.platform.metro.compiler.renderer.ContributesRendererIrExtension
 import software.amazon.app.platform.metro.compiler.robot.ContributesRobotIrExtension
+import software.amazon.app.platform.metro.compiler.scoped.ContributesScopedIrExtension
 
 @AutoService(CompilerPluginRegistrar::class)
 public class AppPlatformMetroExtensionsPluginComponentRegistrar : CompilerPluginRegistrar() {
@@ -17,5 +18,6 @@ public class AppPlatformMetroExtensionsPluginComponentRegistrar : CompilerPlugin
     FirExtensionRegistrarAdapter.registerExtension(AppPlatformMetroExtensionsPluginRegistrar())
     IrGenerationExtension.registerExtension(ContributesRendererIrExtension())
     IrGenerationExtension.registerExtension(ContributesRobotIrExtension())
+    IrGenerationExtension.registerExtension(ContributesScopedIrExtension())
   }
 }

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/ClassIds.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/ClassIds.kt
@@ -12,6 +12,9 @@ internal object ClassIds {
 
   val BINDS = ClassId(FqName("dev.zacsweers.metro"), Name.identifier("Binds"))
 
+  val BINDING_CONTAINER =
+    ClassId(FqName("dev.zacsweers.metro"), Name.identifier("BindingContainer"))
+
   val CONTRIBUTES_RENDERER =
     ClassId(FqName("software.amazon.app.platform.inject"), Name.identifier("ContributesRenderer"))
 

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/fir/FirHelpers.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/fir/FirHelpers.kt
@@ -42,6 +42,12 @@ import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 
+@OptIn(DirectDeclarationsAccess::class)
+internal fun FirRegularClass.addGeneratedDeclaration(declaration: FirDeclaration) {
+  @Suppress("UNCHECKED_CAST") val mutableDeclarations = declarations as MutableList<FirDeclaration>
+  mutableDeclarations += declaration
+}
+
 internal fun hasAnnotation(
   classSymbol: FirClassSymbol<*>,
   annotationClassId: ClassId,

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/fir/TypeResolution.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/fir/TypeResolution.kt
@@ -72,6 +72,14 @@ internal fun findContainingFile(classSymbol: FirClassLikeSymbol<*>, session: Fir
   }
 }
 
+internal fun resolveTypeRef(
+  typeRef: FirTypeRef,
+  owner: FirRegularClassSymbol,
+  session: FirSession,
+): ConeKotlinType? {
+  return resolveSuperTypeRef(typeRef, owner, session)
+}
+
 internal fun allSessions(session: FirSession): List<FirSession> {
   val visitedModules = linkedSetOf<FirModuleData>()
   val visited = linkedSetOf<FirSession>()

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/renderer/ContributesRendererChecker.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/renderer/ContributesRendererChecker.kt
@@ -9,9 +9,7 @@ import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirClassChecker
 import org.jetbrains.kotlin.fir.declarations.FirClass
 import org.jetbrains.kotlin.fir.declarations.toAnnotationClassId
 import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
-import software.amazon.app.platform.metro.compiler.ClassIds
 import software.amazon.app.platform.metro.compiler.fir.AppPlatformMetroExtensionsDiagnostics
-import software.amazon.app.platform.metro.compiler.fir.hasAnnotation
 
 internal object ContributesRendererChecker : FirClassChecker(MppCheckerKind.Common) {
 
@@ -60,8 +58,8 @@ internal object ContributesRendererChecker : FirClassChecker(MppCheckerKind.Comm
       )
     }
 
-    val parameterCount = constructorParameterCount(classSymbol)
-    if (hasAnnotation(classSymbol, ClassIds.INJECT, session)) {
+    val parameterCount = injectedRendererConstructorParameterCount(classSymbol, session)
+    if (hasRendererInjectAnnotation(classSymbol, session)) {
       if (parameterCount == 0) {
         reporter.reportOn(
           annotation.source ?: declaration.source,
@@ -70,12 +68,13 @@ internal object ContributesRendererChecker : FirClassChecker(MppCheckerKind.Comm
             "a zero-arg constructor.",
         )
       }
-    } else if (parameterCount > 0) {
+    } else if (rendererConstructors(classSymbol).size > 1) {
       reporter.reportOn(
         annotation.source ?: declaration.source,
         AppPlatformMetroExtensionsDiagnostics.CONTRIBUTES_RENDERER_ERROR,
-        "When using @ContributesRenderer and you need to inject types in the constructor, " +
-          "then it's necessary to add the @Inject annotation.",
+        "${classSymbol.name.asString()} has multiple constructors. Annotate the constructor " +
+          "to use with @Inject, or remove the extra constructors so @ContributesRenderer can " +
+          "generate a provider.",
       )
     }
   }

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/renderer/ContributesRendererFir.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/renderer/ContributesRendererFir.kt
@@ -7,26 +7,36 @@ import dev.zacsweers.metro.compiler.compat.CompatContext
 import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.Visibilities
+import org.jetbrains.kotlin.fir.FirFunctionTarget
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.declarations.FirFunction
 import org.jetbrains.kotlin.fir.declarations.FirResolvePhase
+import org.jetbrains.kotlin.fir.declarations.FirValueParameter
 import org.jetbrains.kotlin.fir.declarations.builder.buildNamedFunction
 import org.jetbrains.kotlin.fir.declarations.builder.buildRegularClass
 import org.jetbrains.kotlin.fir.declarations.builder.buildValueParameter
 import org.jetbrains.kotlin.fir.declarations.impl.FirResolvedDeclarationStatusImpl
 import org.jetbrains.kotlin.fir.declarations.origin
+import org.jetbrains.kotlin.fir.expressions.FirExpression
+import org.jetbrains.kotlin.fir.expressions.buildResolvedArgumentList
 import org.jetbrains.kotlin.fir.expressions.builder.buildAnnotation
 import org.jetbrains.kotlin.fir.expressions.builder.buildAnnotationArgumentMapping
+import org.jetbrains.kotlin.fir.expressions.builder.buildFunctionCall
+import org.jetbrains.kotlin.fir.expressions.builder.buildPropertyAccessExpression
+import org.jetbrains.kotlin.fir.expressions.builder.buildReturnExpression
+import org.jetbrains.kotlin.fir.expressions.impl.buildSingleExpressionBlock
 import org.jetbrains.kotlin.fir.extensions.FirDeclarationPredicateRegistrar
 import org.jetbrains.kotlin.fir.extensions.NestedClassGenerationContext
 import org.jetbrains.kotlin.fir.extensions.predicateBasedProvider
 import org.jetbrains.kotlin.fir.moduleData
+import org.jetbrains.kotlin.fir.references.builder.buildResolvedNamedReference
 import org.jetbrains.kotlin.fir.resolve.defaultType
 import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
 import org.jetbrains.kotlin.fir.scopes.kotlinScopeProvider
 import org.jetbrains.kotlin.fir.symbols.impl.ConeClassLikeLookupTagImpl
 import org.jetbrains.kotlin.fir.symbols.impl.FirClassLikeSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirConstructorSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirValueParameterSymbol
@@ -35,6 +45,7 @@ import org.jetbrains.kotlin.fir.toFirResolvedTypeRef
 import org.jetbrains.kotlin.fir.types.ConeKotlinType
 import org.jetbrains.kotlin.fir.types.ConeKotlinTypeProjectionOut
 import org.jetbrains.kotlin.fir.types.ConeStarProjection
+import org.jetbrains.kotlin.fir.types.coneType
 import org.jetbrains.kotlin.fir.types.impl.ConeClassLikeTypeImpl
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.ClassId
@@ -46,6 +57,7 @@ import software.amazon.app.platform.metro.compiler.fir.buildAnnotationCallWithAr
 import software.amazon.app.platform.metro.compiler.fir.buildClassExpression
 import software.amazon.app.platform.metro.compiler.fir.buildSimpleAnnotationCall
 import software.amazon.app.platform.metro.compiler.fir.hasAnnotation
+import software.amazon.app.platform.metro.compiler.fir.resolveTypeRef
 
 /**
  * Generates the declaration shape for `@ContributesRenderer` classes.
@@ -182,25 +194,51 @@ public class ContributesRendererFir(session: FirSession) :
       "provide${ContributesRendererIds.generatedSafeClassNamePrefix(owner.classId)}"
     val callableId = CallableId(graphClassId, Name.identifier(functionName))
     val functionSymbol = FirNamedFunctionSymbol(callableId)
+    val constructor = rendererConstructor(owner)
+    val generatedParameters =
+      constructor
+        ?.parameters
+        ?.map { it.toGeneratedParameter(constructor.owner, functionSymbol) }
+        .orEmpty()
+    var returnTarget: FirFunctionTarget? = null
 
     return buildNamedFunction {
-      isLocal = false
-      resolvePhase = FirResolvePhase.BODY_RESOLVE
-      moduleData = session.moduleData
-      origin = Keys.ContributesRendererGeneratorKey.origin
-      source = owner.source
-      symbol = functionSymbol
-      name = callableId.callableName
-      returnTypeRef = owner.defaultType().toFirResolvedTypeRef()
-      dispatchReceiverType = generatedGraphType(graphClassId)
-      status =
-        FirResolvedDeclarationStatusImpl(
-          Visibilities.Public,
-          Modality.OPEN,
-          Visibilities.Public.toEffectiveVisibility(owner, forClass = true),
-        )
-      annotations += buildSimpleAnnotationCall(ClassIds.PROVIDES, functionSymbol, session)
-    }
+        isLocal = false
+        resolvePhase = FirResolvePhase.BODY_RESOLVE
+        moduleData = session.moduleData
+        origin = Keys.ContributesRendererGeneratorKey.origin
+        source = owner.source
+        symbol = functionSymbol
+        name = callableId.callableName
+        returnTypeRef = owner.defaultType().toFirResolvedTypeRef()
+        dispatchReceiverType = generatedGraphType(graphClassId)
+        status =
+          FirResolvedDeclarationStatusImpl(
+            Visibilities.Public,
+            Modality.OPEN,
+            Visibilities.Public.toEffectiveVisibility(owner, forClass = true),
+          )
+        annotations += buildSimpleAnnotationCall(ClassIds.PROVIDES, functionSymbol, session)
+        valueParameters += generatedParameters
+        if (constructor != null) {
+          body =
+            buildSingleExpressionBlock(
+              buildReturnExpression {
+                val target = FirFunctionTarget(labelName = null, isLambda = false)
+                returnTarget = target
+                this.target = target
+                result =
+                  buildConstructorCall(
+                    owner,
+                    constructor.symbol,
+                    constructor.parameters,
+                    generatedParameters,
+                  )
+              }
+            )
+        }
+      }
+      .also { function -> returnTarget?.bind(function) }
   }
 
   private fun buildProvideRendererIntoMapFunction(
@@ -279,6 +317,64 @@ public class ContributesRendererFir(session: FirSession) :
       annotations += buildSimpleAnnotationCall(ClassIds.INTO_MAP, functionSymbol, session)
       annotations += buildRendererKeyAnnotation(owner, modelClass, functionSymbol)
       annotations += buildForScopeAnnotation(functionSymbol)
+    }
+  }
+
+  private fun FirValueParameter.toGeneratedParameter(
+    owner: FirRegularClassSymbol,
+    functionSymbol: FirNamedFunctionSymbol,
+  ): FirValueParameter {
+    val constructorParameter = this
+    return buildValueParameter {
+      resolvePhase = FirResolvePhase.BODY_RESOLVE
+      moduleData = session.moduleData
+      origin = Keys.ContributesRendererGeneratorKey.origin
+      source = null
+      returnTypeRef =
+        resolveTypeRef(constructorParameter.returnTypeRef, owner, session)?.toFirResolvedTypeRef()
+          ?: constructorParameter.returnTypeRef
+      name = constructorParameter.name
+      symbol = FirValueParameterSymbol()
+      containingDeclarationSymbol = functionSymbol
+      isCrossinline = constructorParameter.isCrossinline
+      isNoinline = constructorParameter.isNoinline
+      isVararg = constructorParameter.isVararg
+      annotations += constructorParameter.annotations
+    }
+  }
+
+  private fun buildConstructorCall(
+    owner: FirClassSymbol<*>,
+    constructorSymbol: FirConstructorSymbol,
+    constructorParameters: List<FirValueParameter>,
+    generatedParameters: List<FirValueParameter>,
+  ): FirExpression {
+    return buildFunctionCall {
+      coneTypeOrNull = owner.defaultType()
+      calleeReference = buildResolvedNamedReference {
+        name = owner.name
+        resolvedSymbol = constructorSymbol
+      }
+      argumentList =
+        buildResolvedArgumentList(
+          original = null,
+          mapping =
+            generatedParameters.zip(constructorParameters).associateTo(LinkedHashMap()) {
+              (generatedParameter, constructorParameter) ->
+              buildParameterAccess(generatedParameter) to constructorParameter
+            },
+        )
+    }
+  }
+
+  private fun buildParameterAccess(parameter: FirValueParameter): FirExpression {
+    return buildPropertyAccessExpression {
+      source = parameter.source
+      coneTypeOrNull = parameter.returnTypeRef.coneType
+      calleeReference = buildResolvedNamedReference {
+        name = parameter.name
+        resolvedSymbol = parameter.symbol
+      }
     }
   }
 

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/renderer/ContributesRendererFir.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/renderer/ContributesRendererFir.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.fir.FirFunctionTarget
 import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.declarations.FirConstructor
 import org.jetbrains.kotlin.fir.declarations.FirFunction
 import org.jetbrains.kotlin.fir.declarations.FirResolvePhase
 import org.jetbrains.kotlin.fir.declarations.FirValueParameter
@@ -26,9 +27,12 @@ import org.jetbrains.kotlin.fir.expressions.builder.buildPropertyAccessExpressio
 import org.jetbrains.kotlin.fir.expressions.builder.buildReturnExpression
 import org.jetbrains.kotlin.fir.expressions.impl.buildSingleExpressionBlock
 import org.jetbrains.kotlin.fir.extensions.FirDeclarationPredicateRegistrar
+import org.jetbrains.kotlin.fir.extensions.MemberGenerationContext
 import org.jetbrains.kotlin.fir.extensions.NestedClassGenerationContext
 import org.jetbrains.kotlin.fir.extensions.predicateBasedProvider
 import org.jetbrains.kotlin.fir.moduleData
+import org.jetbrains.kotlin.fir.plugin.createCompanionObject
+import org.jetbrains.kotlin.fir.plugin.createDefaultPrivateConstructor
 import org.jetbrains.kotlin.fir.references.builder.buildResolvedNamedReference
 import org.jetbrains.kotlin.fir.resolve.defaultType
 import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
@@ -51,8 +55,10 @@ import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.name.SpecialNames
 import software.amazon.app.platform.metro.compiler.ClassIds
 import software.amazon.app.platform.metro.compiler.Keys
+import software.amazon.app.platform.metro.compiler.fir.addGeneratedDeclaration
 import software.amazon.app.platform.metro.compiler.fir.buildAnnotationCallWithArgument
 import software.amazon.app.platform.metro.compiler.fir.buildClassExpression
 import software.amazon.app.platform.metro.compiler.fir.buildSimpleAnnotationCall
@@ -68,21 +74,24 @@ import software.amazon.app.platform.metro.compiler.fir.resolveTypeRef
  * class TestRenderer : Renderer<Model> {
  *
  *   @ContributesTo(RendererScope::class)
+ *   @BindingContainer
  *   @Origin(TestRenderer::class)
  *   interface RendererContribution {
- *     @Provides
- *     fun provideTestRenderer(): TestRenderer
- *
  *     @Binds
  *     @IntoMap
  *     @RendererKey(Model::class)
  *     fun provideTestRendererModel(renderer: TestRenderer): Renderer<*>
  *
- *     @Provides
- *     @IntoMap
- *     @RendererKey(Model::class)
- *     @ForScope(RendererScope::class)
- *     fun provideTestRendererModelKey(): KClass<out Renderer<*>>
+ *     companion object {
+ *       @Provides
+ *       fun provideTestRenderer(): TestRenderer
+ *
+ *       @Provides
+ *       @IntoMap
+ *       @RendererKey(Model::class)
+ *       @ForScope(RendererScope::class)
+ *       fun provideTestRendererModelKey(): KClass<out Renderer<*>>
+ *     }
  *   }
  * }
  * ```
@@ -113,6 +122,15 @@ public class ContributesRendererFir(session: FirSession) :
     classSymbol: FirClassSymbol<*>,
     context: NestedClassGenerationContext,
   ): Set<Name> {
+    generatedRendererContributionOwner(classSymbol)?.let { rendererOwner ->
+      val metadata = rendererContributionMetadata(rendererOwner, session) ?: return emptySet()
+      return if (!metadata.hasInjectAnnotation || metadata.modelClasses.isNotEmpty()) {
+        setOf(SpecialNames.DEFAULT_NAME_FOR_COMPANION_OBJECT)
+      } else {
+        emptySet()
+      }
+    }
+
     return if (
       hasAnnotation(classSymbol, ContributesRendererIds.CONTRIBUTES_RENDERER_CLASS_ID, session)
     ) {
@@ -127,6 +145,17 @@ public class ContributesRendererFir(session: FirSession) :
     name: Name,
     context: NestedClassGenerationContext,
   ): FirClassLikeSymbol<*>? {
+    if (name == SpecialNames.DEFAULT_NAME_FOR_COMPANION_OBJECT) {
+      val rendererOwner = generatedRendererContributionOwner(owner) ?: return null
+      val metadata = rendererContributionMetadata(rendererOwner, session) ?: return null
+      val contributionSymbol = owner as? FirRegularClassSymbol ?: return null
+      val companion =
+        buildProviderCompanionObject(contributionSymbol) { companionClassId ->
+          buildProviderFunctions(companionClassId, rendererOwner, metadata)
+        }
+      return companion?.symbol
+    }
+
     if (name != ContributesRendererIds.NESTED_INTERFACE_NAME) return null
     if (!hasAnnotation(owner, ContributesRendererIds.CONTRIBUTES_RENDERER_CLASS_ID, session))
       return null
@@ -136,7 +165,7 @@ public class ContributesRendererFir(session: FirSession) :
     val nestedClassId = rendererOwner.classId.createNestedClassId(name)
     val graphSymbol = FirRegularClassSymbol(nestedClassId)
 
-    buildRegularClass {
+    val contributionClass = buildRegularClass {
       resolvePhase = FirResolvePhase.BODY_RESOLVE
       moduleData = session.moduleData
       origin = Keys.ContributesRendererGeneratorKey.origin
@@ -152,14 +181,98 @@ public class ContributesRendererFir(session: FirSession) :
           Visibilities.Public.toEffectiveVisibility(rendererOwner, forClass = true),
         )
       superTypeRefs += session.builtinTypes.anyType
+      annotations += buildSimpleAnnotationCall(ClassIds.BINDING_CONTAINER, graphSymbol, session)
       annotations += buildReflectionContributesToAnnotation()
       annotations += buildOriginAnnotation(rendererOwner, graphSymbol)
-      for (function in buildProvidesFunctions(nestedClassId, rendererOwner, metadata)) {
+      for (function in buildBindFunctions(nestedClassId, rendererOwner, metadata)) {
         declarations += function
       }
     }
 
-    return graphSymbol
+    return contributionClass.symbol
+  }
+
+  override fun getCallableNamesForClass(
+    classSymbol: FirClassSymbol<*>,
+    context: MemberGenerationContext,
+  ): Set<Name> {
+    return if (generatedRendererProviderCompanionOwner(classSymbol) != null) {
+      setOf(SpecialNames.INIT)
+    } else {
+      emptySet()
+    }
+  }
+
+  override fun generateConstructors(context: MemberGenerationContext): List<FirConstructorSymbol> {
+    if (generatedRendererProviderCompanionOwner(context.owner) == null) {
+      return emptyList()
+    }
+    val constructor: FirConstructor =
+      createDefaultPrivateConstructor(context.owner, Keys.ContributesRendererGeneratorKey)
+    return listOf(constructor.symbol)
+  }
+
+  private fun buildProviderCompanionObject(
+    classSymbol: FirRegularClassSymbol,
+    buildFunctions: (ClassId) -> List<FirFunction>,
+  ) =
+    createCompanionObject(classSymbol, Keys.ContributesRendererGeneratorKey).let { companion ->
+      val functions = buildFunctions(companion.symbol.classId)
+      if (functions.isEmpty()) {
+        null
+      } else {
+        companion.apply {
+          for (function in functions) {
+            addGeneratedDeclaration(function)
+          }
+        }
+      }
+    }
+
+  private fun generatedRendererContributionOwner(
+    classSymbol: FirClassSymbol<*>
+  ): FirRegularClassSymbol? {
+    if (classSymbol.classId.shortClassName != ContributesRendererIds.NESTED_INTERFACE_NAME) {
+      return null
+    }
+    val ownerClassId = classSymbol.classId.outerClassId ?: return null
+    val ownerSymbol =
+      session.symbolProvider.getClassLikeSymbolByClassId(ownerClassId) as? FirRegularClassSymbol
+        ?: return null
+    return ownerSymbol.takeIf {
+      hasAnnotation(it, ContributesRendererIds.CONTRIBUTES_RENDERER_CLASS_ID, session)
+    }
+  }
+
+  private fun generatedRendererProviderCompanionOwner(
+    classSymbol: FirClassSymbol<*>
+  ): FirRegularClassSymbol? {
+    if (classSymbol.classId.shortClassName != SpecialNames.DEFAULT_NAME_FOR_COMPANION_OBJECT) {
+      return null
+    }
+    val contributionClassId = classSymbol.classId.outerClassId ?: return null
+    if (contributionClassId.shortClassName != ContributesRendererIds.NESTED_INTERFACE_NAME) {
+      return null
+    }
+    val ownerClassId = contributionClassId.outerClassId ?: return null
+    val ownerSymbol =
+      session.symbolProvider.getClassLikeSymbolByClassId(ownerClassId) as? FirRegularClassSymbol
+        ?: return null
+    val metadata = rendererContributionMetadata(ownerSymbol, session) ?: return null
+    return ownerSymbol.takeIf {
+      hasAnnotation(it, ContributesRendererIds.CONTRIBUTES_RENDERER_CLASS_ID, session) &&
+        (!metadata.hasInjectAnnotation || metadata.modelClasses.isNotEmpty())
+    }
+  }
+
+  private fun buildBindFunctions(
+    graphClassId: ClassId,
+    owner: FirRegularClassSymbol,
+    metadata: RendererContributionMetadata,
+  ): List<FirFunction> {
+    return metadata.modelClasses.map { modelClass ->
+      buildProvideRendererIntoMapFunction(graphClassId, owner, modelClass)
+    }
   }
 
   private fun annotatedRendererClasses(): List<FirRegularClassSymbol> {
@@ -169,7 +282,7 @@ public class ContributesRendererFir(session: FirSession) :
       .toList()
   }
 
-  private fun buildProvidesFunctions(
+  private fun buildProviderFunctions(
     graphClassId: ClassId,
     owner: FirRegularClassSymbol,
     metadata: RendererContributionMetadata,
@@ -180,7 +293,6 @@ public class ContributesRendererFir(session: FirSession) :
       functions += buildProvideRendererFunction(graphClassId, owner)
     }
     metadata.modelClasses.forEach { modelClass ->
-      functions += buildProvideRendererIntoMapFunction(graphClassId, owner, modelClass)
       functions += buildProvideRendererKeyFunction(graphClassId, owner, modelClass)
     }
     return functions

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/renderer/ContributesRendererIrExtension.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/renderer/ContributesRendererIrExtension.kt
@@ -40,19 +40,21 @@ import software.amazon.app.platform.metro.compiler.Keys
  *   @ContributesTo(RendererScope::class)
  *   @Origin(TestRenderer::class)
  *   interface RendererContribution {
- *     @Provides
- *     fun provideTestRenderer(): TestRenderer = TestRenderer()
- *
  *     @Binds
  *     @IntoMap
  *     @RendererKey(Model::class)
  *     fun provideTestRendererModel(renderer: TestRenderer): Renderer<*>
  *
- *     @Provides
- *     @IntoMap
- *     @RendererKey(Model::class)
- *     @ForScope(RendererScope::class)
- *     fun provideTestRendererModelKey(): KClass<out Renderer<*>> = TestRenderer::class
+ *     companion object {
+ *       @Provides
+ *       fun provideTestRenderer(): TestRenderer = TestRenderer()
+ *
+ *       @Provides
+ *       @IntoMap
+ *       @RendererKey(Model::class)
+ *       @ForScope(RendererScope::class)
+ *       fun provideTestRendererModelKey(): KClass<out Renderer<*>> = TestRenderer::class
+ *     }
  *   }
  * }
  * ```
@@ -137,8 +139,14 @@ private class ContributesRendererIrTransformer(private val pluginContext: IrPlug
 
   private fun generatedOwnerClass(declaration: IrSimpleFunction): IrClass? {
     val parentClass = declaration.parent as? IrClass ?: return null
+    val contributionClass =
+      if (parentClass.isCompanion) {
+        parentClass.parentAsClass
+      } else {
+        parentClass
+      }
     val originAnnotation =
-      parentClass.annotations.firstOrNull { annotation ->
+      contributionClass.annotations.firstOrNull { annotation ->
         annotation.symbol.owner.parentAsClass.name == ClassIds.ORIGIN.shortClassName
       } ?: return null
     val classReference = originAnnotation.arguments[0] as? IrClassReference ?: return null

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/renderer/ContributesRendererIrExtension.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/renderer/ContributesRendererIrExtension.kt
@@ -7,10 +7,12 @@ import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
 import org.jetbrains.kotlin.ir.builders.irBlockBody
 import org.jetbrains.kotlin.ir.builders.irCallConstructor
+import org.jetbrains.kotlin.ir.builders.irGet
 import org.jetbrains.kotlin.ir.builders.irReturn
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.expressions.IrClassReference
 import org.jetbrains.kotlin.ir.expressions.impl.IrClassReferenceImpl
@@ -21,6 +23,7 @@ import org.jetbrains.kotlin.ir.types.defaultType
 import org.jetbrains.kotlin.ir.types.typeWith
 import org.jetbrains.kotlin.ir.util.constructors
 import org.jetbrains.kotlin.ir.util.parentAsClass
+import org.jetbrains.kotlin.ir.util.primaryConstructor
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
 import software.amazon.app.platform.metro.compiler.ClassIds
@@ -54,8 +57,9 @@ import software.amazon.app.platform.metro.compiler.Keys
  * }
  * ```
  *
- * The direct constructor call is only generated for zero-arg renderers. The `@IntoMap` renderer
- * binding stays abstract and is handled by Metro's normal `@Binds` support.
+ * The direct constructor call forwards the generated provider parameters to the renderer
+ * constructor. The `@IntoMap` renderer binding stays abstract and is handled by Metro's normal
+ * `@Binds` support.
  */
 @Suppress("DEPRECATION")
 internal class ContributesRendererIrExtension : IrGenerationExtension {
@@ -94,13 +98,22 @@ private class ContributesRendererIrTransformer(private val pluginContext: IrPlug
   private fun generateProvideRendererBody(declaration: IrSimpleFunction) {
     val classSymbol = (declaration.returnType as? IrSimpleType)?.classOrNull ?: return
     val constructor =
-      classSymbol.constructors.singleOrNull { it.owner.parameters.isEmpty() } ?: return
+      classSymbol.owner.primaryConstructor?.symbol
+        ?: classSymbol.constructors.firstOrNull()
+        ?: return
+    val constructorParameters =
+      constructor.owner.parameters.filter { it.kind == IrParameterKind.Regular }
+    val functionParameters = declaration.parameters.filter { it.kind == IrParameterKind.Regular }
+    if (constructorParameters.size != functionParameters.size) return
     val irBuilder = irBuilderFor(declaration)
 
     declaration.body = irBuilder.irBlockBody {
       val constructorCall = irCallConstructor(constructor, emptyList())
       constructorCall.startOffset = UNDEFINED_OFFSET
       constructorCall.endOffset = UNDEFINED_OFFSET
+      functionParameters.forEachIndexed { index, parameter ->
+        constructorCall.arguments[index] = irGet(parameter)
+      }
       +irReturn(constructorCall)
     }
   }

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/renderer/ContributesRendererSupport.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/renderer/ContributesRendererSupport.kt
@@ -5,7 +5,9 @@ import org.jetbrains.kotlin.fir.declarations.DirectDeclarationsAccess
 import org.jetbrains.kotlin.fir.declarations.FirDeclaration
 import org.jetbrains.kotlin.fir.declarations.FirFile
 import org.jetbrains.kotlin.fir.declarations.FirRegularClass
+import org.jetbrains.kotlin.fir.declarations.FirValueParameter
 import org.jetbrains.kotlin.fir.declarations.getSealedClassInheritors
+import org.jetbrains.kotlin.fir.declarations.toAnnotationClassIdSafe
 import org.jetbrains.kotlin.fir.declarations.utils.isSealed
 import org.jetbrains.kotlin.fir.expressions.FirAnnotationCall
 import org.jetbrains.kotlin.fir.expressions.FirLiteralExpression
@@ -45,6 +47,12 @@ internal data class RendererContributionMetadata(
   val modelClasses: List<ResolvedModelClass>,
 )
 
+internal data class RendererConstructor(
+  val owner: FirRegularClassSymbol,
+  val symbol: FirConstructorSymbol,
+  val parameters: List<FirValueParameter>,
+)
+
 internal sealed interface RendererModelTypeResolution {
   data class Success(val modelClass: ResolvedModelClass) : RendererModelTypeResolution
 
@@ -61,7 +69,7 @@ internal fun rendererContributionMetadata(
   val includeSealedSubtypes = contributesRendererIncludeSealedSubtypes(classSymbol, session)
 
   return RendererContributionMetadata(
-    hasInjectAnnotation = hasAnnotation(classSymbol, ClassIds.INJECT, session),
+    hasInjectAnnotation = hasRendererInjectAnnotation(classSymbol, session),
     modelClasses =
       if (includeSealedSubtypes) {
         collectModelClasses(modelType.modelClass, session)
@@ -112,12 +120,41 @@ internal fun isSingleInRendererScope(
 }
 
 @OptIn(DirectDeclarationsAccess::class, SymbolInternals::class)
-internal fun constructorParameterCount(classSymbol: FirRegularClassSymbol): Int {
+internal fun rendererConstructors(classSymbol: FirRegularClassSymbol): List<FirConstructorSymbol> {
+  return classSymbol.declarationSymbols.filterIsInstance<FirConstructorSymbol>()
+}
+
+@OptIn(DirectDeclarationsAccess::class, SymbolInternals::class)
+internal fun rendererConstructor(classSymbol: FirRegularClassSymbol): RendererConstructor? {
   val constructorSymbol =
-    classSymbol.declarationSymbols.filterIsInstance<FirConstructorSymbol>().firstOrNull {
-      it.isPrimary
-    } ?: classSymbol.declarationSymbols.filterIsInstance<FirConstructorSymbol>().firstOrNull()
-  return constructorSymbol?.fir?.valueParameters?.size ?: 0
+    rendererConstructors(classSymbol).firstOrNull { it.isPrimary }
+      ?: rendererConstructors(classSymbol).firstOrNull()
+  return constructorSymbol?.let { RendererConstructor(classSymbol, it, it.fir.valueParameters) }
+}
+
+@OptIn(DirectDeclarationsAccess::class, SymbolInternals::class)
+internal fun hasRendererInjectAnnotation(
+  classSymbol: FirRegularClassSymbol,
+  session: FirSession,
+): Boolean {
+  return hasAnnotation(classSymbol, ClassIds.INJECT, session) ||
+    rendererConstructors(classSymbol).any { constructor ->
+      constructor.fir.annotations.any { it.toAnnotationClassIdSafe(session) == ClassIds.INJECT }
+    }
+}
+
+@OptIn(DirectDeclarationsAccess::class, SymbolInternals::class)
+internal fun injectedRendererConstructorParameterCount(
+  classSymbol: FirRegularClassSymbol,
+  session: FirSession,
+): Int {
+  val constructorSymbol =
+    rendererConstructors(classSymbol).firstOrNull { constructor ->
+      constructor.fir.annotations.any { it.toAnnotationClassIdSafe(session) == ClassIds.INJECT }
+    }
+  return constructorSymbol?.fir?.valueParameters?.size
+    ?: rendererConstructor(classSymbol)?.parameters?.size
+    ?: 0
 }
 
 private fun explicitRendererModelType(

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/robot/ContributesRobotChecker.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/robot/ContributesRobotChecker.kt
@@ -58,13 +58,14 @@ internal object ContributesRobotChecker : FirClassChecker(MppCheckerKind.Common)
     }
 
     if (
-      requiresInjectAnnotation(declaration) && !hasAnnotation(classSymbol, ClassIds.INJECT, session)
+      !hasInjectAnnotation(declaration, classSymbol, session) && constructors(declaration).size > 1
     ) {
       reporter.reportOn(
         annotation.source ?: declaration.source,
         AppPlatformMetroExtensionsDiagnostics.CONTRIBUTES_ROBOT_ERROR,
-        "${classSymbol.name.asString()} must be annotated with @Inject when injecting arguments " +
-          "into a robot.",
+        "${classSymbol.name.asString()} has multiple constructors. Annotate the constructor " +
+          "to use with @Inject, or remove the extra constructors so @ContributesRobot can " +
+          "generate a provider.",
       )
     }
 
@@ -95,19 +96,27 @@ internal object ContributesRobotChecker : FirClassChecker(MppCheckerKind.Common)
     }
   }
 
+  @OptIn(DirectDeclarationsAccess::class)
+  private fun constructors(declaration: FirClass): List<FirConstructor> {
+    return declaration.declarations.filterIsInstance<FirConstructor>()
+  }
+
+  private fun hasInjectAnnotation(
+    declaration: FirClass,
+    classSymbol: FirRegularClassSymbol,
+    session: FirSession,
+  ): Boolean {
+    return hasAnnotation(classSymbol, ClassIds.INJECT, session) ||
+      constructors(declaration).any { constructor ->
+        constructor.annotations.any { it.toAnnotationClassIdSafe(session) == ClassIds.INJECT }
+      }
+  }
+
   private fun implementsRobot(declaration: FirClass, session: FirSession): Boolean {
     return declaration.superTypeRefs.any { superTypeRef ->
       val coneType = superTypeRef.coneType.fullyExpandedType(session)
       hasTransitiveSupertype(coneType, session, ClassIds.ROBOT_FQ_NAMES)
     }
-  }
-
-  @OptIn(DirectDeclarationsAccess::class)
-  private fun requiresInjectAnnotation(declaration: FirClass): Boolean {
-    val constructor =
-      declaration.declarations.filterIsInstance<FirConstructor>().firstOrNull { it.isPrimary }
-        ?: declaration.declarations.filterIsInstance<FirConstructor>().firstOrNull()
-    return constructor?.valueParameters?.isNotEmpty() == true
   }
 
   private fun isMetroScopeAnnotation(annotationClassId: ClassId?, session: FirSession): Boolean {

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/robot/ContributesRobotFir.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/robot/ContributesRobotFir.kt
@@ -7,31 +7,45 @@ import dev.zacsweers.metro.compiler.compat.CompatContext
 import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.Visibilities
+import org.jetbrains.kotlin.fir.FirFunctionTarget
 import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.declarations.DirectDeclarationsAccess
 import org.jetbrains.kotlin.fir.declarations.FirFunction
 import org.jetbrains.kotlin.fir.declarations.FirResolvePhase
+import org.jetbrains.kotlin.fir.declarations.FirValueParameter
 import org.jetbrains.kotlin.fir.declarations.builder.buildNamedFunction
 import org.jetbrains.kotlin.fir.declarations.builder.buildRegularClass
 import org.jetbrains.kotlin.fir.declarations.builder.buildValueParameter
 import org.jetbrains.kotlin.fir.declarations.impl.FirResolvedDeclarationStatusImpl
 import org.jetbrains.kotlin.fir.declarations.origin
+import org.jetbrains.kotlin.fir.declarations.toAnnotationClassIdSafe
+import org.jetbrains.kotlin.fir.expressions.FirExpression
+import org.jetbrains.kotlin.fir.expressions.buildResolvedArgumentList
 import org.jetbrains.kotlin.fir.expressions.builder.buildAnnotation
 import org.jetbrains.kotlin.fir.expressions.builder.buildAnnotationArgumentMapping
+import org.jetbrains.kotlin.fir.expressions.builder.buildFunctionCall
+import org.jetbrains.kotlin.fir.expressions.builder.buildPropertyAccessExpression
+import org.jetbrains.kotlin.fir.expressions.builder.buildReturnExpression
+import org.jetbrains.kotlin.fir.expressions.impl.buildSingleExpressionBlock
 import org.jetbrains.kotlin.fir.extensions.FirDeclarationPredicateRegistrar
 import org.jetbrains.kotlin.fir.extensions.NestedClassGenerationContext
 import org.jetbrains.kotlin.fir.extensions.predicateBasedProvider
 import org.jetbrains.kotlin.fir.moduleData
+import org.jetbrains.kotlin.fir.references.builder.buildResolvedNamedReference
 import org.jetbrains.kotlin.fir.resolve.defaultType
 import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
 import org.jetbrains.kotlin.fir.scopes.kotlinScopeProvider
+import org.jetbrains.kotlin.fir.symbols.SymbolInternals
 import org.jetbrains.kotlin.fir.symbols.impl.ConeClassLikeLookupTagImpl
 import org.jetbrains.kotlin.fir.symbols.impl.FirClassLikeSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirConstructorSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirValueParameterSymbol
 import org.jetbrains.kotlin.fir.toEffectiveVisibility
 import org.jetbrains.kotlin.fir.toFirResolvedTypeRef
+import org.jetbrains.kotlin.fir.types.coneType
 import org.jetbrains.kotlin.fir.types.impl.ConeClassLikeTypeImpl
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.ClassId
@@ -44,6 +58,7 @@ import software.amazon.app.platform.metro.compiler.fir.buildSimpleAnnotationCall
 import software.amazon.app.platform.metro.compiler.fir.extractScopeArgument
 import software.amazon.app.platform.metro.compiler.fir.extractScopeClassId
 import software.amazon.app.platform.metro.compiler.fir.hasAnnotation
+import software.amazon.app.platform.metro.compiler.fir.resolveTypeRef
 
 /**
  * Generates the declaration shape for `@ContributesRobot` classes.
@@ -56,7 +71,7 @@ import software.amazon.app.platform.metro.compiler.fir.hasAnnotation
  *   @ContributesTo(AppScope::class)
  *   interface RobotContribution {
  *     @Provides
- *     fun provideTestRobot(): TestRobot
+ *     fun provideTestRobot(dependency: RobotDependency): TestRobot
  *
  *     @Binds
  *     @IntoMap
@@ -67,7 +82,7 @@ import software.amazon.app.platform.metro.compiler.fir.hasAnnotation
  * ```
  *
  * No top-level graph interface is generated. If the robot class is already `@Inject`-constructible,
- * the nested declaration omits `provideTestRobot()` and only synthesizes the map-binding method.
+ * the nested declaration omits `provideTestRobot(...)` and only synthesizes the map-binding method.
  */
 public class ContributesRobotFir(session: FirSession) :
   MetroFirDeclarationGenerationExtension(session) {
@@ -161,7 +176,7 @@ public class ContributesRobotFir(session: FirSession) :
     owner: FirClassSymbol<*>,
   ): List<FirFunction> {
     val functions = mutableListOf<FirFunction>()
-    if (!hasAnnotation(owner, ClassIds.INJECT, session)) {
+    if (!hasInjectAnnotation(owner)) {
       functions += buildProvideRobotFunction(graphClassId, owner)
     }
     functions += buildProvideRobotIntoMapFunction(graphClassId, owner)
@@ -175,25 +190,51 @@ public class ContributesRobotFir(session: FirSession) :
     val functionName = "provide${ContributesRobotIds.generatedClassNamePrefix(owner.classId)}"
     val callableId = CallableId(graphClassId, Name.identifier(functionName))
     val functionSymbol = FirNamedFunctionSymbol(callableId)
+    val constructor = robotConstructor(owner)
+    val generatedParameters =
+      constructor
+        ?.parameters
+        ?.map { it.toGeneratedParameter(constructor.owner, functionSymbol) }
+        .orEmpty()
+    var returnTarget: FirFunctionTarget? = null
 
     return buildNamedFunction {
-      isLocal = false
-      resolvePhase = FirResolvePhase.BODY_RESOLVE
-      moduleData = session.moduleData
-      origin = Keys.ContributesRobotGeneratorKey.origin
-      source = owner.source
-      symbol = functionSymbol
-      name = callableId.callableName
-      returnTypeRef = owner.defaultType().toFirResolvedTypeRef()
-      dispatchReceiverType = generatedGraphType(graphClassId)
-      status =
-        FirResolvedDeclarationStatusImpl(
-          Visibilities.Public,
-          Modality.OPEN,
-          Visibilities.Public.toEffectiveVisibility(owner, forClass = true),
-        )
-      annotations += buildSimpleAnnotationCall(ClassIds.PROVIDES, functionSymbol, session)
-    }
+        isLocal = false
+        resolvePhase = FirResolvePhase.BODY_RESOLVE
+        moduleData = session.moduleData
+        origin = Keys.ContributesRobotGeneratorKey.origin
+        source = owner.source
+        symbol = functionSymbol
+        name = callableId.callableName
+        returnTypeRef = owner.defaultType().toFirResolvedTypeRef()
+        dispatchReceiverType = generatedGraphType(graphClassId)
+        status =
+          FirResolvedDeclarationStatusImpl(
+            Visibilities.Public,
+            Modality.OPEN,
+            Visibilities.Public.toEffectiveVisibility(owner, forClass = true),
+          )
+        annotations += buildSimpleAnnotationCall(ClassIds.PROVIDES, functionSymbol, session)
+        valueParameters += generatedParameters
+        if (constructor != null) {
+          body =
+            buildSingleExpressionBlock(
+              buildReturnExpression {
+                val target = FirFunctionTarget(labelName = null, isLambda = false)
+                returnTarget = target
+                this.target = target
+                result =
+                  buildConstructorCall(
+                    owner,
+                    constructor.symbol,
+                    constructor.parameters,
+                    generatedParameters,
+                  )
+              }
+            )
+        }
+      }
+      .also { function -> returnTarget?.bind(function) }
   }
 
   private fun buildProvideRobotIntoMapFunction(
@@ -235,6 +276,90 @@ public class ContributesRobotFir(session: FirSession) :
       annotations += buildSimpleAnnotationCall(ClassIds.BINDS, functionSymbol, session)
       annotations += buildSimpleAnnotationCall(ClassIds.INTO_MAP, functionSymbol, session)
       annotations += buildRobotKeyAnnotation(owner.classId)
+    }
+  }
+
+  private data class RobotConstructor(
+    val owner: FirRegularClassSymbol,
+    val symbol: FirConstructorSymbol,
+    val parameters: List<FirValueParameter>,
+  )
+
+  @OptIn(DirectDeclarationsAccess::class, SymbolInternals::class)
+  private fun robotConstructor(owner: FirClassSymbol<*>): RobotConstructor? {
+    val ownerClass = owner as? FirRegularClassSymbol ?: return null
+    val constructorSymbol =
+      ownerClass.declarationSymbols.filterIsInstance<FirConstructorSymbol>().firstOrNull {
+        it.isPrimary
+      } ?: ownerClass.declarationSymbols.filterIsInstance<FirConstructorSymbol>().firstOrNull()
+    return constructorSymbol?.let { RobotConstructor(ownerClass, it, it.fir.valueParameters) }
+  }
+
+  @OptIn(DirectDeclarationsAccess::class, SymbolInternals::class)
+  private fun hasInjectAnnotation(owner: FirClassSymbol<*>): Boolean {
+    if (hasAnnotation(owner, ClassIds.INJECT, session)) return true
+    val ownerClass = owner as? FirRegularClassSymbol ?: return false
+    return ownerClass.declarationSymbols.filterIsInstance<FirConstructorSymbol>().any { constructor
+      ->
+      constructor.fir.annotations.any { it.toAnnotationClassIdSafe(session) == ClassIds.INJECT }
+    }
+  }
+
+  private fun FirValueParameter.toGeneratedParameter(
+    owner: FirRegularClassSymbol,
+    functionSymbol: FirNamedFunctionSymbol,
+  ): FirValueParameter {
+    val constructorParameter = this
+    return buildValueParameter {
+      resolvePhase = FirResolvePhase.BODY_RESOLVE
+      moduleData = session.moduleData
+      origin = Keys.ContributesRobotGeneratorKey.origin
+      source = null
+      returnTypeRef =
+        resolveTypeRef(constructorParameter.returnTypeRef, owner, session)?.toFirResolvedTypeRef()
+          ?: constructorParameter.returnTypeRef
+      name = constructorParameter.name
+      symbol = FirValueParameterSymbol()
+      containingDeclarationSymbol = functionSymbol
+      isCrossinline = constructorParameter.isCrossinline
+      isNoinline = constructorParameter.isNoinline
+      isVararg = constructorParameter.isVararg
+      annotations += constructorParameter.annotations
+    }
+  }
+
+  private fun buildConstructorCall(
+    owner: FirClassSymbol<*>,
+    constructorSymbol: FirConstructorSymbol,
+    constructorParameters: List<FirValueParameter>,
+    generatedParameters: List<FirValueParameter>,
+  ): FirExpression {
+    return buildFunctionCall {
+      coneTypeOrNull = owner.defaultType()
+      calleeReference = buildResolvedNamedReference {
+        name = owner.name
+        resolvedSymbol = constructorSymbol
+      }
+      argumentList =
+        buildResolvedArgumentList(
+          original = null,
+          mapping =
+            generatedParameters.zip(constructorParameters).associateTo(LinkedHashMap()) {
+              (generatedParameter, constructorParameter) ->
+              buildParameterAccess(generatedParameter) to constructorParameter
+            },
+        )
+    }
+  }
+
+  private fun buildParameterAccess(parameter: FirValueParameter): FirExpression {
+    return buildPropertyAccessExpression {
+      source = parameter.source
+      coneTypeOrNull = parameter.returnTypeRef.coneType
+      calleeReference = buildResolvedNamedReference {
+        name = parameter.name
+        resolvedSymbol = parameter.symbol
+      }
     }
   }
 

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/robot/ContributesRobotFir.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/robot/ContributesRobotFir.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.fir.FirFunctionTarget
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.declarations.DirectDeclarationsAccess
+import org.jetbrains.kotlin.fir.declarations.FirConstructor
 import org.jetbrains.kotlin.fir.declarations.FirFunction
 import org.jetbrains.kotlin.fir.declarations.FirResolvePhase
 import org.jetbrains.kotlin.fir.declarations.FirValueParameter
@@ -28,9 +29,12 @@ import org.jetbrains.kotlin.fir.expressions.builder.buildPropertyAccessExpressio
 import org.jetbrains.kotlin.fir.expressions.builder.buildReturnExpression
 import org.jetbrains.kotlin.fir.expressions.impl.buildSingleExpressionBlock
 import org.jetbrains.kotlin.fir.extensions.FirDeclarationPredicateRegistrar
+import org.jetbrains.kotlin.fir.extensions.MemberGenerationContext
 import org.jetbrains.kotlin.fir.extensions.NestedClassGenerationContext
 import org.jetbrains.kotlin.fir.extensions.predicateBasedProvider
 import org.jetbrains.kotlin.fir.moduleData
+import org.jetbrains.kotlin.fir.plugin.createCompanionObject
+import org.jetbrains.kotlin.fir.plugin.createDefaultPrivateConstructor
 import org.jetbrains.kotlin.fir.references.builder.buildResolvedNamedReference
 import org.jetbrains.kotlin.fir.resolve.defaultType
 import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
@@ -50,8 +54,10 @@ import org.jetbrains.kotlin.fir.types.impl.ConeClassLikeTypeImpl
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.name.SpecialNames
 import software.amazon.app.platform.metro.compiler.ClassIds
 import software.amazon.app.platform.metro.compiler.Keys
+import software.amazon.app.platform.metro.compiler.fir.addGeneratedDeclaration
 import software.amazon.app.platform.metro.compiler.fir.buildAnnotationCallWithArgument
 import software.amazon.app.platform.metro.compiler.fir.buildClassExpression
 import software.amazon.app.platform.metro.compiler.fir.buildSimpleAnnotationCall
@@ -69,14 +75,17 @@ import software.amazon.app.platform.metro.compiler.fir.resolveTypeRef
  * class TestRobot : Robot {
  *
  *   @ContributesTo(AppScope::class)
+ *   @BindingContainer
  *   interface RobotContribution {
- *     @Provides
- *     fun provideTestRobot(dependency: RobotDependency): TestRobot
- *
  *     @Binds
  *     @IntoMap
  *     @RobotKey(TestRobot::class)
  *     fun provideTestRobotIntoMap(robot: TestRobot): Robot
+ *
+ *     companion object {
+ *       @Provides
+ *       fun provideTestRobot(dependency: RobotDependency): TestRobot
+ *     }
  *   }
  * }
  * ```
@@ -108,6 +117,14 @@ public class ContributesRobotFir(session: FirSession) :
     classSymbol: FirClassSymbol<*>,
     context: NestedClassGenerationContext,
   ): Set<Name> {
+    generatedRobotContributionOwner(classSymbol)?.let { owner ->
+      return if (hasInjectAnnotation(owner)) {
+        emptySet()
+      } else {
+        setOf(SpecialNames.DEFAULT_NAME_FOR_COMPANION_OBJECT)
+      }
+    }
+
     return if (
       hasAnnotation(classSymbol, ContributesRobotIds.CONTRIBUTES_ROBOT_CLASS_ID, session)
     ) {
@@ -122,6 +139,17 @@ public class ContributesRobotFir(session: FirSession) :
     name: Name,
     context: NestedClassGenerationContext,
   ): FirClassLikeSymbol<*>? {
+    if (name == SpecialNames.DEFAULT_NAME_FOR_COMPANION_OBJECT) {
+      val robotOwner = generatedRobotContributionOwner(owner) ?: return null
+      if (hasInjectAnnotation(robotOwner)) return null
+      val contributionSymbol = owner as? FirRegularClassSymbol ?: return null
+      val companion =
+        buildProviderCompanionObject(contributionSymbol) { companionClassId ->
+          listOf(buildProvideRobotFunction(companionClassId, robotOwner))
+        }
+      return companion.symbol
+    }
+
     if (name != ContributesRobotIds.NESTED_INTERFACE_NAME) return null
     if (!hasAnnotation(owner, ContributesRobotIds.CONTRIBUTES_ROBOT_CLASS_ID, session)) return null
 
@@ -131,7 +159,7 @@ public class ContributesRobotFir(session: FirSession) :
     val nestedClassId = owner.classId.createNestedClassId(name)
     val classSymbol = FirRegularClassSymbol(nestedClassId)
 
-    buildRegularClass {
+    val contributionClass = buildRegularClass {
       resolvePhase = FirResolvePhase.BODY_RESOLVE
       moduleData = session.moduleData
       origin = Keys.ContributesRobotGeneratorKey.origin
@@ -147,6 +175,7 @@ public class ContributesRobotFir(session: FirSession) :
           Visibilities.Public.toEffectiveVisibility(owner, forClass = true),
         )
       superTypeRefs += session.builtinTypes.anyType
+      annotations += buildSimpleAnnotationCall(ClassIds.BINDING_CONTAINER, classSymbol, session)
       annotations +=
         buildAnnotationCallWithArgument(
           ClassIds.CONTRIBUTES_TO,
@@ -156,12 +185,75 @@ public class ContributesRobotFir(session: FirSession) :
           session,
         )
       annotations += buildOriginAnnotation(owner)
-      for (function in buildProvidesFunctions(nestedClassId, owner)) {
-        declarations += function
+      declarations += buildProvideRobotIntoMapFunction(nestedClassId, owner)
+    }
+
+    return contributionClass.symbol
+  }
+
+  override fun getCallableNamesForClass(
+    classSymbol: FirClassSymbol<*>,
+    context: MemberGenerationContext,
+  ): Set<Name> {
+    return if (generatedRobotProviderCompanionOwner(classSymbol) != null) {
+      setOf(SpecialNames.INIT)
+    } else {
+      emptySet()
+    }
+  }
+
+  override fun generateConstructors(context: MemberGenerationContext): List<FirConstructorSymbol> {
+    if (generatedRobotProviderCompanionOwner(context.owner) == null) {
+      return emptyList()
+    }
+    val constructor: FirConstructor =
+      createDefaultPrivateConstructor(context.owner, Keys.ContributesRobotGeneratorKey)
+    return listOf(constructor.symbol)
+  }
+
+  private fun buildProviderCompanionObject(
+    classSymbol: FirRegularClassSymbol,
+    buildFunctions: (ClassId) -> List<FirFunction>,
+  ) =
+    createCompanionObject(classSymbol, Keys.ContributesRobotGeneratorKey).apply {
+      for (function in buildFunctions(symbol.classId)) {
+        addGeneratedDeclaration(function)
       }
     }
 
-    return classSymbol
+  private fun generatedRobotContributionOwner(
+    classSymbol: FirClassSymbol<*>
+  ): FirRegularClassSymbol? {
+    if (classSymbol.classId.shortClassName != ContributesRobotIds.NESTED_INTERFACE_NAME) {
+      return null
+    }
+    val ownerClassId = classSymbol.classId.outerClassId ?: return null
+    val ownerSymbol =
+      session.symbolProvider.getClassLikeSymbolByClassId(ownerClassId) as? FirRegularClassSymbol
+        ?: return null
+    return ownerSymbol.takeIf {
+      hasAnnotation(it, ContributesRobotIds.CONTRIBUTES_ROBOT_CLASS_ID, session)
+    }
+  }
+
+  private fun generatedRobotProviderCompanionOwner(
+    classSymbol: FirClassSymbol<*>
+  ): FirRegularClassSymbol? {
+    if (classSymbol.classId.shortClassName != SpecialNames.DEFAULT_NAME_FOR_COMPANION_OBJECT) {
+      return null
+    }
+    val contributionClassId = classSymbol.classId.outerClassId ?: return null
+    if (contributionClassId.shortClassName != ContributesRobotIds.NESTED_INTERFACE_NAME) {
+      return null
+    }
+    val ownerClassId = contributionClassId.outerClassId ?: return null
+    val ownerSymbol =
+      session.symbolProvider.getClassLikeSymbolByClassId(ownerClassId) as? FirRegularClassSymbol
+        ?: return null
+    return ownerSymbol.takeIf {
+      hasAnnotation(it, ContributesRobotIds.CONTRIBUTES_ROBOT_CLASS_ID, session) &&
+        !hasInjectAnnotation(it)
+    }
   }
 
   private fun annotatedRobotClasses(): List<FirRegularClassSymbol> {
@@ -169,18 +261,6 @@ public class ContributesRobotFir(session: FirSession) :
       .getSymbolsByPredicate(ContributesRobotIds.PREDICATE)
       .filterIsInstance<FirRegularClassSymbol>()
       .toList()
-  }
-
-  private fun buildProvidesFunctions(
-    graphClassId: ClassId,
-    owner: FirClassSymbol<*>,
-  ): List<FirFunction> {
-    val functions = mutableListOf<FirFunction>()
-    if (!hasInjectAnnotation(owner)) {
-      functions += buildProvideRobotFunction(graphClassId, owner)
-    }
-    functions += buildProvideRobotIntoMapFunction(graphClassId, owner)
-    return functions
   }
 
   private fun buildProvideRobotFunction(

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/robot/ContributesRobotIrExtension.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/robot/ContributesRobotIrExtension.kt
@@ -7,14 +7,17 @@ import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
 import org.jetbrains.kotlin.ir.builders.irBlockBody
 import org.jetbrains.kotlin.ir.builders.irCallConstructor
+import org.jetbrains.kotlin.ir.builders.irGet
 import org.jetbrains.kotlin.ir.builders.irReturn
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.ir.types.IrSimpleType
 import org.jetbrains.kotlin.ir.types.classOrNull
 import org.jetbrains.kotlin.ir.util.constructors
+import org.jetbrains.kotlin.ir.util.primaryConstructor
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
 import software.amazon.app.platform.metro.compiler.Keys
@@ -30,7 +33,7 @@ import software.amazon.app.platform.metro.compiler.Keys
  *   @ContributesTo(AppScope::class)
  *   interface RobotContribution {
  *     @Provides
- *     fun provideTestRobot(): TestRobot = TestRobot()
+ *     fun provideTestRobot(dependency: RobotDependency): TestRobot = TestRobot(dependency)
  *
  *     @Binds
  *     @IntoMap
@@ -40,8 +43,8 @@ import software.amazon.app.platform.metro.compiler.Keys
  * }
  * ```
  *
- * The direct constructor call is only generated for zero-arg robots. The `@IntoMap` binding stays
- * abstract and is handled by Metro's normal `@Binds` support.
+ * The direct constructor call forwards the generated provider parameters to the robot constructor.
+ * The `@IntoMap` binding stays abstract and is handled by Metro's normal `@Binds` support.
  */
 @Suppress("DEPRECATION")
 internal class ContributesRobotIrExtension : IrGenerationExtension {
@@ -77,13 +80,22 @@ private class ContributesRobotIrTransformer(private val pluginContext: IrPluginC
   private fun generateProvideRobotBody(declaration: IrSimpleFunction) {
     val classSymbol = (declaration.returnType as? IrSimpleType)?.classOrNull ?: return
     val constructor =
-      classSymbol.constructors.singleOrNull { it.owner.parameters.isEmpty() } ?: return
+      classSymbol.owner.primaryConstructor?.symbol
+        ?: classSymbol.constructors.firstOrNull()
+        ?: return
+    val constructorParameters =
+      constructor.owner.parameters.filter { it.kind == IrParameterKind.Regular }
+    val functionParameters = declaration.parameters.filter { it.kind == IrParameterKind.Regular }
+    if (constructorParameters.size != functionParameters.size) return
     val irBuilder = irBuilderFor(declaration)
 
     declaration.body = irBuilder.irBlockBody {
       val constructorCall = irCallConstructor(constructor, emptyList())
       constructorCall.startOffset = UNDEFINED_OFFSET
       constructorCall.endOffset = UNDEFINED_OFFSET
+      functionParameters.forEachIndexed { index, parameter ->
+        constructorCall.arguments[index] = irGet(parameter)
+      }
       +irReturn(constructorCall)
     }
   }

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/scoped/ContributesScopedChecker.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/scoped/ContributesScopedChecker.kt
@@ -11,7 +11,6 @@ import org.jetbrains.kotlin.fir.declarations.toAnnotationClassId
 import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
 import software.amazon.app.platform.metro.compiler.ClassIds
 import software.amazon.app.platform.metro.compiler.fir.AppPlatformMetroExtensionsDiagnostics
-import software.amazon.app.platform.metro.compiler.fir.hasAnnotation
 
 internal object ContributesScopedChecker : FirClassChecker(MppCheckerKind.Common) {
 
@@ -36,16 +35,6 @@ internal object ContributesScopedChecker : FirClassChecker(MppCheckerKind.Common
         return
       }
 
-      if (!hasAnnotation(classSymbol, ClassIds.INJECT, session)) {
-        reporter.reportOn(
-          contributesScopedAnnotation.source ?: declaration.source,
-          AppPlatformMetroExtensionsDiagnostics.CONTRIBUTES_SCOPED_ERROR,
-          "${classSymbol.name.asString()} must be annotated with @Inject when using " +
-            "@ContributesScoped.",
-        )
-        return
-      }
-
       if (!implementsScoped(classSymbol, session)) {
         reporter.reportOn(
           contributesScopedAnnotation.source ?: declaration.source,
@@ -62,6 +51,19 @@ internal object ContributesScopedChecker : FirClassChecker(MppCheckerKind.Common
           AppPlatformMetroExtensionsDiagnostics.CONTRIBUTES_SCOPED_ERROR,
           "In order to use @ContributesScoped, ${classSymbol.name.asString()} is allowed to " +
             "have only one other super type besides Scoped.",
+        )
+        return
+      }
+
+      if (
+        !hasScopedInjectAnnotation(classSymbol, session) && scopedConstructors(classSymbol).size > 1
+      ) {
+        reporter.reportOn(
+          contributesScopedAnnotation.source ?: declaration.source,
+          AppPlatformMetroExtensionsDiagnostics.CONTRIBUTES_SCOPED_ERROR,
+          "${classSymbol.name.asString()} has multiple constructors. Annotate the constructor " +
+            "to use with @Inject, or remove the extra constructors so @ContributesScoped can " +
+            "generate a provider.",
         )
         return
       }

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/scoped/ContributesScopedFir.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/scoped/ContributesScopedFir.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.fir.FirFunctionTarget
 import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.declarations.FirConstructor
 import org.jetbrains.kotlin.fir.declarations.FirFunction
 import org.jetbrains.kotlin.fir.declarations.FirResolvePhase
 import org.jetbrains.kotlin.fir.declarations.FirValueParameter
@@ -24,11 +25,15 @@ import org.jetbrains.kotlin.fir.expressions.builder.buildPropertyAccessExpressio
 import org.jetbrains.kotlin.fir.expressions.builder.buildReturnExpression
 import org.jetbrains.kotlin.fir.expressions.impl.buildSingleExpressionBlock
 import org.jetbrains.kotlin.fir.extensions.FirDeclarationPredicateRegistrar
+import org.jetbrains.kotlin.fir.extensions.MemberGenerationContext
 import org.jetbrains.kotlin.fir.extensions.NestedClassGenerationContext
 import org.jetbrains.kotlin.fir.extensions.predicateBasedProvider
 import org.jetbrains.kotlin.fir.moduleData
+import org.jetbrains.kotlin.fir.plugin.createCompanionObject
+import org.jetbrains.kotlin.fir.plugin.createDefaultPrivateConstructor
 import org.jetbrains.kotlin.fir.references.builder.buildResolvedNamedReference
 import org.jetbrains.kotlin.fir.resolve.defaultType
+import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
 import org.jetbrains.kotlin.fir.scopes.kotlinScopeProvider
 import org.jetbrains.kotlin.fir.symbols.impl.ConeClassLikeLookupTagImpl
 import org.jetbrains.kotlin.fir.symbols.impl.FirClassLikeSymbol
@@ -45,8 +50,10 @@ import org.jetbrains.kotlin.fir.types.impl.ConeClassLikeTypeImpl
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.name.SpecialNames
 import software.amazon.app.platform.metro.compiler.ClassIds
 import software.amazon.app.platform.metro.compiler.Keys
+import software.amazon.app.platform.metro.compiler.fir.addGeneratedDeclaration
 import software.amazon.app.platform.metro.compiler.fir.buildAnnotationCallWithArgument
 import software.amazon.app.platform.metro.compiler.fir.buildClassExpression
 import software.amazon.app.platform.metro.compiler.fir.buildSimpleAnnotationCall
@@ -65,11 +72,9 @@ import software.amazon.app.platform.metro.compiler.fir.resolveTypeRef
  * class TestClass : SuperType, Scoped {
  *
  *   @ContributesTo(AppScope::class)
+ *   @BindingContainer
  *   @Origin(TestClass::class)
  *   interface ScopedContribution {
- *     @Provides
- *     fun provideTestClass(dependency: Dependency): TestClass
- *
  *     @Binds
  *     fun bindSuperType(instance: TestClass): SuperType
  *
@@ -77,6 +82,11 @@ import software.amazon.app.platform.metro.compiler.fir.resolveTypeRef
  *     @IntoSet
  *     @ForScope(AppScope::class)
  *     fun bindTestClassScoped(instance: TestClass): Scoped
+ *
+ *     companion object {
+ *       @Provides
+ *       fun provideTestClass(dependency: Dependency): TestClass
+ *     }
  *   }
  * }
  * ```
@@ -113,6 +123,14 @@ public class ContributesScopedFir(session: FirSession) :
     classSymbol: FirClassSymbol<*>,
     context: NestedClassGenerationContext,
   ): Set<Name> {
+    generatedScopedContributionOwner(classSymbol)?.let { scopedOwner ->
+      return if (hasScopedInjectAnnotation(scopedOwner, session)) {
+        emptySet()
+      } else {
+        setOf(SpecialNames.DEFAULT_NAME_FOR_COMPANION_OBJECT)
+      }
+    }
+
     val regularClass = classSymbol as? FirRegularClassSymbol ?: return emptySet()
     return if (
       hasAnnotation(classSymbol, ContributesScopedIds.CONTRIBUTES_SCOPED_CLASS_ID, session) &&
@@ -129,6 +147,17 @@ public class ContributesScopedFir(session: FirSession) :
     name: Name,
     context: NestedClassGenerationContext,
   ): FirClassLikeSymbol<*>? {
+    if (name == SpecialNames.DEFAULT_NAME_FOR_COMPANION_OBJECT) {
+      val scopedOwner = generatedScopedContributionOwner(owner) ?: return null
+      if (hasScopedInjectAnnotation(scopedOwner, session)) return null
+      val contributionSymbol = owner as? FirRegularClassSymbol ?: return null
+      val companion =
+        buildProviderCompanionObject(contributionSymbol) { companionClassId ->
+          listOf(buildProvideScopedFunction(companionClassId, scopedOwner))
+        }
+      return companion.symbol
+    }
+
     if (name != ContributesScopedIds.NESTED_INTERFACE_NAME) return null
     if (!hasAnnotation(owner, ContributesScopedIds.CONTRIBUTES_SCOPED_CLASS_ID, session)) {
       return null
@@ -142,7 +171,7 @@ public class ContributesScopedFir(session: FirSession) :
     val nestedClassId = scopedOwner.classId.createNestedClassId(name)
     val contributionSymbol = FirRegularClassSymbol(nestedClassId)
 
-    buildRegularClass {
+    val contributionClass = buildRegularClass {
       resolvePhase = FirResolvePhase.BODY_RESOLVE
       moduleData = session.moduleData
       origin = Keys.ContributesScopedGeneratorKey.origin
@@ -159,6 +188,8 @@ public class ContributesScopedFir(session: FirSession) :
         )
       superTypeRefs += session.builtinTypes.anyType
       annotations +=
+        buildSimpleAnnotationCall(ClassIds.BINDING_CONTAINER, contributionSymbol, session)
+      annotations +=
         buildAnnotationCallWithArgument(
           classId = ClassIds.CONTRIBUTES_TO,
           argName = Name.identifier("scope"),
@@ -174,13 +205,79 @@ public class ContributesScopedFir(session: FirSession) :
           containingSymbol = contributionSymbol,
           session = session,
         )
-      buildContributionFunctions(nestedClassId, scopedOwner, metadata, scopeArg).forEach { function
-        ->
+      buildBindFunctions(nestedClassId, scopedOwner, metadata, scopeArg).forEach { function ->
         declarations += function
       }
     }
 
-    return contributionSymbol
+    return contributionClass.symbol
+  }
+
+  override fun getCallableNamesForClass(
+    classSymbol: FirClassSymbol<*>,
+    context: MemberGenerationContext,
+  ): Set<Name> {
+    return if (generatedScopedProviderCompanionOwner(classSymbol) != null) {
+      setOf(SpecialNames.INIT)
+    } else {
+      emptySet()
+    }
+  }
+
+  override fun generateConstructors(context: MemberGenerationContext): List<FirConstructorSymbol> {
+    if (generatedScopedProviderCompanionOwner(context.owner) == null) {
+      return emptyList()
+    }
+    val constructor: FirConstructor =
+      createDefaultPrivateConstructor(context.owner, Keys.ContributesScopedGeneratorKey)
+    return listOf(constructor.symbol)
+  }
+
+  private fun buildProviderCompanionObject(
+    classSymbol: FirRegularClassSymbol,
+    buildFunctions: (ClassId) -> List<FirFunction>,
+  ) =
+    createCompanionObject(classSymbol, Keys.ContributesScopedGeneratorKey).apply {
+      for (function in buildFunctions(symbol.classId)) {
+        addGeneratedDeclaration(function)
+      }
+    }
+
+  private fun generatedScopedContributionOwner(
+    classSymbol: FirClassSymbol<*>
+  ): FirRegularClassSymbol? {
+    if (classSymbol.classId.shortClassName != ContributesScopedIds.NESTED_INTERFACE_NAME) {
+      return null
+    }
+    val ownerClassId = classSymbol.classId.outerClassId ?: return null
+    val ownerSymbol =
+      session.symbolProvider.getClassLikeSymbolByClassId(ownerClassId) as? FirRegularClassSymbol
+        ?: return null
+    return ownerSymbol.takeIf {
+      hasAnnotation(it, ContributesScopedIds.CONTRIBUTES_SCOPED_CLASS_ID, session) &&
+        contributesScopedMetadata(it, session) != null
+    }
+  }
+
+  private fun generatedScopedProviderCompanionOwner(
+    classSymbol: FirClassSymbol<*>
+  ): FirRegularClassSymbol? {
+    if (classSymbol.classId.shortClassName != SpecialNames.DEFAULT_NAME_FOR_COMPANION_OBJECT) {
+      return null
+    }
+    val contributionClassId = classSymbol.classId.outerClassId ?: return null
+    if (contributionClassId.shortClassName != ContributesScopedIds.NESTED_INTERFACE_NAME) {
+      return null
+    }
+    val ownerClassId = contributionClassId.outerClassId ?: return null
+    val ownerSymbol =
+      session.symbolProvider.getClassLikeSymbolByClassId(ownerClassId) as? FirRegularClassSymbol
+        ?: return null
+    return ownerSymbol.takeIf {
+      hasAnnotation(it, ContributesScopedIds.CONTRIBUTES_SCOPED_CLASS_ID, session) &&
+        contributesScopedMetadata(it, session) != null &&
+        !hasScopedInjectAnnotation(it, session)
+    }
   }
 
   private fun annotatedScopedClasses(): List<FirRegularClassSymbol> {
@@ -190,16 +287,13 @@ public class ContributesScopedFir(session: FirSession) :
       .toList()
   }
 
-  private fun buildContributionFunctions(
+  private fun buildBindFunctions(
     contributionClassId: ClassId,
     owner: FirRegularClassSymbol,
     metadata: ScopedContributionMetadata,
     scopeArg: org.jetbrains.kotlin.fir.expressions.FirExpression,
   ): List<FirFunction> {
     return buildList {
-      if (!hasScopedInjectAnnotation(owner, session)) {
-        add(buildProvideScopedFunction(contributionClassId, owner))
-      }
       metadata.otherSuperType?.let { otherSuperType ->
         add(buildBindFunction(contributionClassId, owner, otherSuperType))
       }

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/scoped/ContributesScopedFir.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/scoped/ContributesScopedFir.kt
@@ -7,29 +7,40 @@ import dev.zacsweers.metro.compiler.compat.CompatContext
 import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.Visibilities
+import org.jetbrains.kotlin.fir.FirFunctionTarget
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.declarations.FirFunction
 import org.jetbrains.kotlin.fir.declarations.FirResolvePhase
+import org.jetbrains.kotlin.fir.declarations.FirValueParameter
 import org.jetbrains.kotlin.fir.declarations.builder.buildNamedFunction
 import org.jetbrains.kotlin.fir.declarations.builder.buildRegularClass
 import org.jetbrains.kotlin.fir.declarations.builder.buildValueParameter
 import org.jetbrains.kotlin.fir.declarations.impl.FirResolvedDeclarationStatusImpl
 import org.jetbrains.kotlin.fir.declarations.origin
+import org.jetbrains.kotlin.fir.expressions.FirExpression
+import org.jetbrains.kotlin.fir.expressions.buildResolvedArgumentList
+import org.jetbrains.kotlin.fir.expressions.builder.buildFunctionCall
+import org.jetbrains.kotlin.fir.expressions.builder.buildPropertyAccessExpression
+import org.jetbrains.kotlin.fir.expressions.builder.buildReturnExpression
+import org.jetbrains.kotlin.fir.expressions.impl.buildSingleExpressionBlock
 import org.jetbrains.kotlin.fir.extensions.FirDeclarationPredicateRegistrar
 import org.jetbrains.kotlin.fir.extensions.NestedClassGenerationContext
 import org.jetbrains.kotlin.fir.extensions.predicateBasedProvider
 import org.jetbrains.kotlin.fir.moduleData
+import org.jetbrains.kotlin.fir.references.builder.buildResolvedNamedReference
 import org.jetbrains.kotlin.fir.resolve.defaultType
 import org.jetbrains.kotlin.fir.scopes.kotlinScopeProvider
 import org.jetbrains.kotlin.fir.symbols.impl.ConeClassLikeLookupTagImpl
 import org.jetbrains.kotlin.fir.symbols.impl.FirClassLikeSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirConstructorSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirValueParameterSymbol
 import org.jetbrains.kotlin.fir.toEffectiveVisibility
 import org.jetbrains.kotlin.fir.toFirResolvedTypeRef
 import org.jetbrains.kotlin.fir.types.ConeKotlinType
+import org.jetbrains.kotlin.fir.types.coneType
 import org.jetbrains.kotlin.fir.types.impl.ConeClassLikeTypeImpl
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.ClassId
@@ -42,6 +53,7 @@ import software.amazon.app.platform.metro.compiler.fir.buildSimpleAnnotationCall
 import software.amazon.app.platform.metro.compiler.fir.extractScopeArgument
 import software.amazon.app.platform.metro.compiler.fir.extractScopeClassId
 import software.amazon.app.platform.metro.compiler.fir.hasAnnotation
+import software.amazon.app.platform.metro.compiler.fir.resolveTypeRef
 
 /**
  * Generates the declaration shape for `@ContributesScoped` classes.
@@ -55,6 +67,9 @@ import software.amazon.app.platform.metro.compiler.fir.hasAnnotation
  *   @ContributesTo(AppScope::class)
  *   @Origin(TestClass::class)
  *   interface ScopedContribution {
+ *     @Provides
+ *     fun provideTestClass(dependency: Dependency): TestClass
+ *
  *     @Binds
  *     fun bindSuperType(instance: TestClass): SuperType
  *
@@ -66,14 +81,17 @@ import software.amazon.app.platform.metro.compiler.fir.hasAnnotation
  * }
  * ```
  *
- * No top-level graph interface is generated. If the contributed class only implements `Scoped`,
- * then `bindSuperType()` is omitted and only the scoped multibinding is generated.
+ * No top-level graph interface is generated. If the scoped class is already `@Inject`
+ * constructible, the nested declaration omits `provideTestClass(...)` and only synthesizes the
+ * binding methods. If the contributed class only implements `Scoped`, then `bindSuperType()` is
+ * omitted and only the scoped multibinding is generated.
  */
 public class ContributesScopedFir(session: FirSession) :
   MetroFirDeclarationGenerationExtension(session) {
 
   override fun FirDeclarationPredicateRegistrar.registerPredicates() {
     register(ContributesScopedIds.PREDICATE)
+    register(ContributesScopedIds.SINGLE_IN_PREDICATE)
   }
 
   override fun getContributionHints(): List<ContributionHint> {
@@ -156,7 +174,8 @@ public class ContributesScopedFir(session: FirSession) :
           containingSymbol = contributionSymbol,
           session = session,
         )
-      buildBindingFunctions(nestedClassId, scopedOwner, metadata, scopeArg).forEach { function ->
+      buildContributionFunctions(nestedClassId, scopedOwner, metadata, scopeArg).forEach { function
+        ->
         declarations += function
       }
     }
@@ -171,18 +190,85 @@ public class ContributesScopedFir(session: FirSession) :
       .toList()
   }
 
-  private fun buildBindingFunctions(
+  private fun buildContributionFunctions(
     contributionClassId: ClassId,
     owner: FirRegularClassSymbol,
     metadata: ScopedContributionMetadata,
     scopeArg: org.jetbrains.kotlin.fir.expressions.FirExpression,
   ): List<FirFunction> {
     return buildList {
+      if (!hasScopedInjectAnnotation(owner, session)) {
+        add(buildProvideScopedFunction(contributionClassId, owner))
+      }
       metadata.otherSuperType?.let { otherSuperType ->
         add(buildBindFunction(contributionClassId, owner, otherSuperType))
       }
       add(buildBindScopedFunction(contributionClassId, owner, scopeArg))
     }
+  }
+
+  private fun buildProvideScopedFunction(
+    contributionClassId: ClassId,
+    owner: FirRegularClassSymbol,
+  ): FirFunction {
+    val functionName = "provide${ContributesScopedIds.generatedOwnerName(owner.classId)}"
+    val callableId = CallableId(contributionClassId, Name.identifier(functionName))
+    val functionSymbol = FirNamedFunctionSymbol(callableId)
+    val constructor = scopedConstructor(owner)
+    val generatedParameters =
+      constructor
+        ?.parameters
+        ?.map { it.toGeneratedParameter(constructor.owner, functionSymbol) }
+        .orEmpty()
+    var returnTarget: FirFunctionTarget? = null
+
+    return buildNamedFunction {
+        isLocal = false
+        resolvePhase = FirResolvePhase.BODY_RESOLVE
+        moduleData = session.moduleData
+        origin = Keys.ContributesScopedGeneratorKey.origin
+        source = owner.source
+        symbol = functionSymbol
+        name = callableId.callableName
+        returnTypeRef = owner.defaultType().toFirResolvedTypeRef()
+        dispatchReceiverType = contributionType(contributionClassId)
+        status =
+          FirResolvedDeclarationStatusImpl(
+            Visibilities.Public,
+            Modality.OPEN,
+            Visibilities.Public.toEffectiveVisibility(owner, forClass = true),
+          )
+        annotations += buildSimpleAnnotationCall(ClassIds.PROVIDES, functionSymbol, session)
+        extractScopeClassId(owner, ClassIds.SINGLE_IN, session)?.let { scopeClassId ->
+          annotations +=
+            buildAnnotationCallWithArgument(
+              ClassIds.SINGLE_IN,
+              Name.identifier("scope"),
+              buildClassExpression(scopeClassId, session),
+              functionSymbol,
+              session,
+            )
+        }
+        valueParameters += generatedParameters
+        if (constructor != null) {
+          body =
+            buildSingleExpressionBlock(
+              buildReturnExpression {
+                val target = FirFunctionTarget(labelName = null, isLambda = false)
+                returnTarget = target
+                this.target = target
+                result =
+                  buildConstructorCall(
+                    owner,
+                    constructor.symbol,
+                    constructor.parameters,
+                    generatedParameters,
+                  )
+              }
+            )
+        }
+      }
+      .also { function -> returnTarget?.bind(function) }
   }
 
   private fun buildBindFunction(
@@ -267,6 +353,64 @@ public class ContributesScopedFir(session: FirSession) :
       }
       annotations += buildSimpleAnnotationCall(ClassIds.BINDS, functionSymbol, session)
       annotations.additionalAnnotations(functionSymbol)
+    }
+  }
+
+  private fun FirValueParameter.toGeneratedParameter(
+    owner: FirRegularClassSymbol,
+    functionSymbol: FirNamedFunctionSymbol,
+  ): FirValueParameter {
+    val constructorParameter = this
+    return buildValueParameter {
+      resolvePhase = FirResolvePhase.BODY_RESOLVE
+      moduleData = session.moduleData
+      origin = Keys.ContributesScopedGeneratorKey.origin
+      source = null
+      returnTypeRef =
+        resolveTypeRef(constructorParameter.returnTypeRef, owner, session)?.toFirResolvedTypeRef()
+          ?: constructorParameter.returnTypeRef
+      name = constructorParameter.name
+      symbol = FirValueParameterSymbol()
+      containingDeclarationSymbol = functionSymbol
+      isCrossinline = constructorParameter.isCrossinline
+      isNoinline = constructorParameter.isNoinline
+      isVararg = constructorParameter.isVararg
+      annotations += constructorParameter.annotations
+    }
+  }
+
+  private fun buildConstructorCall(
+    owner: FirClassSymbol<*>,
+    constructorSymbol: FirConstructorSymbol,
+    constructorParameters: List<FirValueParameter>,
+    generatedParameters: List<FirValueParameter>,
+  ): FirExpression {
+    return buildFunctionCall {
+      coneTypeOrNull = owner.defaultType()
+      calleeReference = buildResolvedNamedReference {
+        name = owner.name
+        resolvedSymbol = constructorSymbol
+      }
+      argumentList =
+        buildResolvedArgumentList(
+          original = null,
+          mapping =
+            generatedParameters.zip(constructorParameters).associateTo(LinkedHashMap()) {
+              (generatedParameter, constructorParameter) ->
+              buildParameterAccess(generatedParameter) to constructorParameter
+            },
+        )
+    }
+  }
+
+  private fun buildParameterAccess(parameter: FirValueParameter): FirExpression {
+    return buildPropertyAccessExpression {
+      source = parameter.source
+      coneTypeOrNull = parameter.returnTypeRef.coneType
+      calleeReference = buildResolvedNamedReference {
+        name = parameter.name
+        resolvedSymbol = parameter.symbol
+      }
     }
   }
 

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/scoped/ContributesScopedIds.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/scoped/ContributesScopedIds.kt
@@ -9,6 +9,9 @@ internal object ContributesScopedIds {
   val CONTRIBUTES_SCOPED_CLASS_ID = ClassIds.CONTRIBUTES_SCOPED
   val NESTED_INTERFACE_NAME: Name = Name.identifier("ScopedContribution")
   val PREDICATE = LookupPredicate.create { annotated(CONTRIBUTES_SCOPED_CLASS_ID.asSingleFqName()) }
+  val SINGLE_IN_PREDICATE = LookupPredicate.create {
+    annotated(ClassIds.SINGLE_IN.asSingleFqName())
+  }
 
   fun generatedOwnerName(contributingClassId: ClassId): String {
     return contributingClassId.relativeClassName.pathSegments().joinToString(separator = "") {

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/scoped/ContributesScopedIrExtension.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/scoped/ContributesScopedIrExtension.kt
@@ -1,0 +1,81 @@
+package software.amazon.app.platform.metro.compiler.scoped
+
+import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
+import org.jetbrains.kotlin.ir.IrStatement
+import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
+import org.jetbrains.kotlin.ir.builders.irBlockBody
+import org.jetbrains.kotlin.ir.builders.irCallConstructor
+import org.jetbrains.kotlin.ir.builders.irGet
+import org.jetbrains.kotlin.ir.builders.irReturn
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
+import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.declarations.IrParameterKind
+import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+import org.jetbrains.kotlin.ir.types.IrSimpleType
+import org.jetbrains.kotlin.ir.types.classOrNull
+import org.jetbrains.kotlin.ir.util.constructors
+import org.jetbrains.kotlin.ir.util.primaryConstructor
+import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
+import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
+import software.amazon.app.platform.metro.compiler.Keys
+
+/** Fills in FIR-generated nested `@ContributesScoped` provider functions. */
+@Suppress("DEPRECATION")
+internal class ContributesScopedIrExtension : IrGenerationExtension {
+  override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
+    moduleFragment.transformChildrenVoid(ContributesScopedIrTransformer(pluginContext))
+  }
+}
+
+@Suppress("DEPRECATION")
+@OptIn(UnsafeDuringIrConstructionAPI::class)
+private class ContributesScopedIrTransformer(private val pluginContext: IrPluginContext) :
+  IrElementTransformerVoid() {
+
+  override fun visitSimpleFunction(declaration: IrSimpleFunction): IrStatement {
+    val origin = declaration.origin
+    if (
+      origin !is IrDeclarationOrigin.GeneratedByPlugin ||
+        origin.pluginKey != Keys.ContributesScopedGeneratorKey
+    ) {
+      return super.visitSimpleFunction(declaration)
+    }
+    if (declaration.body != null) return super.visitSimpleFunction(declaration)
+    if (!declaration.name.asString().startsWith("provide")) {
+      return super.visitSimpleFunction(declaration)
+    }
+
+    generateProvideScopedBody(declaration)
+
+    return super.visitSimpleFunction(declaration)
+  }
+
+  private fun generateProvideScopedBody(declaration: IrSimpleFunction) {
+    val classSymbol = (declaration.returnType as? IrSimpleType)?.classOrNull ?: return
+    val constructor =
+      classSymbol.owner.primaryConstructor?.symbol
+        ?: classSymbol.constructors.firstOrNull()
+        ?: return
+    val constructorParameters =
+      constructor.owner.parameters.filter { it.kind == IrParameterKind.Regular }
+    val functionParameters = declaration.parameters.filter { it.kind == IrParameterKind.Regular }
+    if (constructorParameters.size != functionParameters.size) return
+    val irBuilder = irBuilderFor(declaration)
+
+    declaration.body = irBuilder.irBlockBody {
+      val constructorCall = irCallConstructor(constructor, emptyList())
+      constructorCall.startOffset = UNDEFINED_OFFSET
+      constructorCall.endOffset = UNDEFINED_OFFSET
+      functionParameters.forEachIndexed { index, parameter ->
+        constructorCall.arguments[index] = irGet(parameter)
+      }
+      +irReturn(constructorCall)
+    }
+  }
+
+  private fun irBuilderFor(declaration: IrSimpleFunction) =
+    DeclarationIrBuilder(pluginContext, declaration.symbol, UNDEFINED_OFFSET, UNDEFINED_OFFSET)
+}

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/scoped/ContributesScopedSupport.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/scoped/ContributesScopedSupport.kt
@@ -1,20 +1,32 @@
 package software.amazon.app.platform.metro.compiler.scoped
 
 import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.declarations.DirectDeclarationsAccess
+import org.jetbrains.kotlin.fir.declarations.FirValueParameter
+import org.jetbrains.kotlin.fir.declarations.toAnnotationClassIdSafe
 import org.jetbrains.kotlin.fir.resolve.defaultType
 import org.jetbrains.kotlin.fir.resolve.fullyExpandedType
 import org.jetbrains.kotlin.fir.resolve.toRegularClassSymbol
+import org.jetbrains.kotlin.fir.symbols.SymbolInternals
+import org.jetbrains.kotlin.fir.symbols.impl.FirConstructorSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
 import org.jetbrains.kotlin.fir.types.ConeKotlinType
 import org.jetbrains.kotlin.fir.types.classId
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.StandardClassIds
 import software.amazon.app.platform.metro.compiler.ClassIds
+import software.amazon.app.platform.metro.compiler.fir.hasAnnotation
 import software.amazon.app.platform.metro.compiler.fir.resolveDeclaredSuperTypes
 
 internal data class ResolvedScopedSuperType(val classId: ClassId, val coneType: ConeKotlinType)
 
 internal data class ScopedContributionMetadata(val otherSuperType: ResolvedScopedSuperType?)
+
+internal data class ScopedConstructor(
+  val owner: FirRegularClassSymbol,
+  val symbol: FirConstructorSymbol,
+  val parameters: List<FirValueParameter>,
+)
 
 internal fun contributesScopedMetadata(
   classSymbol: FirRegularClassSymbol,
@@ -41,6 +53,30 @@ internal fun directOtherSupertypes(
 
 internal fun implementsScoped(classSymbol: FirRegularClassSymbol, session: FirSession): Boolean {
   return isScopedType(classSymbol.defaultType(), session)
+}
+
+@OptIn(DirectDeclarationsAccess::class, SymbolInternals::class)
+internal fun scopedConstructors(classSymbol: FirRegularClassSymbol): List<FirConstructorSymbol> {
+  return classSymbol.declarationSymbols.filterIsInstance<FirConstructorSymbol>()
+}
+
+@OptIn(DirectDeclarationsAccess::class, SymbolInternals::class)
+internal fun scopedConstructor(classSymbol: FirRegularClassSymbol): ScopedConstructor? {
+  val constructorSymbol =
+    scopedConstructors(classSymbol).firstOrNull { it.isPrimary }
+      ?: scopedConstructors(classSymbol).firstOrNull()
+  return constructorSymbol?.let { ScopedConstructor(classSymbol, it, it.fir.valueParameters) }
+}
+
+@OptIn(DirectDeclarationsAccess::class, SymbolInternals::class)
+internal fun hasScopedInjectAnnotation(
+  classSymbol: FirRegularClassSymbol,
+  session: FirSession,
+): Boolean {
+  return hasAnnotation(classSymbol, ClassIds.INJECT, session) ||
+    scopedConstructors(classSymbol).any { constructor ->
+      constructor.fir.annotations.any { it.toAnnotationClassIdSafe(session) == ClassIds.INJECT }
+    }
 }
 
 private fun isScopedType(

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/java/software/amazon/app/platform/metro/compiler/runners/BoxTestGenerated.java
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/java/software/amazon/app/platform/metro/compiler/runners/BoxTestGenerated.java
@@ -101,6 +101,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
     }
 
     @Test
+    @TestMetadata("constructorParametersWithoutInject.kt")
+    public void testConstructorParametersWithoutInject() {
+      runTest("metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrobot/constructorParametersWithoutInject.kt");
+    }
+
+    @Test
     @TestMetadata("defaultConstructorRobot.kt")
     public void testDefaultConstructorRobot() {
       runTest("metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrobot/defaultConstructorRobot.kt");
@@ -113,9 +119,21 @@ public class BoxTestGenerated extends AbstractBoxTest {
     }
 
     @Test
+    @TestMetadata("injectClassSkipsProvider.kt")
+    public void testInjectClassSkipsProvider() {
+      runTest("metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrobot/injectClassSkipsProvider.kt");
+    }
+
+    @Test
     @TestMetadata("injectConstructorRobot.kt")
     public void testInjectConstructorRobot() {
       runTest("metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrobot/injectConstructorRobot.kt");
+    }
+
+    @Test
+    @TestMetadata("injectSecondaryConstructorSkipsProvider.kt")
+    public void testInjectSecondaryConstructorSkipsProvider() {
+      runTest("metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrobot/injectSecondaryConstructorSkipsProvider.kt");
     }
   }
 

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/java/software/amazon/app/platform/metro/compiler/runners/BoxTestGenerated.java
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/java/software/amazon/app/platform/metro/compiler/runners/BoxTestGenerated.java
@@ -31,6 +31,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
     }
 
     @Test
+    @TestMetadata("constructorParametersWithoutInject.kt")
+    public void testConstructorParametersWithoutInject() {
+      runTest("metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrenderer/constructorParametersWithoutInject.kt");
+    }
+
+    @Test
     @TestMetadata("defaultConstructorRenderer.kt")
     public void testDefaultConstructorRenderer() {
       runTest("metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrenderer/defaultConstructorRenderer.kt");
@@ -58,6 +64,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
     @TestMetadata("injectConstructorRenderer.kt")
     public void testInjectConstructorRenderer() {
       runTest("metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrenderer/injectConstructorRenderer.kt");
+    }
+
+    @Test
+    @TestMetadata("injectSecondaryConstructorSkipsProvider.kt")
+    public void testInjectSecondaryConstructorSkipsProvider() {
+      runTest("metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrenderer/injectSecondaryConstructorSkipsProvider.kt");
     }
 
     @Test

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/java/software/amazon/app/platform/metro/compiler/runners/BoxTestGenerated.java
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/java/software/amazon/app/platform/metro/compiler/runners/BoxTestGenerated.java
@@ -159,9 +159,21 @@ public class BoxTestGenerated extends AbstractBoxTest {
     }
 
     @Test
+    @TestMetadata("constructorParametersWithoutInject.kt")
+    public void testConstructorParametersWithoutInject() {
+      runTest("metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesscoped/constructorParametersWithoutInject.kt");
+    }
+
+    @Test
     @TestMetadata("defaultScoped.kt")
     public void testDefaultScoped() {
       runTest("metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesscoped/defaultScoped.kt");
+    }
+
+    @Test
+    @TestMetadata("injectSecondaryConstructorSkipsProvider.kt")
+    public void testInjectSecondaryConstructorSkipsProvider() {
+      runTest("metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesscoped/injectSecondaryConstructorSkipsProvider.kt");
     }
 
     @Test

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/java/software/amazon/app/platform/metro/compiler/runners/FirDiagnosticTestGenerated.java
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/java/software/amazon/app/platform/metro/compiler/runners/FirDiagnosticTestGenerated.java
@@ -99,15 +99,15 @@ public class FirDiagnosticTestGenerated extends AbstractFirDiagnosticTest {
     }
 
     @Test
-    @TestMetadata("multipleOtherSupertypes.kt")
-    public void testMultipleOtherSupertypes() {
-      runTest("metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesscoped/multipleOtherSupertypes.kt");
+    @TestMetadata("multipleConstructorsMustUseInject.kt")
+    public void testMultipleConstructorsMustUseInject() {
+      runTest("metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesscoped/multipleConstructorsMustUseInject.kt");
     }
 
     @Test
-    @TestMetadata("mustBeInject.kt")
-    public void testMustBeInject() {
-      runTest("metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesscoped/mustBeInject.kt");
+    @TestMetadata("multipleOtherSupertypes.kt")
+    public void testMultipleOtherSupertypes() {
+      runTest("metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesscoped/multipleOtherSupertypes.kt");
     }
 
     @Test

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/java/software/amazon/app/platform/metro/compiler/runners/FirDiagnosticTestGenerated.java
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/java/software/amazon/app/platform/metro/compiler/runners/FirDiagnosticTestGenerated.java
@@ -31,15 +31,15 @@ public class FirDiagnosticTestGenerated extends AbstractFirDiagnosticTest {
     }
 
     @Test
-    @TestMetadata("missingInjectOnNonZeroArgConstructor.kt")
-    public void testMissingInjectOnNonZeroArgConstructor() {
-      runTest("metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesrenderer/missingInjectOnNonZeroArgConstructor.kt");
-    }
-
-    @Test
     @TestMetadata("modelTypeMustBeExplicitWhenNotInferable.kt")
     public void testModelTypeMustBeExplicitWhenNotInferable() {
       runTest("metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesrenderer/modelTypeMustBeExplicitWhenNotInferable.kt");
+    }
+
+    @Test
+    @TestMetadata("multipleConstructorsMustUseInject.kt")
+    public void testMultipleConstructorsMustUseInject() {
+      runTest("metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesrenderer/multipleConstructorsMustUseInject.kt");
     }
 
     @Test

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/java/software/amazon/app/platform/metro/compiler/runners/FirDiagnosticTestGenerated.java
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/java/software/amazon/app/platform/metro/compiler/runners/FirDiagnosticTestGenerated.java
@@ -71,9 +71,9 @@ public class FirDiagnosticTestGenerated extends AbstractFirDiagnosticTest {
     }
 
     @Test
-    @TestMetadata("classWithConstructorParametersMustUseInject.kt")
-    public void testClassWithConstructorParametersMustUseInject() {
-      runTest("metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesrobot/classWithConstructorParametersMustUseInject.kt");
+    @TestMetadata("multipleConstructorsMustUseInject.kt")
+    public void testMultipleConstructorsMustUseInject() {
+      runTest("metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesrobot/multipleConstructorsMustUseInject.kt");
     }
 
     @Test

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/java/software/amazon/app/platform/metro/compiler/runners/FirDumpTestGenerated.java
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/java/software/amazon/app/platform/metro/compiler/runners/FirDumpTestGenerated.java
@@ -31,6 +31,12 @@ public class FirDumpTestGenerated extends AbstractFirDumpTest {
     }
 
     @Test
+    @TestMetadata("constructorParametersWithoutInject.kt")
+    public void testConstructorParametersWithoutInject() {
+      runTest("metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrenderer/constructorParametersWithoutInject.kt");
+    }
+
+    @Test
     @TestMetadata("defaultConstructorRenderer.kt")
     public void testDefaultConstructorRenderer() {
       runTest("metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrenderer/defaultConstructorRenderer.kt");

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/java/software/amazon/app/platform/metro/compiler/runners/FirDumpTestGenerated.java
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/java/software/amazon/app/platform/metro/compiler/runners/FirDumpTestGenerated.java
@@ -87,6 +87,12 @@ public class FirDumpTestGenerated extends AbstractFirDumpTest {
     }
 
     @Test
+    @TestMetadata("constructorParametersWithoutInject.kt")
+    public void testConstructorParametersWithoutInject() {
+      runTest("metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesscoped/constructorParametersWithoutInject.kt");
+    }
+
+    @Test
     @TestMetadata("defaultScoped.kt")
     public void testDefaultScoped() {
       runTest("metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesscoped/defaultScoped.kt");

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/java/software/amazon/app/platform/metro/compiler/runners/FirDumpTestGenerated.java
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/java/software/amazon/app/platform/metro/compiler/runners/FirDumpTestGenerated.java
@@ -53,6 +53,12 @@ public class FirDumpTestGenerated extends AbstractFirDumpTest {
     }
 
     @Test
+    @TestMetadata("constructorParametersWithoutInject.kt")
+    public void testConstructorParametersWithoutInject() {
+      runTest("metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrobot/constructorParametersWithoutInject.kt");
+    }
+
+    @Test
     @TestMetadata("defaultConstructorRobot.kt")
     public void testDefaultConstructorRobot() {
       runTest("metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrobot/defaultConstructorRobot.kt");

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrenderer/constructorParametersWithoutInject.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrenderer/constructorParametersWithoutInject.kt
@@ -1,5 +1,6 @@
 package com.test
 
+import dev.zacsweers.metro.BindingContainer
 import software.amazon.app.platform.inject.ContributesRenderer
 import software.amazon.app.platform.metro.compiler.support.UnusedRendererFactory
 import software.amazon.app.platform.presenter.BaseModel
@@ -19,6 +20,27 @@ interface AppGraph {
 }
 
 fun box(): String {
+  if (
+    TestRenderer.RendererContribution::class.java.getAnnotation(BindingContainer::class.java) ==
+      null
+  ) {
+    return "FAIL: expected RendererContribution to be a BindingContainer"
+  }
+  if (
+    TestRenderer.RendererContribution::class.java.declaredMethods.any {
+      it.name == "provideComTestTestRenderer"
+    }
+  ) {
+    return "FAIL: expected constructor provider to be moved off the RendererContribution interface"
+  }
+  if (
+    TestRenderer.RendererContribution.Companion::class.java.declaredMethods.none {
+      it.name == "provideComTestTestRenderer"
+    }
+  ) {
+    return "FAIL: expected constructor provider on RendererContribution companion"
+  }
+
   val factory = createGraph<AppGraph>() as RendererGraph.Factory
   val graph = factory.createRendererGraph(UnusedRendererFactory)
   val rendererProvider = graph.renderers.getValue(Model::class)

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrenderer/constructorParametersWithoutInject.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrenderer/constructorParametersWithoutInject.kt
@@ -1,0 +1,40 @@
+package com.test
+
+import software.amazon.app.platform.inject.ContributesRenderer
+import software.amazon.app.platform.metro.compiler.support.UnusedRendererFactory
+import software.amazon.app.platform.presenter.BaseModel
+import software.amazon.app.platform.renderer.Renderer
+import software.amazon.app.platform.renderer.RendererGraph
+
+class Model : BaseModel
+
+@ContributesRenderer
+class TestRenderer(val string: String) : Renderer<Model> {
+  override fun render(model: Model) = Unit
+}
+
+@DependencyGraph(AppScope::class)
+interface AppGraph {
+  @Provides fun provideString(): String = "abc"
+}
+
+fun box(): String {
+  val factory = createGraph<AppGraph>() as RendererGraph.Factory
+  val graph = factory.createRendererGraph(UnusedRendererFactory)
+  val rendererProvider = graph.renderers.getValue(Model::class)
+  val renderer = rendererProvider()
+  if (renderer !is TestRenderer) {
+    return "FAIL: expected TestRenderer but got $renderer"
+  }
+  if (renderer.string != "abc") {
+    return "FAIL: expected injected string to be abc but got ${renderer.string}"
+  }
+  if (graph.renderers.keys != setOf(Model::class)) {
+    return "FAIL: unexpected renderer keys ${graph.renderers.keys}"
+  }
+  if (graph.modelToRendererMapping != mapOf(Model::class to TestRenderer::class)) {
+    return "FAIL: unexpected modelToRendererMapping ${graph.modelToRendererMapping}"
+  }
+
+  return "OK"
+}

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrenderer/injectSecondaryConstructorSkipsProvider.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrenderer/injectSecondaryConstructorSkipsProvider.kt
@@ -1,0 +1,48 @@
+package com.test
+
+import software.amazon.app.platform.inject.ContributesRenderer
+import software.amazon.app.platform.metro.compiler.support.UnusedRendererFactory
+import software.amazon.app.platform.presenter.BaseModel
+import software.amazon.app.platform.renderer.Renderer
+import software.amazon.app.platform.renderer.RendererGraph
+
+class Model : BaseModel
+
+@ContributesRenderer
+class TestRenderer private constructor(
+  val string: String,
+  val marker: String,
+) : Renderer<Model> {
+  @Inject constructor(string: String) : this(string, "injected")
+
+  override fun render(model: Model) = Unit
+}
+
+@DependencyGraph(AppScope::class)
+interface AppGraph {
+  @Provides fun provideString(): String = "abc"
+}
+
+fun box(): String {
+  val factory = createGraph<AppGraph>() as RendererGraph.Factory
+  val graph = factory.createRendererGraph(UnusedRendererFactory)
+  val rendererProvider = graph.renderers.getValue(Model::class)
+  val renderer = rendererProvider()
+  if (renderer !is TestRenderer) {
+    return "FAIL: expected TestRenderer but got $renderer"
+  }
+  if (renderer.string != "abc") {
+    return "FAIL: expected injected string to be abc but got ${renderer.string}"
+  }
+  if (renderer.marker != "injected") {
+    return "FAIL: expected marker to be injected but got ${renderer.marker}"
+  }
+  if (graph.renderers.keys != setOf(Model::class)) {
+    return "FAIL: unexpected renderer keys ${graph.renderers.keys}"
+  }
+  if (graph.modelToRendererMapping != mapOf(Model::class to TestRenderer::class)) {
+    return "FAIL: unexpected modelToRendererMapping ${graph.modelToRendererMapping}"
+  }
+
+  return "OK"
+}

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrobot/constructorParametersWithoutInject.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrobot/constructorParametersWithoutInject.kt
@@ -1,0 +1,35 @@
+package com.test
+
+import software.amazon.app.platform.inject.robot.ContributesRobot
+import software.amazon.app.platform.robot.Robot
+import software.amazon.app.platform.robot.RobotGraph
+
+class RobotDependency {
+  fun value(): String = "dependency"
+}
+
+@ContributesRobot(AppScope::class)
+class TestRobot(
+  val dependency: RobotDependency,
+) : Robot
+
+@DependencyGraph(AppScope::class)
+interface MyGraph : RobotGraph {
+  @Provides fun robotDependency(): RobotDependency = RobotDependency()
+}
+
+fun box(): String {
+  val graph = createGraph<MyGraph>()
+  val robotFactory = graph.robots.getValue(TestRobot::class)
+  val robot = robotFactory()
+
+  if (robot !is TestRobot) {
+    return "FAIL: expected TestRobot but got $robot"
+  }
+
+  return if (robot.dependency.value() == "dependency") {
+    "OK"
+  } else {
+    "FAIL: dependency was not injected"
+  }
+}

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrobot/constructorParametersWithoutInject.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrobot/constructorParametersWithoutInject.kt
@@ -1,5 +1,6 @@
 package com.test
 
+import dev.zacsweers.metro.BindingContainer
 import software.amazon.app.platform.inject.robot.ContributesRobot
 import software.amazon.app.platform.robot.Robot
 import software.amazon.app.platform.robot.RobotGraph
@@ -19,6 +20,24 @@ interface MyGraph : RobotGraph {
 }
 
 fun box(): String {
+  if (
+    TestRobot.RobotContribution::class.java.getAnnotation(BindingContainer::class.java) == null
+  ) {
+    return "FAIL: expected RobotContribution to be a BindingContainer"
+  }
+  if (
+    TestRobot.RobotContribution::class.java.declaredMethods.any { it.name == "provideTestRobot" }
+  ) {
+    return "FAIL: expected provider to be moved off the RobotContribution interface"
+  }
+  if (
+    TestRobot.RobotContribution.Companion::class.java.declaredMethods.none {
+      it.name == "provideTestRobot"
+    }
+  ) {
+    return "FAIL: expected provider on RobotContribution companion"
+  }
+
   val graph = createGraph<MyGraph>()
   val robotFactory = graph.robots.getValue(TestRobot::class)
   val robot = robotFactory()

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrobot/injectClassSkipsProvider.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrobot/injectClassSkipsProvider.kt
@@ -1,0 +1,43 @@
+package com.test
+
+import software.amazon.app.platform.inject.robot.ContributesRobot
+import software.amazon.app.platform.robot.Robot
+import software.amazon.app.platform.robot.RobotGraph
+
+@Inject
+class RobotDependency {
+  fun value(): String = "dependency"
+}
+
+@Inject
+@ContributesRobot(AppScope::class)
+class TestRobot(
+  val dependency: RobotDependency,
+) : Robot
+
+@DependencyGraph(AppScope::class)
+interface MyGraph : RobotGraph
+
+fun box(): String {
+  val provider =
+    TestRobot.RobotContribution::class.java.declaredMethods.singleOrNull {
+      it.name == "provideTestRobot"
+    }
+  if (provider != null) {
+    return "FAIL: expected generated provider to be skipped"
+  }
+
+  val graph = createGraph<MyGraph>()
+  val robotFactory = graph.robots.getValue(TestRobot::class)
+  val robot = robotFactory()
+
+  if (robot !is TestRobot) {
+    return "FAIL: expected TestRobot but got $robot"
+  }
+
+  return if (robot.dependency.value() == "dependency") {
+    "OK"
+  } else {
+    "FAIL: dependency was not injected"
+  }
+}

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrobot/injectSecondaryConstructorSkipsProvider.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesrobot/injectSecondaryConstructorSkipsProvider.kt
@@ -1,0 +1,45 @@
+package com.test
+
+import software.amazon.app.platform.inject.robot.ContributesRobot
+import software.amazon.app.platform.robot.Robot
+import software.amazon.app.platform.robot.RobotGraph
+
+@Inject
+class RobotDependency {
+  fun value(): String = "dependency"
+}
+
+@ContributesRobot(AppScope::class)
+class TestRobot private constructor(
+  val dependency: RobotDependency,
+  val marker: String,
+) : Robot {
+  @Inject constructor(dependency: RobotDependency) : this(dependency, "injected")
+}
+
+@DependencyGraph(AppScope::class)
+interface MyGraph : RobotGraph
+
+fun box(): String {
+  val provider =
+    TestRobot.RobotContribution::class.java.declaredMethods.singleOrNull {
+      it.name == "provideTestRobot"
+    }
+  if (provider != null) {
+    return "FAIL: expected generated provider to be skipped"
+  }
+
+  val graph = createGraph<MyGraph>()
+  val robotFactory = graph.robots.getValue(TestRobot::class)
+  val robot = robotFactory()
+
+  if (robot !is TestRobot) {
+    return "FAIL: expected TestRobot but got $robot"
+  }
+
+  return if (robot.dependency.value() == "dependency" && robot.marker == "injected") {
+    "OK"
+  } else {
+    "FAIL: dependency was not injected through secondary constructor"
+  }
+}

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesscoped/constructorParametersWithoutInject.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesscoped/constructorParametersWithoutInject.kt
@@ -1,0 +1,46 @@
+package com.test
+
+import software.amazon.app.platform.inject.metro.ContributesScoped
+import software.amazon.app.platform.scope.Scoped
+
+interface SuperType
+
+class ScopedDependency {
+  fun value(): String = "dependency"
+}
+
+@SingleIn(AppScope::class)
+@ContributesScoped(AppScope::class)
+class TestClass(
+  val dependency: ScopedDependency,
+) : SuperType, Scoped
+
+@DependencyGraph(AppScope::class)
+@SingleIn(AppScope::class)
+interface GraphInterface {
+  val superTypeInstance: SuperType
+
+  @ForScope(AppScope::class)
+  val allScoped: Set<Scoped>
+
+  @Provides fun scopedDependency(): ScopedDependency = ScopedDependency()
+}
+
+fun box(): String {
+  val graph = createGraph<GraphInterface>()
+  val scoped = graph.allScoped.single()
+  if (graph.superTypeInstance !is TestClass) {
+    return "FAIL: expected TestClass super type binding but got ${graph.superTypeInstance}"
+  }
+  if (scoped !is TestClass) {
+    return "FAIL: expected TestClass scoped binding but got $scoped"
+  }
+  if (graph.superTypeInstance !== scoped) {
+    return "FAIL: expected scoped provider to share the singleton instance"
+  }
+  if (scoped.dependency.value() != "dependency") {
+    return "FAIL: dependency was not injected"
+  }
+
+  return "OK"
+}

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesscoped/constructorParametersWithoutInject.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesscoped/constructorParametersWithoutInject.kt
@@ -1,5 +1,6 @@
 package com.test
 
+import dev.zacsweers.metro.BindingContainer
 import software.amazon.app.platform.inject.metro.ContributesScoped
 import software.amazon.app.platform.scope.Scoped
 
@@ -27,6 +28,24 @@ interface GraphInterface {
 }
 
 fun box(): String {
+  if (
+    TestClass.ScopedContribution::class.java.getAnnotation(BindingContainer::class.java) == null
+  ) {
+    return "FAIL: expected ScopedContribution to be a BindingContainer"
+  }
+  if (
+    TestClass.ScopedContribution::class.java.declaredMethods.any { it.name == "provideTestClass" }
+  ) {
+    return "FAIL: expected provider to be moved off the ScopedContribution interface"
+  }
+  if (
+    TestClass.ScopedContribution.Companion::class.java.declaredMethods.none {
+      it.name == "provideTestClass"
+    }
+  ) {
+    return "FAIL: expected provider on ScopedContribution companion"
+  }
+
   val graph = createGraph<GraphInterface>()
   val scoped = graph.allScoped.single()
   if (graph.superTypeInstance !is TestClass) {

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesscoped/injectSecondaryConstructorSkipsProvider.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/box/contributesscoped/injectSecondaryConstructorSkipsProvider.kt
@@ -1,0 +1,57 @@
+package com.test
+
+import software.amazon.app.platform.inject.metro.ContributesScoped
+import software.amazon.app.platform.scope.Scoped
+
+interface SuperType
+
+@Inject
+class ScopedDependency {
+  fun value(): String = "dependency"
+}
+
+@SingleIn(AppScope::class)
+@ContributesScoped(AppScope::class)
+class TestClass private constructor(
+  val dependency: ScopedDependency,
+  val marker: String,
+) : SuperType, Scoped {
+  @Inject constructor(dependency: ScopedDependency) : this(dependency, "injected")
+}
+
+@DependencyGraph(AppScope::class)
+@SingleIn(AppScope::class)
+interface GraphInterface {
+  val superTypeInstance: SuperType
+
+  @ForScope(AppScope::class)
+  val allScoped: Set<Scoped>
+}
+
+fun box(): String {
+  val provider =
+    TestClass.ScopedContribution::class.java.declaredMethods.singleOrNull {
+      it.name == "provideTestClass"
+    }
+  if (provider != null) {
+    return "FAIL: expected generated provider to be skipped"
+  }
+
+  val graph = createGraph<GraphInterface>()
+  val scoped = graph.allScoped.single()
+  if (graph.superTypeInstance !is TestClass) {
+    return "FAIL: expected TestClass super type binding but got ${graph.superTypeInstance}"
+  }
+  if (scoped !is TestClass) {
+    return "FAIL: expected TestClass scoped binding but got $scoped"
+  }
+  if (graph.superTypeInstance !== scoped) {
+    return "FAIL: expected shared singleton instance"
+  }
+
+  return if (scoped.dependency.value() == "dependency" && scoped.marker == "injected") {
+    "OK"
+  } else {
+    "FAIL: dependency was not injected through secondary constructor"
+  }
+}

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesrenderer/missingInjectOnNonZeroArgConstructor.fir.diag.txt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesrenderer/missingInjectOnNonZeroArgConstructor.fir.diag.txt
@@ -1,1 +1,0 @@
-/missingInjectOnNonZeroArgConstructor.kt:(278,298): error: When using @ContributesRenderer and you need to inject types in the constructor, then it's necessary to add the @Inject annotation.

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesrenderer/multipleConstructorsMustUseInject.fir.diag.txt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesrenderer/multipleConstructorsMustUseInject.fir.diag.txt
@@ -1,0 +1,1 @@
+/multipleConstructorsMustUseInject.kt:(278,298): error: TestRenderer has multiple constructors. Annotate the constructor to use with @Inject, or remove the extra constructors so @ContributesRenderer can generate a provider.

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesrenderer/multipleConstructorsMustUseInject.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesrenderer/multipleConstructorsMustUseInject.kt
@@ -8,6 +8,8 @@ import software.amazon.app.platform.renderer.Renderer
 class Model : BaseModel
 
 <!CONTRIBUTES_RENDERER_ERROR!>@ContributesRenderer<!>
-class TestRenderer(@Suppress("unused") val string: String) : Renderer<Model> {
+class TestRenderer(val string: String) : Renderer<Model> {
+  constructor(string: String, marker: String) : this(string)
+
   override fun render(model: Model) = Unit
 }

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesrobot/classWithConstructorParametersMustUseInject.fir.diag.txt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesrobot/classWithConstructorParametersMustUseInject.fir.diag.txt
@@ -1,1 +1,0 @@
-/classWithConstructorParametersMustUseInject.kt:(217,251): error: TestRobot must be annotated with @Inject when injecting arguments into a robot.

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesrobot/multipleConstructorsMustUseInject.fir.diag.txt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesrobot/multipleConstructorsMustUseInject.fir.diag.txt
@@ -1,0 +1,1 @@
+/multipleConstructorsMustUseInject.kt:(217,251): error: TestRobot has multiple constructors. Annotate the constructor to use with @Inject, or remove the extra constructors so @ContributesRobot can generate a provider.

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesrobot/multipleConstructorsMustUseInject.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesrobot/multipleConstructorsMustUseInject.kt
@@ -9,4 +9,6 @@ class RobotDependency
 <!CONTRIBUTES_ROBOT_ERROR!>@ContributesRobot(AppScope::class)<!>
 class TestRobot(
   val dependency: RobotDependency,
-) : Robot
+) : Robot {
+  constructor(dependency: RobotDependency, marker: String) : this(dependency)
+}

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesscoped/multipleConstructorsMustUseInject.fir.diag.txt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesscoped/multipleConstructorsMustUseInject.fir.diag.txt
@@ -1,0 +1,1 @@
+/multipleConstructorsMustUseInject.kt:(217,252): error: TestClass has multiple constructors. Annotate the constructor to use with @Inject, or remove the extra constructors so @ContributesScoped can generate a provider.

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesscoped/multipleConstructorsMustUseInject.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesscoped/multipleConstructorsMustUseInject.kt
@@ -6,6 +6,9 @@ import software.amazon.app.platform.scope.Scoped
 
 interface SuperType
 
-@SingleIn(AppScope::class)
 <!CONTRIBUTES_SCOPED_ERROR!>@ContributesScoped(AppScope::class)<!>
-class TestClass : SuperType, Scoped
+class TestClass(
+  val dependency: String,
+) : SuperType, Scoped {
+  constructor(dependency: String, marker: String) : this(dependency)
+}

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesscoped/mustBeInject.fir.diag.txt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/diagnostics/contributesscoped/mustBeInject.fir.diag.txt
@@ -1,1 +1,0 @@
-/mustBeInject.kt:(244,279): error: TestClass must be annotated with @Inject when using @ContributesScoped.

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrenderer/constructorParametersWithoutInject.fir.txt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrenderer/constructorParametersWithoutInject.fir.txt
@@ -1,4 +1,4 @@
-FILE: defaultConstructorRenderer.kt
+FILE: constructorParametersWithoutInject.kt
     package com.test
 
     public final class Model : R|software/amazon/app/platform/presenter/BaseModel| {
@@ -7,18 +7,36 @@ FILE: defaultConstructorRenderer.kt
         }
 
     }
-    @R|software/amazon/app/platform/inject/ContributesRenderer|() public final class TestRenderer : R|software/amazon/app/platform/renderer/Renderer<com/test/Model>| {
-        public constructor(): R|com/test/TestRenderer| {
+    public final class RendererDependency : R|kotlin/Any| {
+        public constructor(): R|com/test/RendererDependency| {
             super<R|kotlin/Any|>()
         }
+
+    }
+    public final class AnotherRendererDependency : R|kotlin/Any| {
+        public constructor(): R|com/test/AnotherRendererDependency| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    @R|software/amazon/app/platform/inject/ContributesRenderer|() public final class TestRenderer : R|software/amazon/app/platform/renderer/Renderer<com/test/Model>| {
+        public constructor(dependency: R|com/test/RendererDependency|, anotherDependency: R|com/test/AnotherRendererDependency|): R|com/test/TestRenderer| {
+            super<R|kotlin/Any|>()
+        }
+
+        public final val dependency: R|com/test/RendererDependency| = R|<local>/dependency|
+            public get(): R|com/test/RendererDependency|
+
+        public final val anotherDependency: R|com/test/AnotherRendererDependency| = R|<local>/anotherDependency|
+            public get(): R|com/test/AnotherRendererDependency|
 
         public open override fun render(model: R|com/test/Model|): R|kotlin/Unit| {
             ^render Q|kotlin/Unit|
         }
 
         @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|software/amazon/app/platform/renderer/RendererScope|)) @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/TestRenderer|)) public abstract interface RendererContribution : R|kotlin/Any| {
-            @R|dev/zacsweers/metro/Provides|() public open fun provideComTestTestRenderer(): R|com/test/TestRenderer| {
-                ^provideComTestTestRenderer R|com/test/TestRenderer.TestRenderer|()
+            @R|dev/zacsweers/metro/Provides|() public open fun provideComTestTestRenderer(dependency: R|com/test/RendererDependency|, anotherDependency: R|com/test/AnotherRendererDependency|): R|com/test/TestRenderer| {
+                ^provideComTestTestRenderer R|com/test/TestRenderer.TestRenderer|(R|<local>/dependency|, R|<local>/anotherDependency|)
             }
 
             @R|dev/zacsweers/metro/Binds|() @R|dev/zacsweers/metro/IntoMap|() @R|software/amazon/app/platform/renderer/metro/RendererKey|(value = <getClass>(Q|com/test/Model|)) public open fun provideComTestTestRendererModel(renderer: R|com/test/TestRenderer|): R|software/amazon/app/platform/renderer/Renderer<*>|
@@ -28,7 +46,7 @@ FILE: defaultConstructorRenderer.kt
             @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/MetroContribution|(scope = <getClass>(Q|software/amazon/app/platform/renderer/RendererScope|)) public abstract interface MetroContributionToSoftwareamazonappplatformrendererrendererScope2FKSELE : R|com/test/TestRenderer.RendererContribution| {
             }
 
-            @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/CallableMetadata|(callableName = String(provideComTestTestRenderer), propertyName = String(), startOffset = Int(276), endOffset = Int(380), newInstanceName = String(provideComTestTestRenderer)) public final class ProvideComTestTestRendererMetroFactory : R|kotlin/Any| {
+            @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/CallableMetadata|(callableName = String(provideComTestTestRenderer), propertyName = String(), startOffset = Int(335), endOffset = Int(532), newInstanceName = String(provideComTestTestRenderer)) public final class ProvideComTestTestRendererMetroFactory : R|kotlin/Any| {
                 public final companion object Companion : R|kotlin/Any| {
                     private constructor(): R|com/test/TestRenderer.RendererContribution.ProvideComTestTestRendererMetroFactory.Companion| {
                         super<R|kotlin/Any|>()
@@ -38,7 +56,7 @@ FILE: defaultConstructorRenderer.kt
 
             }
 
-            @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/CallableMetadata|(callableName = String(provideComTestTestRendererModelKey), propertyName = String(), startOffset = Int(276), endOffset = Int(380), newInstanceName = String(provideComTestTestRendererModelKey)) public final class ProvideComTestTestRendererModelKeyMetroFactory : R|kotlin/Any| {
+            @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/CallableMetadata|(callableName = String(provideComTestTestRendererModelKey), propertyName = String(), startOffset = Int(335), endOffset = Int(532), newInstanceName = String(provideComTestTestRendererModelKey)) public final class ProvideComTestTestRendererModelKeyMetroFactory : R|kotlin/Any| {
                 public final companion object Companion : R|kotlin/Any| {
                     private constructor(): R|com/test/TestRenderer.RendererContribution.ProvideComTestTestRendererModelKeyMetroFactory.Companion| {
                         super<R|kotlin/Any|>()

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrenderer/constructorParametersWithoutInject.fir.txt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrenderer/constructorParametersWithoutInject.fir.txt
@@ -34,31 +34,32 @@ FILE: constructorParametersWithoutInject.kt
             ^render Q|kotlin/Unit|
         }
 
-        @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|software/amazon/app/platform/renderer/RendererScope|)) @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/TestRenderer|)) public abstract interface RendererContribution : R|kotlin/Any| {
-            @R|dev/zacsweers/metro/Provides|() public open fun provideComTestTestRenderer(dependency: R|com/test/RendererDependency|, anotherDependency: R|com/test/AnotherRendererDependency|): R|com/test/TestRenderer| {
-                ^provideComTestTestRenderer R|com/test/TestRenderer.TestRenderer|(R|<local>/dependency|, R|<local>/anotherDependency|)
-            }
-
+        @R|dev/zacsweers/metro/BindingContainer|() @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|software/amazon/app/platform/renderer/RendererScope|)) @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/TestRenderer|)) public abstract interface RendererContribution : R|kotlin/Any| {
             @R|dev/zacsweers/metro/Binds|() @R|dev/zacsweers/metro/IntoMap|() @R|software/amazon/app/platform/renderer/metro/RendererKey|(value = <getClass>(Q|com/test/Model|)) public open fun provideComTestTestRendererModel(renderer: R|com/test/TestRenderer|): R|software/amazon/app/platform/renderer/Renderer<*>|
 
-            @R|dev/zacsweers/metro/Provides|() @R|dev/zacsweers/metro/IntoMap|() @R|software/amazon/app/platform/renderer/metro/RendererKey|(value = <getClass>(Q|com/test/Model|)) @R|dev/zacsweers/metro/ForScope|(scope = <getClass>(Q|software/amazon/app/platform/renderer/RendererScope|)) public open fun provideComTestTestRendererModelKey(): R|kotlin/reflect/KClass<out software/amazon/app/platform/renderer/Renderer<*>>|
+            public final companion object Companion : R|kotlin/Any| {
+                @R|dev/zacsweers/metro/Provides|() public open fun provideComTestTestRenderer(dependency: R|com/test/RendererDependency|, anotherDependency: R|com/test/AnotherRendererDependency|): R|com/test/TestRenderer| {
+                    ^provideComTestTestRenderer R|com/test/TestRenderer.TestRenderer|(R|<local>/dependency|, R|<local>/anotherDependency|)
+                }
 
-            @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/MetroContribution|(scope = <getClass>(Q|software/amazon/app/platform/renderer/RendererScope|)) public abstract interface MetroContributionToSoftwareamazonappplatformrendererrendererScope2FKSELE : R|com/test/TestRenderer.RendererContribution| {
-            }
+                @R|dev/zacsweers/metro/Provides|() @R|dev/zacsweers/metro/IntoMap|() @R|software/amazon/app/platform/renderer/metro/RendererKey|(value = <getClass>(Q|com/test/Model|)) @R|dev/zacsweers/metro/ForScope|(scope = <getClass>(Q|software/amazon/app/platform/renderer/RendererScope|)) public open fun provideComTestTestRendererModelKey(): R|kotlin/reflect/KClass<out software/amazon/app/platform/renderer/Renderer<*>>|
 
-            @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/CallableMetadata|(callableName = String(provideComTestTestRenderer), propertyName = String(), startOffset = Int(335), endOffset = Int(532), newInstanceName = String(provideComTestTestRenderer)) public final class ProvideComTestTestRendererMetroFactory : R|kotlin/Any| {
-                public final companion object Companion : R|kotlin/Any| {
-                    private constructor(): R|com/test/TestRenderer.RendererContribution.ProvideComTestTestRendererMetroFactory.Companion| {
-                        super<R|kotlin/Any|>()
+                private constructor(): R|com/test/TestRenderer.RendererContribution.Companion| {
+                    super<R|kotlin/Any|>()
+                }
+
+                @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/CallableMetadata|(callableName = String(provideComTestTestRenderer), propertyName = String(), startOffset = Int(335), endOffset = Int(532), newInstanceName = String(provideComTestTestRenderer)) public final class ProvideComTestTestRendererMetroFactory : R|kotlin/Any| {
+                    public final companion object Companion : R|kotlin/Any| {
+                        private constructor(): R|com/test/TestRenderer.RendererContribution.Companion.ProvideComTestTestRendererMetroFactory.Companion| {
+                            super<R|kotlin/Any|>()
+                        }
+
                     }
 
                 }
 
-            }
-
-            @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/CallableMetadata|(callableName = String(provideComTestTestRendererModelKey), propertyName = String(), startOffset = Int(335), endOffset = Int(532), newInstanceName = String(provideComTestTestRendererModelKey)) public final class ProvideComTestTestRendererModelKeyMetroFactory : R|kotlin/Any| {
-                public final companion object Companion : R|kotlin/Any| {
-                    private constructor(): R|com/test/TestRenderer.RendererContribution.ProvideComTestTestRendererModelKeyMetroFactory.Companion| {
+                @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/CallableMetadata|(callableName = String(provideComTestTestRendererModelKey), propertyName = String(), startOffset = Int(335), endOffset = Int(532), newInstanceName = String(provideComTestTestRendererModelKey)) public final object ProvideComTestTestRendererModelKeyMetroFactory : R|kotlin/Any| {
+                    private constructor(): R|com/test/TestRenderer.RendererContribution.Companion.ProvideComTestTestRendererModelKeyMetroFactory| {
                         super<R|kotlin/Any|>()
                     }
 

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrenderer/constructorParametersWithoutInject.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrenderer/constructorParametersWithoutInject.kt
@@ -1,0 +1,20 @@
+// RUN_PIPELINE_TILL: BACKEND
+package com.test
+
+import software.amazon.app.platform.inject.ContributesRenderer
+import software.amazon.app.platform.presenter.BaseModel
+import software.amazon.app.platform.renderer.Renderer
+
+class Model : BaseModel
+
+class RendererDependency
+
+class AnotherRendererDependency
+
+@ContributesRenderer
+class TestRenderer(
+  val dependency: RendererDependency,
+  val anotherDependency: AnotherRendererDependency,
+) : Renderer<Model> {
+  override fun render(model: Model) = Unit
+}

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrenderer/defaultConstructorRenderer.fir.txt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrenderer/defaultConstructorRenderer.fir.txt
@@ -16,31 +16,29 @@ FILE: defaultConstructorRenderer.kt
             ^render Q|kotlin/Unit|
         }
 
-        @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|software/amazon/app/platform/renderer/RendererScope|)) @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/TestRenderer|)) public abstract interface RendererContribution : R|kotlin/Any| {
-            @R|dev/zacsweers/metro/Provides|() public open fun provideComTestTestRenderer(): R|com/test/TestRenderer| {
-                ^provideComTestTestRenderer R|com/test/TestRenderer.TestRenderer|()
-            }
-
+        @R|dev/zacsweers/metro/BindingContainer|() @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|software/amazon/app/platform/renderer/RendererScope|)) @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/TestRenderer|)) public abstract interface RendererContribution : R|kotlin/Any| {
             @R|dev/zacsweers/metro/Binds|() @R|dev/zacsweers/metro/IntoMap|() @R|software/amazon/app/platform/renderer/metro/RendererKey|(value = <getClass>(Q|com/test/Model|)) public open fun provideComTestTestRendererModel(renderer: R|com/test/TestRenderer|): R|software/amazon/app/platform/renderer/Renderer<*>|
 
-            @R|dev/zacsweers/metro/Provides|() @R|dev/zacsweers/metro/IntoMap|() @R|software/amazon/app/platform/renderer/metro/RendererKey|(value = <getClass>(Q|com/test/Model|)) @R|dev/zacsweers/metro/ForScope|(scope = <getClass>(Q|software/amazon/app/platform/renderer/RendererScope|)) public open fun provideComTestTestRendererModelKey(): R|kotlin/reflect/KClass<out software/amazon/app/platform/renderer/Renderer<*>>|
+            public final companion object Companion : R|kotlin/Any| {
+                @R|dev/zacsweers/metro/Provides|() public open fun provideComTestTestRenderer(): R|com/test/TestRenderer| {
+                    ^provideComTestTestRenderer R|com/test/TestRenderer.TestRenderer|()
+                }
 
-            @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/MetroContribution|(scope = <getClass>(Q|software/amazon/app/platform/renderer/RendererScope|)) public abstract interface MetroContributionToSoftwareamazonappplatformrendererrendererScope2FKSELE : R|com/test/TestRenderer.RendererContribution| {
-            }
+                @R|dev/zacsweers/metro/Provides|() @R|dev/zacsweers/metro/IntoMap|() @R|software/amazon/app/platform/renderer/metro/RendererKey|(value = <getClass>(Q|com/test/Model|)) @R|dev/zacsweers/metro/ForScope|(scope = <getClass>(Q|software/amazon/app/platform/renderer/RendererScope|)) public open fun provideComTestTestRendererModelKey(): R|kotlin/reflect/KClass<out software/amazon/app/platform/renderer/Renderer<*>>|
 
-            @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/CallableMetadata|(callableName = String(provideComTestTestRenderer), propertyName = String(), startOffset = Int(276), endOffset = Int(380), newInstanceName = String(provideComTestTestRenderer)) public final class ProvideComTestTestRendererMetroFactory : R|kotlin/Any| {
-                public final companion object Companion : R|kotlin/Any| {
-                    private constructor(): R|com/test/TestRenderer.RendererContribution.ProvideComTestTestRendererMetroFactory.Companion| {
+                private constructor(): R|com/test/TestRenderer.RendererContribution.Companion| {
+                    super<R|kotlin/Any|>()
+                }
+
+                @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/CallableMetadata|(callableName = String(provideComTestTestRenderer), propertyName = String(), startOffset = Int(276), endOffset = Int(380), newInstanceName = String(provideComTestTestRenderer)) public final object ProvideComTestTestRendererMetroFactory : R|kotlin/Any| {
+                    private constructor(): R|com/test/TestRenderer.RendererContribution.Companion.ProvideComTestTestRendererMetroFactory| {
                         super<R|kotlin/Any|>()
                     }
 
                 }
 
-            }
-
-            @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/CallableMetadata|(callableName = String(provideComTestTestRendererModelKey), propertyName = String(), startOffset = Int(276), endOffset = Int(380), newInstanceName = String(provideComTestTestRendererModelKey)) public final class ProvideComTestTestRendererModelKeyMetroFactory : R|kotlin/Any| {
-                public final companion object Companion : R|kotlin/Any| {
-                    private constructor(): R|com/test/TestRenderer.RendererContribution.ProvideComTestTestRendererModelKeyMetroFactory.Companion| {
+                @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/CallableMetadata|(callableName = String(provideComTestTestRendererModelKey), propertyName = String(), startOffset = Int(276), endOffset = Int(380), newInstanceName = String(provideComTestTestRendererModelKey)) public final object ProvideComTestTestRendererModelKeyMetroFactory : R|kotlin/Any| {
+                    private constructor(): R|com/test/TestRenderer.RendererContribution.Companion.ProvideComTestTestRendererModelKeyMetroFactory| {
                         super<R|kotlin/Any|>()
                     }
 

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrenderer/defaultConstructorRendererIr.fir.kt.txt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrenderer/defaultConstructorRendererIr.fir.kt.txt
@@ -12,6 +12,7 @@ class Model : BaseModel {
 
 @ContributesRenderer
 class TestRenderer : Renderer<Model> {
+  @BindingContainer
   @ContributesTo(scope = RendererScope::class)
   @Origin(value = TestRenderer::class)
   interface RendererContribution {
@@ -32,16 +33,10 @@ class TestRenderer : Renderer<Model> {
 
     }
 
-    @Deprecated(message = "This synthesized declaration should not be used directly", level = DeprecationLevel.HIDDEN)
-    @MetroContribution(scope = RendererScope::class)
-    interface MetroContributionToSoftwareamazonappplatformrendererrendererScope2FKSELE : RendererContribution {
-    }
-
-    @Deprecated(message = "This synthesized declaration should not be used directly", level = DeprecationLevel.HIDDEN)
-    @CallableMetadata(callableName = "provideComTestTestRenderer", propertyName = "", startOffset = 290, endOffset = 394, newInstanceName = "provideComTestTestRenderer")
-    class ProvideComTestTestRendererMetroFactory : Factory<TestRenderer> {
-      private /* final field */ val instance: RendererContribution = instance
-      companion object Companion {
+    companion object Companion {
+      @Deprecated(message = "This synthesized declaration should not be used directly", level = DeprecationLevel.HIDDEN)
+      @CallableMetadata(callableName = "provideComTestTestRenderer", propertyName = "", startOffset = 290, endOffset = 394, newInstanceName = "provideComTestTestRenderer")
+      object ProvideComTestTestRendererMetroFactory : Factory<TestRenderer> {
         private constructor() /* primary */ {
           super/*Any*/()
           /* <init>() */
@@ -51,43 +46,32 @@ class TestRenderer : Renderer<Model> {
         @HiddenFromObjC
         @JvmStatic
         @JsStatic
-        fun create(instance: RendererContribution): Factory<TestRenderer> {
-          return ProvideComTestTestRendererMetroFactory(instance = instance)
+        fun create(): Factory<TestRenderer> {
+          return ProvideComTestTestRendererMetroFactory
         }
 
         @HiddenFromObjC
         @JvmStatic
         @JsStatic
-        fun provideComTestTestRenderer(instance: RendererContribution): TestRenderer {
-          return instance.provideComTestTestRenderer()
+        fun provideComTestTestRenderer(): TestRenderer {
+          return Companion.provideComTestTestRenderer()
+        }
+
+        @HiddenFromObjC
+        override operator fun invoke(): TestRenderer {
+          return ProvideComTestTestRendererMetroFactory.provideComTestTestRenderer()
+        }
+
+        @HiddenFromObjC
+        fun mirrorFunction(): TestRenderer {
+          return error(message = "Never called")
         }
 
       }
 
-      @HiddenFromObjC
-      private constructor(instance: RendererContribution) /* primary */ {
-        super/*Any*/()
-        /* <init>() */
-
-      }
-
-      @HiddenFromObjC
-      override operator fun invoke(): TestRenderer {
-        return Companion.provideComTestTestRenderer(instance = <this>.#instance)
-      }
-
-      @HiddenFromObjC
-      fun mirrorFunction(): TestRenderer {
-        return error(message = "Never called")
-      }
-
-    }
-
-    @Deprecated(message = "This synthesized declaration should not be used directly", level = DeprecationLevel.HIDDEN)
-    @CallableMetadata(callableName = "provideComTestTestRendererModelKey", propertyName = "", startOffset = 290, endOffset = 394, newInstanceName = "provideComTestTestRendererModelKey")
-    class ProvideComTestTestRendererModelKeyMetroFactory : Factory<KClass<out Renderer<*>>> {
-      private /* final field */ val instance: RendererContribution = instance
-      companion object Companion {
+      @Deprecated(message = "This synthesized declaration should not be used directly", level = DeprecationLevel.HIDDEN)
+      @CallableMetadata(callableName = "provideComTestTestRendererModelKey", propertyName = "", startOffset = 290, endOffset = 394, newInstanceName = "provideComTestTestRendererModelKey")
+      object ProvideComTestTestRendererModelKeyMetroFactory : Factory<KClass<out Renderer<*>>> {
         private constructor() /* primary */ {
           super/*Any*/()
           /* <init>() */
@@ -97,44 +81,51 @@ class TestRenderer : Renderer<Model> {
         @HiddenFromObjC
         @JvmStatic
         @JsStatic
-        fun create(instance: RendererContribution): Factory<KClass<out Renderer<*>>> {
-          return ProvideComTestTestRendererModelKeyMetroFactory(instance = instance)
+        fun create(): Factory<KClass<out Renderer<*>>> {
+          return ProvideComTestTestRendererModelKeyMetroFactory
         }
 
         @HiddenFromObjC
         @JvmStatic
         @JsStatic
-        fun provideComTestTestRendererModelKey(instance: RendererContribution): KClass<out Renderer<*>> {
-          return instance.provideComTestTestRendererModelKey()
+        fun provideComTestTestRendererModelKey(): KClass<out Renderer<*>> {
+          return Companion.provideComTestTestRendererModelKey()
+        }
+
+        @HiddenFromObjC
+        override operator fun invoke(): KClass<out Renderer<*>> {
+          return ProvideComTestTestRendererModelKeyMetroFactory.provideComTestTestRendererModelKey()
+        }
+
+        @IntoMap
+        @ForScope(scope = RendererScope::class)
+        @RendererKey(value = Model::class)
+        @HiddenFromObjC
+        fun mirrorFunction(): KClass<out Renderer<*>> {
+          return error(message = "Never called")
         }
 
       }
 
-      @HiddenFromObjC
-      private constructor(instance: RendererContribution) /* primary */ {
+      private constructor() /* primary */ {
         super/*Any*/()
         /* <init>() */
 
       }
 
-      @HiddenFromObjC
-      override operator fun invoke(): KClass<out Renderer<*>> {
-        return Companion.provideComTestTestRendererModelKey(instance = <this>.#instance)
+      @Provides
+      open fun provideComTestTestRenderer(): TestRenderer {
+        return TestRenderer()
       }
 
+      @Provides
       @IntoMap
-      @ForScope(scope = RendererScope::class)
       @RendererKey(value = Model::class)
-      @HiddenFromObjC
-      fun mirrorFunction(): KClass<out Renderer<*>> {
-        return error(message = "Never called")
+      @ForScope(scope = RendererScope::class)
+      open fun provideComTestTestRendererModelKey(): KClass<out Renderer<*>> {
+        return TestRenderer::class
       }
 
-    }
-
-    @Provides
-    fun provideComTestTestRenderer(): TestRenderer {
-      return TestRenderer()
     }
 
     @Binds
@@ -143,14 +134,6 @@ class TestRenderer : Renderer<Model> {
     @ComptimeOnly
     fun provideComTestTestRendererModel(renderer: TestRenderer): Renderer<*> {
       return error(message = "Never called")
-    }
-
-    @Provides
-    @IntoMap
-    @RendererKey(value = Model::class)
-    @ForScope(scope = RendererScope::class)
-    fun provideComTestTestRendererModelKey(): KClass<out Renderer<*>> {
-      return TestRenderer::class
     }
 
   }

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrenderer/defaultConstructorRendererIr.fir.txt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrenderer/defaultConstructorRendererIr.fir.txt
@@ -17,7 +17,9 @@ FILE: defaultConstructorRendererIr.kt
         }
 
         @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|software/amazon/app/platform/renderer/RendererScope|)) @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/TestRenderer|)) public abstract interface RendererContribution : R|kotlin/Any| {
-            @R|dev/zacsweers/metro/Provides|() public open fun provideComTestTestRenderer(): R|com/test/TestRenderer|
+            @R|dev/zacsweers/metro/Provides|() public open fun provideComTestTestRenderer(): R|com/test/TestRenderer| {
+                ^provideComTestTestRenderer R|com/test/TestRenderer.TestRenderer|()
+            }
 
             @R|dev/zacsweers/metro/Binds|() @R|dev/zacsweers/metro/IntoMap|() @R|software/amazon/app/platform/renderer/metro/RendererKey|(value = <getClass>(Q|com/test/Model|)) public open fun provideComTestTestRendererModel(renderer: R|com/test/TestRenderer|): R|software/amazon/app/platform/renderer/Renderer<*>|
 

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrenderer/defaultConstructorRendererIr.fir.txt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrenderer/defaultConstructorRendererIr.fir.txt
@@ -16,31 +16,29 @@ FILE: defaultConstructorRendererIr.kt
             ^render Q|kotlin/Unit|
         }
 
-        @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|software/amazon/app/platform/renderer/RendererScope|)) @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/TestRenderer|)) public abstract interface RendererContribution : R|kotlin/Any| {
-            @R|dev/zacsweers/metro/Provides|() public open fun provideComTestTestRenderer(): R|com/test/TestRenderer| {
-                ^provideComTestTestRenderer R|com/test/TestRenderer.TestRenderer|()
-            }
-
+        @R|dev/zacsweers/metro/BindingContainer|() @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|software/amazon/app/platform/renderer/RendererScope|)) @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/TestRenderer|)) public abstract interface RendererContribution : R|kotlin/Any| {
             @R|dev/zacsweers/metro/Binds|() @R|dev/zacsweers/metro/IntoMap|() @R|software/amazon/app/platform/renderer/metro/RendererKey|(value = <getClass>(Q|com/test/Model|)) public open fun provideComTestTestRendererModel(renderer: R|com/test/TestRenderer|): R|software/amazon/app/platform/renderer/Renderer<*>|
 
-            @R|dev/zacsweers/metro/Provides|() @R|dev/zacsweers/metro/IntoMap|() @R|software/amazon/app/platform/renderer/metro/RendererKey|(value = <getClass>(Q|com/test/Model|)) @R|dev/zacsweers/metro/ForScope|(scope = <getClass>(Q|software/amazon/app/platform/renderer/RendererScope|)) public open fun provideComTestTestRendererModelKey(): R|kotlin/reflect/KClass<out software/amazon/app/platform/renderer/Renderer<*>>|
+            public final companion object Companion : R|kotlin/Any| {
+                @R|dev/zacsweers/metro/Provides|() public open fun provideComTestTestRenderer(): R|com/test/TestRenderer| {
+                    ^provideComTestTestRenderer R|com/test/TestRenderer.TestRenderer|()
+                }
 
-            @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/MetroContribution|(scope = <getClass>(Q|software/amazon/app/platform/renderer/RendererScope|)) public abstract interface MetroContributionToSoftwareamazonappplatformrendererrendererScope2FKSELE : R|com/test/TestRenderer.RendererContribution| {
-            }
+                @R|dev/zacsweers/metro/Provides|() @R|dev/zacsweers/metro/IntoMap|() @R|software/amazon/app/platform/renderer/metro/RendererKey|(value = <getClass>(Q|com/test/Model|)) @R|dev/zacsweers/metro/ForScope|(scope = <getClass>(Q|software/amazon/app/platform/renderer/RendererScope|)) public open fun provideComTestTestRendererModelKey(): R|kotlin/reflect/KClass<out software/amazon/app/platform/renderer/Renderer<*>>|
 
-            @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/CallableMetadata|(callableName = String(provideComTestTestRenderer), propertyName = String(), startOffset = Int(290), endOffset = Int(394), newInstanceName = String(provideComTestTestRenderer)) public final class ProvideComTestTestRendererMetroFactory : R|kotlin/Any| {
-                public final companion object Companion : R|kotlin/Any| {
-                    private constructor(): R|com/test/TestRenderer.RendererContribution.ProvideComTestTestRendererMetroFactory.Companion| {
+                private constructor(): R|com/test/TestRenderer.RendererContribution.Companion| {
+                    super<R|kotlin/Any|>()
+                }
+
+                @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/CallableMetadata|(callableName = String(provideComTestTestRenderer), propertyName = String(), startOffset = Int(290), endOffset = Int(394), newInstanceName = String(provideComTestTestRenderer)) public final object ProvideComTestTestRendererMetroFactory : R|kotlin/Any| {
+                    private constructor(): R|com/test/TestRenderer.RendererContribution.Companion.ProvideComTestTestRendererMetroFactory| {
                         super<R|kotlin/Any|>()
                     }
 
                 }
 
-            }
-
-            @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/CallableMetadata|(callableName = String(provideComTestTestRendererModelKey), propertyName = String(), startOffset = Int(290), endOffset = Int(394), newInstanceName = String(provideComTestTestRendererModelKey)) public final class ProvideComTestTestRendererModelKeyMetroFactory : R|kotlin/Any| {
-                public final companion object Companion : R|kotlin/Any| {
-                    private constructor(): R|com/test/TestRenderer.RendererContribution.ProvideComTestTestRendererModelKeyMetroFactory.Companion| {
+                @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/CallableMetadata|(callableName = String(provideComTestTestRendererModelKey), propertyName = String(), startOffset = Int(290), endOffset = Int(394), newInstanceName = String(provideComTestTestRendererModelKey)) public final object ProvideComTestTestRendererModelKeyMetroFactory : R|kotlin/Any| {
+                    private constructor(): R|com/test/TestRenderer.RendererContribution.Companion.ProvideComTestTestRendererModelKeyMetroFactory| {
                         super<R|kotlin/Any|>()
                     }
 

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrobot/constructorParametersWithoutInject.fir.txt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrobot/constructorParametersWithoutInject.fir.txt
@@ -1,14 +1,32 @@
-FILE: defaultConstructorRobot.kt
+FILE: constructorParametersWithoutInject.kt
     package com.test
 
-    @R|software/amazon/app/platform/inject/robot/ContributesRobot|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) public final class TestRobot : R|software/amazon/app/platform/robot/Robot| {
-        public constructor(): R|com/test/TestRobot| {
+    public final class RobotDependency : R|kotlin/Any| {
+        public constructor(): R|com/test/RobotDependency| {
             super<R|kotlin/Any|>()
         }
 
+    }
+    public final class AnotherRobotDependency : R|kotlin/Any| {
+        public constructor(): R|com/test/AnotherRobotDependency| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    @R|software/amazon/app/platform/inject/robot/ContributesRobot|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) public final class TestRobot : R|software/amazon/app/platform/robot/Robot| {
+        public constructor(dependency: R|com/test/RobotDependency|, anotherDependency: R|com/test/AnotherRobotDependency|): R|com/test/TestRobot| {
+            super<R|kotlin/Any|>()
+        }
+
+        public final val dependency: R|com/test/RobotDependency| = R|<local>/dependency|
+            public get(): R|com/test/RobotDependency|
+
+        public final val anotherDependency: R|com/test/AnotherRobotDependency| = R|<local>/anotherDependency|
+            public get(): R|com/test/AnotherRobotDependency|
+
         @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/TestRobot|)) public abstract interface RobotContribution : R|kotlin/Any| {
-            @R|dev/zacsweers/metro/Provides|() public open fun provideTestRobot(): R|com/test/TestRobot| {
-                ^provideTestRobot R|com/test/TestRobot.TestRobot|()
+            @R|dev/zacsweers/metro/Provides|() public open fun provideTestRobot(dependency: R|com/test/RobotDependency|, anotherDependency: R|com/test/AnotherRobotDependency|): R|com/test/TestRobot| {
+                ^provideTestRobot R|com/test/TestRobot.TestRobot|(R|<local>/dependency|, R|<local>/anotherDependency|)
             }
 
             @R|dev/zacsweers/metro/Binds|() @R|dev/zacsweers/metro/IntoMap|() @R|software/amazon/app/platform/renderer/metro/RobotKey|(value = <getClass>(Q|com/test/TestRobot|)) public open fun provideTestRobotIntoMap(robot: R|com/test/TestRobot|): R|software/amazon/app/platform/robot/Robot|
@@ -16,7 +34,7 @@ FILE: defaultConstructorRobot.kt
             @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/MetroContribution|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) public abstract interface MetroContributionToDevzacsweersmetroappScopeoxd1AHI : R|com/test/TestRobot.RobotContribution| {
             }
 
-            @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/CallableMetadata|(callableName = String(provideTestRobot), propertyName = String(), startOffset = Int(192), endOffset = Int(250), newInstanceName = String(provideTestRobot)) public final class ProvideTestRobotMetroFactory : R|kotlin/Any| {
+            @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/CallableMetadata|(callableName = String(provideTestRobot), propertyName = String(), startOffset = Int(245), endOffset = Int(390), newInstanceName = String(provideTestRobot)) public final class ProvideTestRobotMetroFactory : R|kotlin/Any| {
                 public final companion object Companion : R|kotlin/Any| {
                     private constructor(): R|com/test/TestRobot.RobotContribution.ProvideTestRobotMetroFactory.Companion| {
                         super<R|kotlin/Any|>()

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrobot/constructorParametersWithoutInject.fir.txt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrobot/constructorParametersWithoutInject.fir.txt
@@ -24,20 +24,24 @@ FILE: constructorParametersWithoutInject.kt
         public final val anotherDependency: R|com/test/AnotherRobotDependency| = R|<local>/anotherDependency|
             public get(): R|com/test/AnotherRobotDependency|
 
-        @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/TestRobot|)) public abstract interface RobotContribution : R|kotlin/Any| {
-            @R|dev/zacsweers/metro/Provides|() public open fun provideTestRobot(dependency: R|com/test/RobotDependency|, anotherDependency: R|com/test/AnotherRobotDependency|): R|com/test/TestRobot| {
-                ^provideTestRobot R|com/test/TestRobot.TestRobot|(R|<local>/dependency|, R|<local>/anotherDependency|)
-            }
-
+        @R|dev/zacsweers/metro/BindingContainer|() @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/TestRobot|)) public abstract interface RobotContribution : R|kotlin/Any| {
             @R|dev/zacsweers/metro/Binds|() @R|dev/zacsweers/metro/IntoMap|() @R|software/amazon/app/platform/renderer/metro/RobotKey|(value = <getClass>(Q|com/test/TestRobot|)) public open fun provideTestRobotIntoMap(robot: R|com/test/TestRobot|): R|software/amazon/app/platform/robot/Robot|
 
-            @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/MetroContribution|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) public abstract interface MetroContributionToDevzacsweersmetroappScopeoxd1AHI : R|com/test/TestRobot.RobotContribution| {
-            }
+            public final companion object Companion : R|kotlin/Any| {
+                @R|dev/zacsweers/metro/Provides|() public open fun provideTestRobot(dependency: R|com/test/RobotDependency|, anotherDependency: R|com/test/AnotherRobotDependency|): R|com/test/TestRobot| {
+                    ^provideTestRobot R|com/test/TestRobot.TestRobot|(R|<local>/dependency|, R|<local>/anotherDependency|)
+                }
 
-            @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/CallableMetadata|(callableName = String(provideTestRobot), propertyName = String(), startOffset = Int(245), endOffset = Int(390), newInstanceName = String(provideTestRobot)) public final class ProvideTestRobotMetroFactory : R|kotlin/Any| {
-                public final companion object Companion : R|kotlin/Any| {
-                    private constructor(): R|com/test/TestRobot.RobotContribution.ProvideTestRobotMetroFactory.Companion| {
-                        super<R|kotlin/Any|>()
+                private constructor(): R|com/test/TestRobot.RobotContribution.Companion| {
+                    super<R|kotlin/Any|>()
+                }
+
+                @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/CallableMetadata|(callableName = String(provideTestRobot), propertyName = String(), startOffset = Int(245), endOffset = Int(390), newInstanceName = String(provideTestRobot)) public final class ProvideTestRobotMetroFactory : R|kotlin/Any| {
+                    public final companion object Companion : R|kotlin/Any| {
+                        private constructor(): R|com/test/TestRobot.RobotContribution.Companion.ProvideTestRobotMetroFactory.Companion| {
+                            super<R|kotlin/Any|>()
+                        }
+
                     }
 
                 }

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrobot/constructorParametersWithoutInject.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrobot/constructorParametersWithoutInject.kt
@@ -1,0 +1,15 @@
+// RUN_PIPELINE_TILL: BACKEND
+package com.test
+
+import software.amazon.app.platform.inject.robot.ContributesRobot
+import software.amazon.app.platform.robot.Robot
+
+class RobotDependency
+
+class AnotherRobotDependency
+
+@ContributesRobot(AppScope::class)
+class TestRobot(
+  val dependency: RobotDependency,
+  val anotherDependency: AnotherRobotDependency,
+) : Robot

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrobot/defaultConstructorRobot.fir.txt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrobot/defaultConstructorRobot.fir.txt
@@ -6,19 +6,20 @@ FILE: defaultConstructorRobot.kt
             super<R|kotlin/Any|>()
         }
 
-        @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/TestRobot|)) public abstract interface RobotContribution : R|kotlin/Any| {
-            @R|dev/zacsweers/metro/Provides|() public open fun provideTestRobot(): R|com/test/TestRobot| {
-                ^provideTestRobot R|com/test/TestRobot.TestRobot|()
-            }
-
+        @R|dev/zacsweers/metro/BindingContainer|() @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/TestRobot|)) public abstract interface RobotContribution : R|kotlin/Any| {
             @R|dev/zacsweers/metro/Binds|() @R|dev/zacsweers/metro/IntoMap|() @R|software/amazon/app/platform/renderer/metro/RobotKey|(value = <getClass>(Q|com/test/TestRobot|)) public open fun provideTestRobotIntoMap(robot: R|com/test/TestRobot|): R|software/amazon/app/platform/robot/Robot|
 
-            @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/MetroContribution|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) public abstract interface MetroContributionToDevzacsweersmetroappScopeoxd1AHI : R|com/test/TestRobot.RobotContribution| {
-            }
+            public final companion object Companion : R|kotlin/Any| {
+                @R|dev/zacsweers/metro/Provides|() public open fun provideTestRobot(): R|com/test/TestRobot| {
+                    ^provideTestRobot R|com/test/TestRobot.TestRobot|()
+                }
 
-            @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/CallableMetadata|(callableName = String(provideTestRobot), propertyName = String(), startOffset = Int(192), endOffset = Int(250), newInstanceName = String(provideTestRobot)) public final class ProvideTestRobotMetroFactory : R|kotlin/Any| {
-                public final companion object Companion : R|kotlin/Any| {
-                    private constructor(): R|com/test/TestRobot.RobotContribution.ProvideTestRobotMetroFactory.Companion| {
+                private constructor(): R|com/test/TestRobot.RobotContribution.Companion| {
+                    super<R|kotlin/Any|>()
+                }
+
+                @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/CallableMetadata|(callableName = String(provideTestRobot), propertyName = String(), startOffset = Int(192), endOffset = Int(250), newInstanceName = String(provideTestRobot)) public final object ProvideTestRobotMetroFactory : R|kotlin/Any| {
+                    private constructor(): R|com/test/TestRobot.RobotContribution.Companion.ProvideTestRobotMetroFactory| {
                         super<R|kotlin/Any|>()
                     }
 

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrobot/defaultConstructorRobotIr.fir.kt.txt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrobot/defaultConstructorRobotIr.fir.kt.txt
@@ -3,6 +3,7 @@ package com.test
 
 @ContributesRobot(scope = AppScope::class)
 class TestRobot : Robot {
+  @BindingContainer
   @ContributesTo(scope = AppScope::class)
   @Origin(value = TestRobot::class)
   interface RobotContribution {
@@ -23,16 +24,10 @@ class TestRobot : Robot {
 
     }
 
-    @Deprecated(message = "This synthesized declaration should not be used directly", level = DeprecationLevel.HIDDEN)
-    @MetroContribution(scope = AppScope::class)
-    interface MetroContributionToDevzacsweersmetroappScopeoxd1AHI : RobotContribution {
-    }
-
-    @Deprecated(message = "This synthesized declaration should not be used directly", level = DeprecationLevel.HIDDEN)
-    @CallableMetadata(callableName = "provideTestRobot", propertyName = "", startOffset = 206, endOffset = 264, newInstanceName = "provideTestRobot")
-    class ProvideTestRobotMetroFactory : Factory<TestRobot> {
-      private /* final field */ val instance: RobotContribution = instance
-      companion object Companion {
+    companion object Companion {
+      @Deprecated(message = "This synthesized declaration should not be used directly", level = DeprecationLevel.HIDDEN)
+      @CallableMetadata(callableName = "provideTestRobot", propertyName = "", startOffset = 206, endOffset = 264, newInstanceName = "provideTestRobot")
+      object ProvideTestRobotMetroFactory : Factory<TestRobot> {
         private constructor() /* primary */ {
           super/*Any*/()
           /* <init>() */
@@ -42,41 +37,40 @@ class TestRobot : Robot {
         @HiddenFromObjC
         @JvmStatic
         @JsStatic
-        fun create(instance: RobotContribution): Factory<TestRobot> {
-          return ProvideTestRobotMetroFactory(instance = instance)
+        fun create(): Factory<TestRobot> {
+          return ProvideTestRobotMetroFactory
         }
 
         @HiddenFromObjC
         @JvmStatic
         @JsStatic
-        fun provideTestRobot(instance: RobotContribution): TestRobot {
-          return instance.provideTestRobot()
+        fun provideTestRobot(): TestRobot {
+          return Companion.provideTestRobot()
+        }
+
+        @HiddenFromObjC
+        override operator fun invoke(): TestRobot {
+          return ProvideTestRobotMetroFactory.provideTestRobot()
+        }
+
+        @HiddenFromObjC
+        fun mirrorFunction(): TestRobot {
+          return error(message = "Never called")
         }
 
       }
 
-      @HiddenFromObjC
-      private constructor(instance: RobotContribution) /* primary */ {
+      private constructor() /* primary */ {
         super/*Any*/()
         /* <init>() */
 
       }
 
-      @HiddenFromObjC
-      override operator fun invoke(): TestRobot {
-        return Companion.provideTestRobot(instance = <this>.#instance)
+      @Provides
+      open fun provideTestRobot(): TestRobot {
+        return TestRobot()
       }
 
-      @HiddenFromObjC
-      fun mirrorFunction(): TestRobot {
-        return error(message = "Never called")
-      }
-
-    }
-
-    @Provides
-    fun provideTestRobot(): TestRobot {
-      return TestRobot()
     }
 
     @Binds

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrobot/defaultConstructorRobotIr.fir.txt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrobot/defaultConstructorRobotIr.fir.txt
@@ -7,7 +7,9 @@ FILE: defaultConstructorRobotIr.kt
         }
 
         @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/TestRobot|)) public abstract interface RobotContribution : R|kotlin/Any| {
-            @R|dev/zacsweers/metro/Provides|() public open fun provideTestRobot(): R|com/test/TestRobot|
+            @R|dev/zacsweers/metro/Provides|() public open fun provideTestRobot(): R|com/test/TestRobot| {
+                ^provideTestRobot R|com/test/TestRobot.TestRobot|()
+            }
 
             @R|dev/zacsweers/metro/Binds|() @R|dev/zacsweers/metro/IntoMap|() @R|software/amazon/app/platform/renderer/metro/RobotKey|(value = <getClass>(Q|com/test/TestRobot|)) public open fun provideTestRobotIntoMap(robot: R|com/test/TestRobot|): R|software/amazon/app/platform/robot/Robot|
 

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrobot/defaultConstructorRobotIr.fir.txt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesrobot/defaultConstructorRobotIr.fir.txt
@@ -6,19 +6,20 @@ FILE: defaultConstructorRobotIr.kt
             super<R|kotlin/Any|>()
         }
 
-        @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/TestRobot|)) public abstract interface RobotContribution : R|kotlin/Any| {
-            @R|dev/zacsweers/metro/Provides|() public open fun provideTestRobot(): R|com/test/TestRobot| {
-                ^provideTestRobot R|com/test/TestRobot.TestRobot|()
-            }
-
+        @R|dev/zacsweers/metro/BindingContainer|() @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/TestRobot|)) public abstract interface RobotContribution : R|kotlin/Any| {
             @R|dev/zacsweers/metro/Binds|() @R|dev/zacsweers/metro/IntoMap|() @R|software/amazon/app/platform/renderer/metro/RobotKey|(value = <getClass>(Q|com/test/TestRobot|)) public open fun provideTestRobotIntoMap(robot: R|com/test/TestRobot|): R|software/amazon/app/platform/robot/Robot|
 
-            @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/MetroContribution|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) public abstract interface MetroContributionToDevzacsweersmetroappScopeoxd1AHI : R|com/test/TestRobot.RobotContribution| {
-            }
+            public final companion object Companion : R|kotlin/Any| {
+                @R|dev/zacsweers/metro/Provides|() public open fun provideTestRobot(): R|com/test/TestRobot| {
+                    ^provideTestRobot R|com/test/TestRobot.TestRobot|()
+                }
 
-            @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/CallableMetadata|(callableName = String(provideTestRobot), propertyName = String(), startOffset = Int(206), endOffset = Int(264), newInstanceName = String(provideTestRobot)) public final class ProvideTestRobotMetroFactory : R|kotlin/Any| {
-                public final companion object Companion : R|kotlin/Any| {
-                    private constructor(): R|com/test/TestRobot.RobotContribution.ProvideTestRobotMetroFactory.Companion| {
+                private constructor(): R|com/test/TestRobot.RobotContribution.Companion| {
+                    super<R|kotlin/Any|>()
+                }
+
+                @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/CallableMetadata|(callableName = String(provideTestRobot), propertyName = String(), startOffset = Int(206), endOffset = Int(264), newInstanceName = String(provideTestRobot)) public final object ProvideTestRobotMetroFactory : R|kotlin/Any| {
+                    private constructor(): R|com/test/TestRobot.RobotContribution.Companion.ProvideTestRobotMetroFactory| {
                         super<R|kotlin/Any|>()
                     }
 

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesscoped/constructorParametersWithoutInject.fir.txt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesscoped/constructorParametersWithoutInject.fir.txt
@@ -1,0 +1,68 @@
+FILE: constructorParametersWithoutInject.kt
+    package com.test
+
+    public abstract interface SuperType : R|kotlin/Any| {
+    }
+    public final class ScopedDependency : R|kotlin/Any| {
+        public constructor(): R|com/test/ScopedDependency| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    public final class AnotherScopedDependency : R|kotlin/Any| {
+        public constructor(): R|com/test/AnotherScopedDependency| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    @R|dev/zacsweers/metro/SingleIn|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) @R|software/amazon/app/platform/inject/metro/ContributesScoped|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) public final class TestClass : R|com/test/SuperType|, R|software/amazon/app/platform/scope/Scoped| {
+        public constructor(dependency: R|com/test/ScopedDependency|, anotherDependency: R|com/test/AnotherScopedDependency|): R|com/test/TestClass| {
+            super<R|kotlin/Any|>()
+        }
+
+        public final val dependency: R|com/test/ScopedDependency| = R|<local>/dependency|
+            public get(): R|com/test/ScopedDependency|
+
+        public final val anotherDependency: R|com/test/AnotherScopedDependency| = R|<local>/anotherDependency|
+            public get(): R|com/test/AnotherScopedDependency|
+
+        @R|dev/zacsweers/metro/BindingContainer|() @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/TestClass|)) public abstract interface ScopedContribution : R|kotlin/Any| {
+            @R|dev/zacsweers/metro/Binds|() public open fun bindSuperType(instance: R|com/test/TestClass|): R|com/test/SuperType|
+
+            @R|dev/zacsweers/metro/Binds|() @R|dev/zacsweers/metro/IntoSet|() @R|dev/zacsweers/metro/ForScope|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) public open fun bindTestClassScoped(instance: R|com/test/TestClass|): R|software/amazon/app/platform/scope/Scoped|
+
+            public final companion object Companion : R|kotlin/Any| {
+                @R|dev/zacsweers/metro/Provides|() @R|dev/zacsweers/metro/SingleIn|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) public open fun provideTestClass(dependency: R|com/test/ScopedDependency|, anotherDependency: R|com/test/AnotherScopedDependency|): R|com/test/TestClass| {
+                    ^provideTestClass R|com/test/TestClass.TestClass|(R|<local>/dependency|, R|<local>/anotherDependency|)
+                }
+
+                private constructor(): R|com/test/TestClass.ScopedContribution.Companion| {
+                    super<R|kotlin/Any|>()
+                }
+
+                @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/CallableMetadata|(callableName = String(provideTestClass), propertyName = String(), startOffset = Int(270), endOffset = Int(457), newInstanceName = String(provideTestClass)) public final class ProvideTestClassMetroFactory : R|kotlin/Any| {
+                    public final companion object Companion : R|kotlin/Any| {
+                        private constructor(): R|com/test/TestClass.ScopedContribution.Companion.ProvideTestClassMetroFactory.Companion| {
+                            super<R|kotlin/Any|>()
+                        }
+
+                    }
+
+                }
+
+            }
+
+            @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public abstract class BindsMirror : R|kotlin/Any| {
+                private constructor(): R|com/test/TestClass.ScopedContribution.BindsMirror| {
+                    super<R|kotlin/Any|>()
+                }
+
+                private constructor(): R|com/test/TestClass.ScopedContribution.BindsMirror| {
+                    super<R|kotlin/Any|>()
+                }
+
+            }
+
+        }
+
+    }

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesscoped/constructorParametersWithoutInject.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesscoped/constructorParametersWithoutInject.kt
@@ -1,0 +1,18 @@
+// RUN_PIPELINE_TILL: BACKEND
+package com.test
+
+import software.amazon.app.platform.inject.metro.ContributesScoped
+import software.amazon.app.platform.scope.Scoped
+
+interface SuperType
+
+class ScopedDependency
+
+class AnotherScopedDependency
+
+@SingleIn(AppScope::class)
+@ContributesScoped(AppScope::class)
+class TestClass(
+  val dependency: ScopedDependency,
+  val anotherDependency: AnotherScopedDependency,
+) : SuperType, Scoped

--- a/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesscoped/defaultScoped.fir.txt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/test/resources/dump/contributesscoped/defaultScoped.fir.txt
@@ -8,13 +8,10 @@ FILE: defaultScoped.kt
             super<R|kotlin/Any|>()
         }
 
-        @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/TestClass|)) public abstract interface ScopedContribution : R|kotlin/Any| {
+        @R|dev/zacsweers/metro/BindingContainer|() @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) @R|dev/zacsweers/metro/Origin|(value = <getClass>(Q|com/test/TestClass|)) public abstract interface ScopedContribution : R|kotlin/Any| {
             @R|dev/zacsweers/metro/Binds|() public open fun bindSuperType(instance: R|com/test/TestClass|): R|com/test/SuperType|
 
             @R|dev/zacsweers/metro/Binds|() @R|dev/zacsweers/metro/IntoSet|() @R|dev/zacsweers/metro/ForScope|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) public open fun bindTestClassScoped(instance: R|com/test/TestClass|): R|software/amazon/app/platform/scope/Scoped|
-
-            @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/MetroContribution|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) public abstract interface MetroContributionToDevzacsweersmetroappScopeoxd1AHI : R|com/test/TestClass.ScopedContribution| {
-            }
 
             @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public abstract class BindsMirror : R|kotlin/Any| {
                 private constructor(): R|com/test/TestClass.ScopedContribution.BindsMirror| {

--- a/sample/app/src/desktopTest/kotlin/software/amazon/app/platform/sample/TestAnimationHelper.kt
+++ b/sample/app/src/desktopTest/kotlin/software/amazon/app/platform/sample/TestAnimationHelper.kt
@@ -2,7 +2,6 @@ package software.amazon.app.platform.sample
 
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
-import dev.zacsweers.metro.Inject
 import software.amazon.app.platform.sample.user.AnimationHelper
 import software.amazon.app.platform.sample.user.DefaultAnimationsHelper
 
@@ -10,7 +9,6 @@ import software.amazon.app.platform.sample.user.DefaultAnimationsHelper
  * This implementation replaces [DefaultAnimationsHelper] in UI tests to disable animations and make
  * tests more stable.
  */
-@Inject
 @ContributesBinding(AppScope::class, replaces = [DefaultAnimationsHelper::class])
 class TestAnimationHelper : AnimationHelper {
   override fun isAnimationsEnabled(): Boolean = false

--- a/sample/login/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/login/LoginPresenterImpl.kt
+++ b/sample/login/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/login/LoginPresenterImpl.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
-import dev.zacsweers.metro.Inject
 import kotlin.random.Random
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
@@ -16,7 +15,6 @@ import software.amazon.app.platform.sample.login.LoginPresenter.Model
 import software.amazon.app.platform.sample.user.UserManager
 
 /** Production implementation for [LoginPresenter]. */
-@Inject
 @ContributesBinding(AppScope::class)
 class LoginPresenterImpl(private val userManager: UserManager) : LoginPresenter {
   @Composable

--- a/sample/navigation/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/navigation/NavigationPresenterImpl.kt
+++ b/sample/navigation/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/navigation/NavigationPresenterImpl.kt
@@ -7,7 +7,6 @@ import androidx.compose.runtime.remember
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.ContributesTo
-import dev.zacsweers.metro.Inject
 import software.amazon.app.platform.presenter.BaseModel
 import software.amazon.app.platform.presenter.molecule.MoleculePresenter
 import software.amazon.app.platform.sample.login.LoginPresenter
@@ -23,7 +22,6 @@ import software.amazon.app.platform.scope.di.metro.metroDependencyGraph
  * [loginPresenter] is injected lazily to delay initialization until it's actually needed. See
  * [MoleculePresenter] for more details.
  */
-@Inject
 @ContributesBinding(AppScope::class)
 class NavigationPresenterImpl(
   private val userManager: UserManager,

--- a/sample/templates/impl/src/androidMain/kotlin/software/amazon/app/platform/sample/template/AndroidSampleAppTemplateRenderer.kt
+++ b/sample/templates/impl/src/androidMain/kotlin/software/amazon/app/platform/sample/template/AndroidSampleAppTemplateRenderer.kt
@@ -12,7 +12,6 @@ import software.amazon.app.platform.sample.templates.impl.R
 /** An Android renderer implementation for templates used in the sample application. */
 // This implementation is disabled and we always use ComposeSampleAppTemplateRenderer.
 // The Android sample app could use this renderer if desired.
-// @Inject
 // @ContributesRenderer
 class AndroidSampleAppTemplateRenderer(rendererFactory: RendererFactory) :
   AndroidTemplateRenderer<SampleAppTemplate>(rendererFactory) {

--- a/sample/templates/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/template/ComposeSampleAppTemplateRenderer.kt
+++ b/sample/templates/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/template/ComposeSampleAppTemplateRenderer.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
-import dev.zacsweers.metro.Inject
 import software.amazon.app.platform.inject.ContributesRenderer
 import software.amazon.app.platform.presenter.BaseModel
 import software.amazon.app.platform.presenter.molecule.backgesture.BackGestureDispatcherPresenter
@@ -30,7 +29,6 @@ import software.amazon.app.platform.sample.template.animation.LocalSharedTransit
  * [rendererFactory] is used to get the [Renderer] for the [BaseModel] wrapped in the template.
  */
 @OptIn(ExperimentalSharedTransitionApi::class)
-@Inject
 @ContributesRenderer
 class ComposeSampleAppTemplateRenderer(
   private val rendererFactory: RendererFactory,

--- a/sample/user/impl-robots/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserPageRobot.kt
+++ b/sample/user/impl-robots/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserPageRobot.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import dev.zacsweers.metro.AppScope
-import dev.zacsweers.metro.Inject
 import software.amazon.app.platform.inject.robot.ContributesRobot
 import software.amazon.app.platform.robot.ComposeRobot
 
@@ -16,7 +15,6 @@ import software.amazon.app.platform.robot.ComposeRobot
  * further data or change behavior of classes. Robots are not exclusive to verifying UI and UI
  * interactions.
  */
-@Inject
 @ContributesRobot(AppScope::class)
 class UserPageRobot(private val userManager: UserManager) : ComposeRobot() {
 

--- a/sample/user/impl/src/androidMain/kotlin/software/amazon/app/platform/sample/user/AndroidAnimationsHelper.kt
+++ b/sample/user/impl/src/androidMain/kotlin/software/amazon/app/platform/sample/user/AndroidAnimationsHelper.kt
@@ -4,13 +4,11 @@ import android.app.Application
 import android.provider.Settings
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
-import dev.zacsweers.metro.Inject
 
 /**
  * Android implementation of [AnimationHelper] which queries the device state to determine whether
  * animations are enabled.
  */
-@Inject
 @ContributesBinding(AppScope::class)
 class AndroidAnimationsHelper(private val application: Application) : AnimationHelper {
   override fun isAnimationsEnabled(): Boolean {

--- a/sample/user/impl/src/appleAndDesktopMain/kotlin/software/amazon/app/platform/sample/user/DefaultAnimationsHelper.kt
+++ b/sample/user/impl/src/appleAndDesktopMain/kotlin/software/amazon/app/platform/sample/user/DefaultAnimationsHelper.kt
@@ -2,13 +2,11 @@ package software.amazon.app.platform.sample.user
 
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
-import dev.zacsweers.metro.Inject
 
 /**
  * Default implementation of [AnimationHelper] that always keeps animations enabled. This
  * implementation is used for iOS and Desktop.
  */
-@Inject
 @ContributesBinding(AppScope::class)
 class DefaultAnimationsHelper : AnimationHelper {
   override fun isAnimationsEnabled(): Boolean = true

--- a/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/SessionTimeout.kt
+++ b/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/SessionTimeout.kt
@@ -1,6 +1,5 @@
 package software.amazon.app.platform.sample.user
 
-import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -23,7 +22,6 @@ import software.amazon.app.platform.scope.coroutine.launch
  * will be called. [onExitScope] will be called on the `CoroutineScope` will be destroyed when the
  * user logs out.
  */
-@Inject
 @SingleIn(UserScope::class)
 @ContributesScoped(UserScope::class)
 class SessionTimeout(private val userManager: UserManager, animationHelper: AnimationHelper) :

--- a/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserManagerImpl.kt
+++ b/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserManagerImpl.kt
@@ -4,7 +4,6 @@ import app_platform.sample.user.impl.generated.resources.Res
 import app_platform.sample.user.impl.generated.resources.allDrawableResources
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
-import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import kotlin.random.Random
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -20,7 +19,6 @@ import software.amazon.app.platform.scope.register
  *
  * This class is responsible for creating the [UserScope] and [UserGraph].
  */
-@Inject
 @SingleIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 class UserManagerImpl(

--- a/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserPagePresenterImpl.kt
+++ b/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserPagePresenterImpl.kt
@@ -2,7 +2,6 @@ package software.amazon.app.platform.sample.user
 
 import androidx.compose.runtime.Composable
 import dev.zacsweers.metro.ContributesBinding
-import dev.zacsweers.metro.Inject
 import software.amazon.app.platform.presenter.BaseModel
 import software.amazon.app.platform.presenter.molecule.backgesture.BackHandlerPresenter
 import software.amazon.app.platform.presenter.template.ModelDelegate
@@ -19,7 +18,6 @@ import software.amazon.app.platform.sample.user.UserPagePresenter.Model
  * Note that this class itself doesn't have a [Renderer], because it only combines models from child
  * presenters, which come with a [Renderer].
  */
-@Inject
 @ContributesBinding(UserScope::class)
 class UserPagePresenterImpl(
   private val user: User,

--- a/sample/user/impl/src/wasmJsMain/kotlin/software/amazon/app/platform/sample/user/DefaultAnimationsHelper.kt
+++ b/sample/user/impl/src/wasmJsMain/kotlin/software/amazon/app/platform/sample/user/DefaultAnimationsHelper.kt
@@ -2,13 +2,11 @@ package software.amazon.app.platform.sample.user
 
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
-import dev.zacsweers.metro.Inject
 
 /**
  * Default implementation of [AnimationHelper] that always keeps animations enabled. This
  * implementation is used for Wasm.
  */
-@Inject
 @ContributesBinding(AppScope::class)
 class DefaultAnimationsHelper : AnimationHelper {
   override fun isAnimationsEnabled(): Boolean = true


### PR DESCRIPTION
- Generates constructor provider functions for `@ContributesRobot`, `@ContributesRenderer`, and `@ContributesScoped` when a contributed class has constructor parameters but no `@Inject` constructor.
- Skips the generated provider when the class or selected constructor is already annotated with `@Inject`.
- Reports an error when a contributed robot, renderer, or scoped type has multiple constructors and none is annotated with `@Inject`.
- Annotates generated Metro contribution containers with `@BindingContainer`, using companion objects for generated `@Provides` functions when the container also has `@Binds` functions.
- Updates compiler/KSP tests, generated dump/box/diagnostic test data, CHANGELOG.md, sample Metro usage, and docs.