### PR TITLE
Use the `Dispatchers.Main` as default (kotlin-inject)

### DIFF
--- a/kotlin-inject/impl/src/commonMain/kotlin/software/amazon/app/platform/scope/coroutine/CoroutineDispatcherComponent.kt
+++ b/kotlin-inject/impl/src/commonMain/kotlin/software/amazon/app/platform/scope/coroutine/CoroutineDispatcherComponent.kt
@@ -22,5 +22,5 @@ public interface CoroutineDispatcherComponent {
   /** Provides the main dispatcher in the dependency graph. */
   @Provides
   @MainCoroutineDispatcher
-  public fun provideMainCoroutineDispatcher(): CoroutineDispatcher = Dispatchers.Main.immediate
+  public fun provideMainCoroutineDispatcher(): CoroutineDispatcher = Dispatchers.Main
 }


### PR DESCRIPTION
Use the `Dispatchers.Main` as default main dispatcher instead of the immediate main dispatcher. This fixes issues in the Molecule runtime on iOS.

