### PR TITLE
Use the `Dispatchers.Main` as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Use the `Dispatchers.Main` as default main dispatcher instead of the immediate main dispatcher.
+
 ### Deprecated
 
 ### Removed

--- a/metro/impl/api/android/impl.api
+++ b/metro/impl/api/android/impl.api
@@ -1,144 +1,90 @@
-public abstract interface class software/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph {
-	public fun providePresenterCoroutineScope (Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;)Lkotlinx/coroutines/CoroutineScope;
-}
-
-public final class software/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph$DefaultImpls {
-	public static fun providePresenterCoroutineScope (Lsoftware/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;)Lkotlinx/coroutines/CoroutineScope;
-}
-
-public abstract interface class software/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph$MetroContributionToAppScope : software/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph {
-}
-
-public final class software/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph$MetroContributionToAppScope$DefaultImpls {
-	public static fun providePresenterCoroutineScope (Lsoftware/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph$MetroContributionToAppScope;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;)Lkotlinx/coroutines/CoroutineScope;
+public final class software/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph {
+	public static final field INSTANCE Lsoftware/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph;
+	public final fun providePresenterCoroutineScope (Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;)Lkotlinx/coroutines/CoroutineScope;
 }
 
 public final class software/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph$ProvidePresenterCoroutineScopeMetroFactory : dev/zacsweers/metro/internal/Factory {
 	public static final field Companion Lsoftware/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph$ProvidePresenterCoroutineScopeMetroFactory$Companion;
-	public synthetic fun <init> (Lsoftware/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph;Ldev/zacsweers/metro/Provider;Ldev/zacsweers/metro/Provider;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public static final fun create (Lsoftware/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph;Ldev/zacsweers/metro/Provider;Ldev/zacsweers/metro/Provider;)Ldev/zacsweers/metro/internal/Factory;
+	public synthetic fun <init> (Ldev/zacsweers/metro/Provider;Ldev/zacsweers/metro/Provider;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Ldev/zacsweers/metro/Provider;Ldev/zacsweers/metro/Provider;)Ldev/zacsweers/metro/internal/Factory;
 	public synthetic fun invoke ()Ljava/lang/Object;
 	public final fun invoke ()Lkotlinx/coroutines/CoroutineScope;
 	public final fun mirrorFunction (Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;)Lkotlinx/coroutines/CoroutineScope;
-	public static final fun providePresenterCoroutineScope (Lsoftware/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;)Lkotlinx/coroutines/CoroutineScope;
+	public static final fun providePresenterCoroutineScope (Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;)Lkotlinx/coroutines/CoroutineScope;
 }
 
 public final class software/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph$ProvidePresenterCoroutineScopeMetroFactory$Companion {
-	public final fun create (Lsoftware/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph;Ldev/zacsweers/metro/Provider;Ldev/zacsweers/metro/Provider;)Ldev/zacsweers/metro/internal/Factory;
-	public final fun providePresenterCoroutineScope (Lsoftware/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;)Lkotlinx/coroutines/CoroutineScope;
+	public final fun create (Ldev/zacsweers/metro/Provider;Ldev/zacsweers/metro/Provider;)Ldev/zacsweers/metro/internal/Factory;
+	public final fun providePresenterCoroutineScope (Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;)Lkotlinx/coroutines/CoroutineScope;
 }
 
-public abstract interface class software/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph {
-	public fun provideAppCoroutineScope (Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;)Lkotlinx/coroutines/CoroutineScope;
-	public fun provideAppScopeCoroutineScopeScoped (Lkotlinx/coroutines/CoroutineDispatcher;)Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;
-}
-
-public final class software/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph$DefaultImpls {
-	public static fun provideAppCoroutineScope (Lsoftware/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph;Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;)Lkotlinx/coroutines/CoroutineScope;
-	public static fun provideAppScopeCoroutineScopeScoped (Lsoftware/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph;Lkotlinx/coroutines/CoroutineDispatcher;)Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;
-}
-
-public abstract interface class software/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph$MetroContributionToAppScope : software/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph {
-}
-
-public final class software/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph$MetroContributionToAppScope$DefaultImpls {
-	public static fun provideAppCoroutineScope (Lsoftware/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph$MetroContributionToAppScope;Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;)Lkotlinx/coroutines/CoroutineScope;
-	public static fun provideAppScopeCoroutineScopeScoped (Lsoftware/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph$MetroContributionToAppScope;Lkotlinx/coroutines/CoroutineDispatcher;)Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;
+public final class software/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph {
+	public static final field INSTANCE Lsoftware/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph;
+	public final fun provideAppCoroutineScope (Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;)Lkotlinx/coroutines/CoroutineScope;
+	public final fun provideAppScopeCoroutineScopeScoped (Lkotlinx/coroutines/CoroutineDispatcher;)Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;
 }
 
 public final class software/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph$ProvideAppCoroutineScopeMetroFactory : dev/zacsweers/metro/internal/Factory {
 	public static final field Companion Lsoftware/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph$ProvideAppCoroutineScopeMetroFactory$Companion;
-	public synthetic fun <init> (Lsoftware/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph;Ldev/zacsweers/metro/Provider;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public static final fun create (Lsoftware/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph;Ldev/zacsweers/metro/Provider;)Ldev/zacsweers/metro/internal/Factory;
+	public synthetic fun <init> (Ldev/zacsweers/metro/Provider;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Ldev/zacsweers/metro/Provider;)Ldev/zacsweers/metro/internal/Factory;
 	public synthetic fun invoke ()Ljava/lang/Object;
 	public final fun invoke ()Lkotlinx/coroutines/CoroutineScope;
 	public final fun mirrorFunction (Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;)Lkotlinx/coroutines/CoroutineScope;
-	public static final fun provideAppCoroutineScope (Lsoftware/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph;Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;)Lkotlinx/coroutines/CoroutineScope;
+	public static final fun provideAppCoroutineScope (Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;)Lkotlinx/coroutines/CoroutineScope;
 }
 
 public final class software/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph$ProvideAppCoroutineScopeMetroFactory$Companion {
-	public final fun create (Lsoftware/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph;Ldev/zacsweers/metro/Provider;)Ldev/zacsweers/metro/internal/Factory;
-	public final fun provideAppCoroutineScope (Lsoftware/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph;Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;)Lkotlinx/coroutines/CoroutineScope;
+	public final fun create (Ldev/zacsweers/metro/Provider;)Ldev/zacsweers/metro/internal/Factory;
+	public final fun provideAppCoroutineScope (Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;)Lkotlinx/coroutines/CoroutineScope;
 }
 
 public final class software/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph$ProvideAppScopeCoroutineScopeScopedMetroFactory : dev/zacsweers/metro/internal/Factory {
 	public static final field Companion Lsoftware/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph$ProvideAppScopeCoroutineScopeScopedMetroFactory$Companion;
-	public synthetic fun <init> (Lsoftware/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph;Ldev/zacsweers/metro/Provider;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public static final fun create (Lsoftware/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph;Ldev/zacsweers/metro/Provider;)Ldev/zacsweers/metro/internal/Factory;
+	public synthetic fun <init> (Ldev/zacsweers/metro/Provider;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Ldev/zacsweers/metro/Provider;)Ldev/zacsweers/metro/internal/Factory;
 	public synthetic fun invoke ()Ljava/lang/Object;
 	public final fun invoke ()Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;
 	public final fun mirrorFunction (Lkotlinx/coroutines/CoroutineDispatcher;)Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;
-	public static final fun provideAppScopeCoroutineScopeScoped (Lsoftware/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph;Lkotlinx/coroutines/CoroutineDispatcher;)Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;
+	public static final fun provideAppScopeCoroutineScopeScoped (Lkotlinx/coroutines/CoroutineDispatcher;)Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;
 }
 
 public final class software/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph$ProvideAppScopeCoroutineScopeScopedMetroFactory$Companion {
-	public final fun create (Lsoftware/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph;Ldev/zacsweers/metro/Provider;)Ldev/zacsweers/metro/internal/Factory;
-	public final fun provideAppScopeCoroutineScopeScoped (Lsoftware/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph;Lkotlinx/coroutines/CoroutineDispatcher;)Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;
+	public final fun create (Ldev/zacsweers/metro/Provider;)Ldev/zacsweers/metro/internal/Factory;
+	public final fun provideAppScopeCoroutineScopeScoped (Lkotlinx/coroutines/CoroutineDispatcher;)Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;
 }
 
-public abstract interface class software/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph {
-	public fun provideDefaultCoroutineDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
-	public fun provideIoCoroutineDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
-	public fun provideMainCoroutineDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
-}
-
-public final class software/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$DefaultImpls {
-	public static fun provideDefaultCoroutineDispatcher (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;)Lkotlinx/coroutines/CoroutineDispatcher;
-	public static fun provideIoCoroutineDispatcher (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;)Lkotlinx/coroutines/CoroutineDispatcher;
-	public static fun provideMainCoroutineDispatcher (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;)Lkotlinx/coroutines/CoroutineDispatcher;
-}
-
-public abstract interface class software/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$MetroContributionToAppScope : software/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph {
-}
-
-public final class software/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$MetroContributionToAppScope$DefaultImpls {
-	public static fun provideDefaultCoroutineDispatcher (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$MetroContributionToAppScope;)Lkotlinx/coroutines/CoroutineDispatcher;
-	public static fun provideIoCoroutineDispatcher (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$MetroContributionToAppScope;)Lkotlinx/coroutines/CoroutineDispatcher;
-	public static fun provideMainCoroutineDispatcher (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$MetroContributionToAppScope;)Lkotlinx/coroutines/CoroutineDispatcher;
+public final class software/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph {
+	public static final field INSTANCE Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;
+	public final fun provideDefaultCoroutineDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
+	public final fun provideIoCoroutineDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
+	public final fun provideMainCoroutineDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 }
 
 public final class software/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$ProvideDefaultCoroutineDispatcherMetroFactory : dev/zacsweers/metro/internal/Factory {
-	public static final field Companion Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$ProvideDefaultCoroutineDispatcherMetroFactory$Companion;
-	public synthetic fun <init> (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public static final fun create (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;)Ldev/zacsweers/metro/internal/Factory;
+	public static final field INSTANCE Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$ProvideDefaultCoroutineDispatcherMetroFactory;
+	public static final fun create ()Ldev/zacsweers/metro/internal/Factory;
 	public synthetic fun invoke ()Ljava/lang/Object;
 	public final fun invoke ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public final fun mirrorFunction ()Lkotlinx/coroutines/CoroutineDispatcher;
-	public static final fun provideDefaultCoroutineDispatcher (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;)Lkotlinx/coroutines/CoroutineDispatcher;
-}
-
-public final class software/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$ProvideDefaultCoroutineDispatcherMetroFactory$Companion {
-	public final fun create (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;)Ldev/zacsweers/metro/internal/Factory;
-	public final fun provideDefaultCoroutineDispatcher (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;)Lkotlinx/coroutines/CoroutineDispatcher;
+	public static final fun provideDefaultCoroutineDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 }
 
 public final class software/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$ProvideIoCoroutineDispatcherMetroFactory : dev/zacsweers/metro/internal/Factory {
-	public static final field Companion Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$ProvideIoCoroutineDispatcherMetroFactory$Companion;
-	public synthetic fun <init> (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public static final fun create (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;)Ldev/zacsweers/metro/internal/Factory;
+	public static final field INSTANCE Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$ProvideIoCoroutineDispatcherMetroFactory;
+	public static final fun create ()Ldev/zacsweers/metro/internal/Factory;
 	public synthetic fun invoke ()Ljava/lang/Object;
 	public final fun invoke ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public final fun mirrorFunction ()Lkotlinx/coroutines/CoroutineDispatcher;
-	public static final fun provideIoCoroutineDispatcher (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;)Lkotlinx/coroutines/CoroutineDispatcher;
-}
-
-public final class software/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$ProvideIoCoroutineDispatcherMetroFactory$Companion {
-	public final fun create (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;)Ldev/zacsweers/metro/internal/Factory;
-	public final fun provideIoCoroutineDispatcher (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;)Lkotlinx/coroutines/CoroutineDispatcher;
+	public static final fun provideIoCoroutineDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 }
 
 public final class software/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$ProvideMainCoroutineDispatcherMetroFactory : dev/zacsweers/metro/internal/Factory {
-	public static final field Companion Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$ProvideMainCoroutineDispatcherMetroFactory$Companion;
-	public synthetic fun <init> (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public static final fun create (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;)Ldev/zacsweers/metro/internal/Factory;
+	public static final field INSTANCE Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$ProvideMainCoroutineDispatcherMetroFactory;
+	public static final fun create ()Ldev/zacsweers/metro/internal/Factory;
 	public synthetic fun invoke ()Ljava/lang/Object;
 	public final fun invoke ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public final fun mirrorFunction ()Lkotlinx/coroutines/CoroutineDispatcher;
-	public static final fun provideMainCoroutineDispatcher (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;)Lkotlinx/coroutines/CoroutineDispatcher;
-}
-
-public final class software/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$ProvideMainCoroutineDispatcherMetroFactory$Companion {
-	public final fun create (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;)Ldev/zacsweers/metro/internal/Factory;
-	public final fun provideMainCoroutineDispatcher (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;)Lkotlinx/coroutines/CoroutineDispatcher;
+	public static final fun provideMainCoroutineDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 }
 

--- a/metro/impl/api/desktop/impl.api
+++ b/metro/impl/api/desktop/impl.api
@@ -1,144 +1,90 @@
-public abstract interface class software/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph {
-	public fun providePresenterCoroutineScope (Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;)Lkotlinx/coroutines/CoroutineScope;
-}
-
-public final class software/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph$DefaultImpls {
-	public static fun providePresenterCoroutineScope (Lsoftware/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;)Lkotlinx/coroutines/CoroutineScope;
-}
-
-public abstract interface class software/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph$MetroContributionToAppScope : software/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph {
-}
-
-public final class software/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph$MetroContributionToAppScope$DefaultImpls {
-	public static fun providePresenterCoroutineScope (Lsoftware/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph$MetroContributionToAppScope;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;)Lkotlinx/coroutines/CoroutineScope;
+public final class software/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph {
+	public static final field INSTANCE Lsoftware/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph;
+	public final fun providePresenterCoroutineScope (Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;)Lkotlinx/coroutines/CoroutineScope;
 }
 
 public final class software/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph$ProvidePresenterCoroutineScopeMetroFactory : dev/zacsweers/metro/internal/Factory {
 	public static final field Companion Lsoftware/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph$ProvidePresenterCoroutineScopeMetroFactory$Companion;
-	public synthetic fun <init> (Lsoftware/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph;Ldev/zacsweers/metro/Provider;Ldev/zacsweers/metro/Provider;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public static final fun create (Lsoftware/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph;Ldev/zacsweers/metro/Provider;Ldev/zacsweers/metro/Provider;)Ldev/zacsweers/metro/internal/Factory;
+	public synthetic fun <init> (Ldev/zacsweers/metro/Provider;Ldev/zacsweers/metro/Provider;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Ldev/zacsweers/metro/Provider;Ldev/zacsweers/metro/Provider;)Ldev/zacsweers/metro/internal/Factory;
 	public synthetic fun invoke ()Ljava/lang/Object;
 	public final fun invoke ()Lkotlinx/coroutines/CoroutineScope;
 	public final fun mirrorFunction (Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;)Lkotlinx/coroutines/CoroutineScope;
-	public static final fun providePresenterCoroutineScope (Lsoftware/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;)Lkotlinx/coroutines/CoroutineScope;
+	public static final fun providePresenterCoroutineScope (Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;)Lkotlinx/coroutines/CoroutineScope;
 }
 
 public final class software/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph$ProvidePresenterCoroutineScopeMetroFactory$Companion {
-	public final fun create (Lsoftware/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph;Ldev/zacsweers/metro/Provider;Ldev/zacsweers/metro/Provider;)Ldev/zacsweers/metro/internal/Factory;
-	public final fun providePresenterCoroutineScope (Lsoftware/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;)Lkotlinx/coroutines/CoroutineScope;
+	public final fun create (Ldev/zacsweers/metro/Provider;Ldev/zacsweers/metro/Provider;)Ldev/zacsweers/metro/internal/Factory;
+	public final fun providePresenterCoroutineScope (Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;)Lkotlinx/coroutines/CoroutineScope;
 }
 
-public abstract interface class software/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph {
-	public fun provideAppCoroutineScope (Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;)Lkotlinx/coroutines/CoroutineScope;
-	public fun provideAppScopeCoroutineScopeScoped (Lkotlinx/coroutines/CoroutineDispatcher;)Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;
-}
-
-public final class software/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph$DefaultImpls {
-	public static fun provideAppCoroutineScope (Lsoftware/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph;Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;)Lkotlinx/coroutines/CoroutineScope;
-	public static fun provideAppScopeCoroutineScopeScoped (Lsoftware/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph;Lkotlinx/coroutines/CoroutineDispatcher;)Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;
-}
-
-public abstract interface class software/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph$MetroContributionToAppScope : software/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph {
-}
-
-public final class software/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph$MetroContributionToAppScope$DefaultImpls {
-	public static fun provideAppCoroutineScope (Lsoftware/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph$MetroContributionToAppScope;Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;)Lkotlinx/coroutines/CoroutineScope;
-	public static fun provideAppScopeCoroutineScopeScoped (Lsoftware/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph$MetroContributionToAppScope;Lkotlinx/coroutines/CoroutineDispatcher;)Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;
+public final class software/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph {
+	public static final field INSTANCE Lsoftware/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph;
+	public final fun provideAppCoroutineScope (Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;)Lkotlinx/coroutines/CoroutineScope;
+	public final fun provideAppScopeCoroutineScopeScoped (Lkotlinx/coroutines/CoroutineDispatcher;)Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;
 }
 
 public final class software/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph$ProvideAppCoroutineScopeMetroFactory : dev/zacsweers/metro/internal/Factory {
 	public static final field Companion Lsoftware/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph$ProvideAppCoroutineScopeMetroFactory$Companion;
-	public synthetic fun <init> (Lsoftware/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph;Ldev/zacsweers/metro/Provider;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public static final fun create (Lsoftware/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph;Ldev/zacsweers/metro/Provider;)Ldev/zacsweers/metro/internal/Factory;
+	public synthetic fun <init> (Ldev/zacsweers/metro/Provider;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Ldev/zacsweers/metro/Provider;)Ldev/zacsweers/metro/internal/Factory;
 	public synthetic fun invoke ()Ljava/lang/Object;
 	public final fun invoke ()Lkotlinx/coroutines/CoroutineScope;
 	public final fun mirrorFunction (Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;)Lkotlinx/coroutines/CoroutineScope;
-	public static final fun provideAppCoroutineScope (Lsoftware/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph;Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;)Lkotlinx/coroutines/CoroutineScope;
+	public static final fun provideAppCoroutineScope (Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;)Lkotlinx/coroutines/CoroutineScope;
 }
 
 public final class software/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph$ProvideAppCoroutineScopeMetroFactory$Companion {
-	public final fun create (Lsoftware/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph;Ldev/zacsweers/metro/Provider;)Ldev/zacsweers/metro/internal/Factory;
-	public final fun provideAppCoroutineScope (Lsoftware/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph;Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;)Lkotlinx/coroutines/CoroutineScope;
+	public final fun create (Ldev/zacsweers/metro/Provider;)Ldev/zacsweers/metro/internal/Factory;
+	public final fun provideAppCoroutineScope (Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;)Lkotlinx/coroutines/CoroutineScope;
 }
 
 public final class software/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph$ProvideAppScopeCoroutineScopeScopedMetroFactory : dev/zacsweers/metro/internal/Factory {
 	public static final field Companion Lsoftware/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph$ProvideAppScopeCoroutineScopeScopedMetroFactory$Companion;
-	public synthetic fun <init> (Lsoftware/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph;Ldev/zacsweers/metro/Provider;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public static final fun create (Lsoftware/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph;Ldev/zacsweers/metro/Provider;)Ldev/zacsweers/metro/internal/Factory;
+	public synthetic fun <init> (Ldev/zacsweers/metro/Provider;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Ldev/zacsweers/metro/Provider;)Ldev/zacsweers/metro/internal/Factory;
 	public synthetic fun invoke ()Ljava/lang/Object;
 	public final fun invoke ()Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;
 	public final fun mirrorFunction (Lkotlinx/coroutines/CoroutineDispatcher;)Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;
-	public static final fun provideAppScopeCoroutineScopeScoped (Lsoftware/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph;Lkotlinx/coroutines/CoroutineDispatcher;)Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;
+	public static final fun provideAppScopeCoroutineScopeScoped (Lkotlinx/coroutines/CoroutineDispatcher;)Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;
 }
 
 public final class software/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph$ProvideAppScopeCoroutineScopeScopedMetroFactory$Companion {
-	public final fun create (Lsoftware/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph;Ldev/zacsweers/metro/Provider;)Ldev/zacsweers/metro/internal/Factory;
-	public final fun provideAppScopeCoroutineScopeScoped (Lsoftware/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph;Lkotlinx/coroutines/CoroutineDispatcher;)Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;
+	public final fun create (Ldev/zacsweers/metro/Provider;)Ldev/zacsweers/metro/internal/Factory;
+	public final fun provideAppScopeCoroutineScopeScoped (Lkotlinx/coroutines/CoroutineDispatcher;)Lsoftware/amazon/app/platform/scope/coroutine/CoroutineScopeScoped;
 }
 
-public abstract interface class software/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph {
-	public fun provideDefaultCoroutineDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
-	public fun provideIoCoroutineDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
-	public fun provideMainCoroutineDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
-}
-
-public final class software/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$DefaultImpls {
-	public static fun provideDefaultCoroutineDispatcher (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;)Lkotlinx/coroutines/CoroutineDispatcher;
-	public static fun provideIoCoroutineDispatcher (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;)Lkotlinx/coroutines/CoroutineDispatcher;
-	public static fun provideMainCoroutineDispatcher (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;)Lkotlinx/coroutines/CoroutineDispatcher;
-}
-
-public abstract interface class software/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$MetroContributionToAppScope : software/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph {
-}
-
-public final class software/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$MetroContributionToAppScope$DefaultImpls {
-	public static fun provideDefaultCoroutineDispatcher (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$MetroContributionToAppScope;)Lkotlinx/coroutines/CoroutineDispatcher;
-	public static fun provideIoCoroutineDispatcher (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$MetroContributionToAppScope;)Lkotlinx/coroutines/CoroutineDispatcher;
-	public static fun provideMainCoroutineDispatcher (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$MetroContributionToAppScope;)Lkotlinx/coroutines/CoroutineDispatcher;
+public final class software/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph {
+	public static final field INSTANCE Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;
+	public final fun provideDefaultCoroutineDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
+	public final fun provideIoCoroutineDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
+	public final fun provideMainCoroutineDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 }
 
 public final class software/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$ProvideDefaultCoroutineDispatcherMetroFactory : dev/zacsweers/metro/internal/Factory {
-	public static final field Companion Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$ProvideDefaultCoroutineDispatcherMetroFactory$Companion;
-	public synthetic fun <init> (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public static final fun create (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;)Ldev/zacsweers/metro/internal/Factory;
+	public static final field INSTANCE Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$ProvideDefaultCoroutineDispatcherMetroFactory;
+	public static final fun create ()Ldev/zacsweers/metro/internal/Factory;
 	public synthetic fun invoke ()Ljava/lang/Object;
 	public final fun invoke ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public final fun mirrorFunction ()Lkotlinx/coroutines/CoroutineDispatcher;
-	public static final fun provideDefaultCoroutineDispatcher (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;)Lkotlinx/coroutines/CoroutineDispatcher;
-}
-
-public final class software/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$ProvideDefaultCoroutineDispatcherMetroFactory$Companion {
-	public final fun create (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;)Ldev/zacsweers/metro/internal/Factory;
-	public final fun provideDefaultCoroutineDispatcher (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;)Lkotlinx/coroutines/CoroutineDispatcher;
+	public static final fun provideDefaultCoroutineDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 }
 
 public final class software/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$ProvideIoCoroutineDispatcherMetroFactory : dev/zacsweers/metro/internal/Factory {
-	public static final field Companion Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$ProvideIoCoroutineDispatcherMetroFactory$Companion;
-	public synthetic fun <init> (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public static final fun create (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;)Ldev/zacsweers/metro/internal/Factory;
+	public static final field INSTANCE Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$ProvideIoCoroutineDispatcherMetroFactory;
+	public static final fun create ()Ldev/zacsweers/metro/internal/Factory;
 	public synthetic fun invoke ()Ljava/lang/Object;
 	public final fun invoke ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public final fun mirrorFunction ()Lkotlinx/coroutines/CoroutineDispatcher;
-	public static final fun provideIoCoroutineDispatcher (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;)Lkotlinx/coroutines/CoroutineDispatcher;
-}
-
-public final class software/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$ProvideIoCoroutineDispatcherMetroFactory$Companion {
-	public final fun create (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;)Ldev/zacsweers/metro/internal/Factory;
-	public final fun provideIoCoroutineDispatcher (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;)Lkotlinx/coroutines/CoroutineDispatcher;
+	public static final fun provideIoCoroutineDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 }
 
 public final class software/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$ProvideMainCoroutineDispatcherMetroFactory : dev/zacsweers/metro/internal/Factory {
-	public static final field Companion Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$ProvideMainCoroutineDispatcherMetroFactory$Companion;
-	public synthetic fun <init> (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public static final fun create (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;)Ldev/zacsweers/metro/internal/Factory;
+	public static final field INSTANCE Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$ProvideMainCoroutineDispatcherMetroFactory;
+	public static final fun create ()Ldev/zacsweers/metro/internal/Factory;
 	public synthetic fun invoke ()Ljava/lang/Object;
 	public final fun invoke ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public final fun mirrorFunction ()Lkotlinx/coroutines/CoroutineDispatcher;
-	public static final fun provideMainCoroutineDispatcher (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;)Lkotlinx/coroutines/CoroutineDispatcher;
-}
-
-public final class software/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph$ProvideMainCoroutineDispatcherMetroFactory$Companion {
-	public final fun create (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;)Ldev/zacsweers/metro/internal/Factory;
-	public final fun provideMainCoroutineDispatcher (Lsoftware/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph;)Lkotlinx/coroutines/CoroutineDispatcher;
+	public static final fun provideMainCoroutineDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 }
 

--- a/metro/impl/src/commonMain/kotlin/software/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph.kt
+++ b/metro/impl/src/commonMain/kotlin/software/amazon/app/platform/presenter/metro/PresenterCoroutineScopeGraph.kt
@@ -1,6 +1,7 @@
 package software.amazon.app.platform.presenter.metro
 
 import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.ForScope
 import dev.zacsweers.metro.Provides
@@ -12,7 +13,8 @@ import software.amazon.app.platform.scope.coroutine.MainCoroutineDispatcher
 
 /** Provides the coroutine scope to run presenters. */
 @ContributesTo(AppScope::class)
-public interface PresenterCoroutineScopeGraph {
+@BindingContainer
+public object PresenterCoroutineScopeGraph {
   /**
    * Bind the app coroutine scope as default scope for presenters to allow them to run as long as
    * the app is alive. The coroutine scope will use the main dispatcher by default, because

--- a/metro/impl/src/commonMain/kotlin/software/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph.kt
+++ b/metro/impl/src/commonMain/kotlin/software/amazon/app/platform/scope/coroutine/metro/AppScopeCoroutineScopeGraph.kt
@@ -1,6 +1,7 @@
 package software.amazon.app.platform.scope.coroutine.metro
 
 import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.ForScope
 import dev.zacsweers.metro.Provides
@@ -14,7 +15,8 @@ import software.amazon.app.platform.scope.coroutine.IoCoroutineDispatcher
 
 /** Graph providing coroutine scopes in the App scope. */
 @ContributesTo(AppScope::class)
-public interface AppScopeCoroutineScopeGraph {
+@BindingContainer
+public object AppScopeCoroutineScopeGraph {
   /**
    * Provides the [CoroutineScopeScoped] for the app scope. This is a single instance for the app
    * scope.

--- a/metro/impl/src/commonMain/kotlin/software/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph.kt
+++ b/metro/impl/src/commonMain/kotlin/software/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph.kt
@@ -25,5 +25,5 @@ public interface CoroutineDispatcherGraph {
   /** Provides the main dispatcher in the dependency graph. */
   @Provides
   @MainCoroutineDispatcher
-  public fun provideMainCoroutineDispatcher(): CoroutineDispatcher = Dispatchers.Main.immediate
+  public fun provideMainCoroutineDispatcher(): CoroutineDispatcher = Dispatchers.Main
 }

--- a/metro/impl/src/commonMain/kotlin/software/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph.kt
+++ b/metro/impl/src/commonMain/kotlin/software/amazon/app/platform/scope/coroutine/metro/CoroutineDispatcherGraph.kt
@@ -1,6 +1,7 @@
 package software.amazon.app.platform.scope.coroutine.metro
 
 import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provides
 import kotlinx.coroutines.CoroutineDispatcher
@@ -11,7 +12,8 @@ import software.amazon.app.platform.scope.coroutine.MainCoroutineDispatcher
 
 /** Provides default dispatchers for coroutine scopes. */
 @ContributesTo(AppScope::class)
-public interface CoroutineDispatcherGraph {
+@BindingContainer
+public object CoroutineDispatcherGraph {
   /** Provides the IO dispatcher in the dependency graph. */
   @Provides
   @IoCoroutineDispatcher


### PR DESCRIPTION
* Use the `Dispatchers.Main` as default main dispatcher instead of the immediate main dispatcher. This fixes issues in the Molecule runtime on iOS.
* Use the `@BindingContainer` annotation where inheritance is not needed.