### PR TITLE
Don't apply the KSP plugin automatically anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Use the `Dispatchers.Main` as default main dispatcher instead of the immediate main dispatcher.
 - Upgrade Kotlin to `2.3.21`, Compose Multiplatform to `1.11.0`, Metro to `1.1.1`, and other dependencies.
+- **Breaking change:** The App Platform Gradle plugin doesn't apply the KSP plugin automatically anymore. If you use kotlin-inject as DI framework, then you need to add a dependency on KSP yourself (similar to how you apply the App Platform Gradle plugin).
 
 ### Deprecated
 

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -52,7 +52,7 @@ dependencies {
 
     // This is needed to reference KspExperimental for experimental features.
     compileOnly libs.ksp.api
-    implementation libs.ksp.gradle.plugin
+    compileOnly libs.ksp.gradle.plugin
 
     // compileOnly to not set a minimum version for any consumers of this Gradle plugin and
     // because AGP is purely optional. Usage of AGP APIs is gated by checks when the plugin


### PR DESCRIPTION
The plugin was applied no matter if you used kotlin-inject and KSP. That's unnecessary.
