### PR TITLE
Make the App Platform Gradle plugin compatible with AGP 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Fixed
 
+- Make the App Platform Gradle plugin compatible with AGP 9's Android KMP and built-in Kotlin behavior while staying compatible with AGP 8.
+
 ### Security
 
 ### Other Notes & Contributions

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     // compileOnly to not set a minimum version for any consumers of this Gradle plugin and
     // because AGP is purely optional. Usage of AGP APIs is gated by checks when the plugin
     // is applied.
-    compileOnly libs.android.gradle.plugin.api
+    compileOnly libs.android.gradle.plugin.api.gradle.plugin
 
     // compileOnly, because not every consumer of this Gradle plugin will use KMP. All usages
     // are guarded by checks when the plugin is applied.

--- a/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/AppPlatformExtension.kt
+++ b/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/AppPlatformExtension.kt
@@ -363,7 +363,7 @@ private fun Project.enableComposeUi() {
     }
   }
 
-  plugins.withIds(PluginIds.KOTLIN_ANDROID) {
+  plugins.withIds(PluginIds.ANDROID_APP, PluginIds.ANDROID_LIBRARY) {
     plugins.apply(PluginIds.COMPOSE_COMPILER)
 
     android.buildFeatures.compose = true
@@ -384,10 +384,6 @@ private fun Project.enableComposeUi() {
         "$APP_PLATFORM_GROUP:robot-compose-multiplatform-public:$APP_PLATFORM_VERSION",
       )
     }
-  }
-
-  plugins.withIds(PluginIds.ANDROID_APP, PluginIds.ANDROID_LIBRARY) {
-    android.buildFeatures.compose = true
 
     if (isAppModule()) {
       dependencies.add(

--- a/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/GradleExtensions.kt
+++ b/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/GradleExtensions.kt
@@ -1,12 +1,14 @@
 package software.amazon.app.platform.gradle
 
 import com.android.build.api.dsl.CommonExtension
+import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
 import com.android.build.api.variant.AndroidComponentsExtension
 import java.util.Locale
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.UnknownTaskException
+import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.plugins.PluginContainer
 import org.gradle.api.project.IsolatedProject
 import org.gradle.api.tasks.TaskContainer
@@ -28,7 +30,7 @@ internal fun Project.requireParent(): IsolatedProject =
 internal val Project.isKmpModule: Boolean
   get() = plugins.hasPlugin(PluginIds.KOTLIN_MULTIPLATFORM)
 
-internal val Project.android: CommonExtension<*, *, *, *, *, *>
+internal val Project.android: CommonExtension
   get() = extensions.getByType(CommonExtension::class.java)
 
 internal val Project.androidComponents: AndroidComponentsExtension<*, *, *>
@@ -36,6 +38,12 @@ internal val Project.androidComponents: AndroidComponentsExtension<*, *, *>
 
 internal val Project.kmpExtension: KotlinMultiplatformExtension
   get() = extensions.getByType(KotlinMultiplatformExtension::class.java)
+
+internal val Project.androidKmpTarget: KotlinMultiplatformAndroidLibraryTarget
+  get() =
+    (kmpExtension as ExtensionAware)
+      .extensions
+      .getByType(KotlinMultiplatformAndroidLibraryTarget::class.java)
 
 internal fun TaskContainer.namedOptional(name: String, configurationAction: (Task) -> Unit) {
   try {

--- a/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/ModuleStructurePlugin.kt
+++ b/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/ModuleStructurePlugin.kt
@@ -1,6 +1,5 @@
 package software.amazon.app.platform.gradle
 
-import com.android.build.api.dsl.androidLibrary
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import software.amazon.app.platform.gradle.ModuleStructureDependencyCheckTask.Companion.registerModuleStructureDependencyCheckTask
@@ -87,11 +86,8 @@ public open class ModuleStructurePlugin : Plugin<Project> {
       }
     }
     plugins.withId(PluginIds.ANDROID_KMP_LIBRARY) {
-      @Suppress("UnstableApiUsage")
-      kmpExtension.androidLibrary {
-        if (namespace == null) {
-          namespace = namespace()
-        }
+      if (androidKmpTarget.namespace == null) {
+        androidKmpTarget.namespace = namespace()
       }
     }
   }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.13.2"
+agp-gradle-plugin = "9.2.1"
 android-compileSdk = "36"
 # https://developer.android.com/jetpack/androidx/releases/compose-ui
 # https://maven.google.com/web/index.html#androidx.compose.ui:ui
@@ -61,6 +62,7 @@ viewbinding = "7.0.0"
 [libraries]
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 android-gradle-plugin-api = { module = "com.android.tools.build:gradle-api", version.ref = "agp" }
+android-gradle-plugin-api-gradle-plugin = { module = "com.android.tools.build:gradle-api", version.ref = "agp-gradle-plugin" }
 androidx-activity = { module = "androidx.activity:activity", version.ref = "androidx-activity" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-annotations = { module = "androidx.annotation:annotation", version.ref = "androidx-annotations" }


### PR DESCRIPTION
Make the App Platform Gradle plugin compatible with AGP 9's Android KMP and built-in Kotlin behavior while staying compatible with AGP 8.

