### PR TITLE
Introduce `presentDetached()` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- Add `@ExperimentalAppPlatform` in `:common:public` for APIs that require explicit consumer opt-in.
+- Add experimental `MoleculePresenter.presentDetached()` to compose presenter subtrees in detached Molecule hierarchies so busy parent presenters do not recompose slower child presenters.
+
 ### Changed
 
 ### Deprecated

--- a/buildSrc/src/main/kotlin/software/amazon/app/platform/gradle/buildsrc/BasePlugin.kt
+++ b/buildSrc/src/main/kotlin/software/amazon/app/platform/gradle/buildsrc/BasePlugin.kt
@@ -55,6 +55,7 @@ public open class BasePlugin : Plugin<Project> {
     // as well.
     val substitutions =
       mapOf(
+        "${APP_PLATFORM_GROUP}:common-public" to ":common:public",
         "${APP_PLATFORM_GROUP}:di-common-public" to ":di-common:public",
         "${APP_PLATFORM_GROUP}:kotlin-inject-public" to ":kotlin-inject:public",
         "${APP_PLATFORM_GROUP}:kotlin-inject-contribute-impl-code-generators" to

--- a/common/public/api/android/public.api
+++ b/common/public/api/android/public.api
@@ -1,0 +1,3 @@
+public abstract interface annotation class software/amazon/app/platform/ExperimentalAppPlatform : java/lang/annotation/Annotation {
+}
+

--- a/common/public/api/desktop/public.api
+++ b/common/public/api/desktop/public.api
@@ -1,0 +1,3 @@
+public abstract interface annotation class software/amazon/app/platform/ExperimentalAppPlatform : java/lang/annotation/Annotation {
+}
+

--- a/common/public/build.gradle
+++ b/common/public/build.gradle
@@ -1,0 +1,7 @@
+plugins {
+    id 'software.amazon.app.platform.lib'
+}
+
+appPlatformBuildSrc {
+    enablePublishing true
+}

--- a/common/public/src/commonMain/kotlin/software/amazon/app/platform/ExperimentalAppPlatform.kt
+++ b/common/public/src/commonMain/kotlin/software/amazon/app/platform/ExperimentalAppPlatform.kt
@@ -1,0 +1,23 @@
+package software.amazon.app.platform
+
+/**
+ * Marks App Platform APIs that are experimental and may change without preserving source or binary
+ * compatibility.
+ */
+@MustBeDocumented
+@RequiresOptIn(
+  level = RequiresOptIn.Level.ERROR,
+  message =
+    "This App Platform API is experimental and may change without preserving source or " +
+      "binary compatibility.",
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(
+  AnnotationTarget.ANNOTATION_CLASS,
+  AnnotationTarget.CLASS,
+  AnnotationTarget.CONSTRUCTOR,
+  AnnotationTarget.FUNCTION,
+  AnnotationTarget.PROPERTY,
+  AnnotationTarget.TYPEALIAS,
+)
+public annotation class ExperimentalAppPlatform

--- a/docs/presenter.md
+++ b/docs/presenter.md
@@ -367,6 +367,51 @@ val stateFlow = moleculeScope
     }
     ```
 
+### Detached presenters
+
+Calling a child presenter's `present()` function directly makes it part of the same Compose hierarchy as its parent.
+This is the right default because the call is simple and composition locals naturally flow through the presenter tree.
+However, every parent recomposition also invokes every inline child presenter. If a busy parent produces a new value
+frequently, then expensive child presenters below it are called just as frequently even when their own input has not
+changed.
+
+Use `presentDetached()` when a child presenter should run in its own Molecule hierarchy:
+
+```kotlin
+class ParentPresenter(
+  private val busyPresenter: BusyPresenter,
+  private val expensivePresenter: ExpensivePresenter,
+) : MoleculePresenter<Unit, ParentPresenter.Model> {
+
+  @Composable
+  override fun present(input: Unit): Model {
+    val busyModel = busyPresenter.present(Unit)
+    val expensiveModel = expensivePresenter.presentDetached(Unit)
+
+    return Model(busyModel, expensiveModel)
+  }
+
+  data class Model(
+    val busyModel: BusyPresenter.Model,
+    val expensiveModel: ExpensivePresenter.Model,
+  ) : BaseModel
+}
+```
+
+In this example, recompositions caused by `BusyPresenter` do not invoke `ExpensivePresenter.present()` again. The
+detached presenter still recomposes when its own `input` changes or when state read by the detached hierarchy changes.
+
+`presentDetached()` uses the current presenter's `RecompositionMode` by default and cancels the detached hierarchy when
+the call leaves composition. Prefer direct `present()` calls for cheap child presenters or when the child depends on
+composition locals provided by the parent. Only App Platform composition locals explicitly preserved by
+`presentDetached()` are available in the detached hierarchy.
+
+The detached hierarchy catches up to input changes asynchronously. If the parent input changes, the parent presenter may
+emit one model containing the new parent input and the previous detached child model before the detached presenter
+recomposes with the new input. Prefer a direct `present()` call when parent and child model state must update atomically
+in the same emission. This is not a concern when the detached presenter always receives the same input, such as `Unit`;
+in that case, child presenter updates are driven by the detached hierarchy's own state changes.
+
 ## Testing
 
 A [`test()`](https://github.com/amzn/app-platform/blob/main/presenter-molecule/testing/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/TestPresenter.kt)

--- a/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/AppPlatformPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/AppPlatformPlugin.kt
@@ -28,6 +28,7 @@ public open class AppPlatformPlugin : Plugin<Project> {
 
     val implementationDependencies =
       setOf(
+        "$APP_PLATFORM_GROUP:common-public:$APP_PLATFORM_VERSION",
         "$APP_PLATFORM_GROUP:presenter-public:$APP_PLATFORM_VERSION",
         "$APP_PLATFORM_GROUP:renderer-public:$APP_PLATFORM_VERSION",
         "$APP_PLATFORM_GROUP:scope-public:$APP_PLATFORM_VERSION",
@@ -116,6 +117,7 @@ public open class AppPlatformPlugin : Plugin<Project> {
     @JvmStatic
     public fun exportedDependencies(): Set<String> =
       setOf(
+          "common-public",
           "di-common-public",
           "kotlin-inject-contribute-public",
           "kotlin-inject-impl",

--- a/presenter-molecule/public/api/android/public.api
+++ b/presenter-molecule/public/api/android/public.api
@@ -2,6 +2,7 @@ public final class software/amazon/app/platform/presenter/molecule/LaunchMolecul
 	public static final fun launchMoleculePresenter (Lkotlinx/coroutines/CoroutineScope;Lsoftware/amazon/app/platform/presenter/molecule/MoleculePresenter;Lkotlinx/coroutines/flow/StateFlow;Lapp/cash/molecule/RecompositionMode;)Lsoftware/amazon/app/platform/presenter/Presenter;
 	public static final fun launchMoleculePresenter (Lsoftware/amazon/app/platform/presenter/molecule/MoleculeScope;Lsoftware/amazon/app/platform/presenter/molecule/MoleculePresenter;Ljava/lang/Object;)Lsoftware/amazon/app/platform/presenter/Presenter;
 	public static final fun launchMoleculePresenter (Lsoftware/amazon/app/platform/presenter/molecule/MoleculeScope;Lsoftware/amazon/app/platform/presenter/molecule/MoleculePresenter;Lkotlinx/coroutines/flow/StateFlow;)Lsoftware/amazon/app/platform/presenter/Presenter;
+	public static final fun presentDetached (Lsoftware/amazon/app/platform/presenter/molecule/MoleculePresenter;Ljava/lang/Object;Lapp/cash/molecule/RecompositionMode;Landroidx/compose/runtime/Composer;II)Lsoftware/amazon/app/platform/presenter/BaseModel;
 }
 
 public abstract interface class software/amazon/app/platform/presenter/molecule/MoleculePresenter {

--- a/presenter-molecule/public/api/desktop/public.api
+++ b/presenter-molecule/public/api/desktop/public.api
@@ -2,6 +2,7 @@ public final class software/amazon/app/platform/presenter/molecule/LaunchMolecul
 	public static final fun launchMoleculePresenter (Lkotlinx/coroutines/CoroutineScope;Lsoftware/amazon/app/platform/presenter/molecule/MoleculePresenter;Lkotlinx/coroutines/flow/StateFlow;Lapp/cash/molecule/RecompositionMode;)Lsoftware/amazon/app/platform/presenter/Presenter;
 	public static final fun launchMoleculePresenter (Lsoftware/amazon/app/platform/presenter/molecule/MoleculeScope;Lsoftware/amazon/app/platform/presenter/molecule/MoleculePresenter;Ljava/lang/Object;)Lsoftware/amazon/app/platform/presenter/Presenter;
 	public static final fun launchMoleculePresenter (Lsoftware/amazon/app/platform/presenter/molecule/MoleculeScope;Lsoftware/amazon/app/platform/presenter/molecule/MoleculePresenter;Lkotlinx/coroutines/flow/StateFlow;)Lsoftware/amazon/app/platform/presenter/Presenter;
+	public static final fun presentDetached (Lsoftware/amazon/app/platform/presenter/molecule/MoleculePresenter;Ljava/lang/Object;Lapp/cash/molecule/RecompositionMode;Landroidx/compose/runtime/Composer;II)Lsoftware/amazon/app/platform/presenter/BaseModel;
 }
 
 public abstract interface class software/amazon/app/platform/presenter/molecule/MoleculePresenter {

--- a/presenter-molecule/public/build.gradle
+++ b/presenter-molecule/public/build.gradle
@@ -8,6 +8,7 @@ appPlatformBuildSrc {
 }
 
 dependencies {
+    commonMainApi project(':common:public')
     commonMainApi project(':presenter:public')
     commonMainApi libs.androidx.annotations
     commonTestImplementation project(':internal:testing')

--- a/presenter-molecule/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/LaunchMoleculePresenter.kt
+++ b/presenter-molecule/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/LaunchMoleculePresenter.kt
@@ -1,14 +1,29 @@
 package software.amazon.app.platform.presenter.molecule
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.RememberObserver
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import app.cash.molecule.RecompositionMode
 import app.cash.molecule.launchMolecule
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import software.amazon.app.platform.ExperimentalAppPlatform
 import software.amazon.app.platform.presenter.BaseModel
 import software.amazon.app.platform.presenter.Presenter
+
+internal val LocalRecompositionMode: ProvidableCompositionLocal<RecompositionMode> =
+  compositionLocalOf {
+    error("No RecompositionMode is available in the current presenter hierarchy.")
+  }
 
 /**
  * Launch a coroutine into this [CoroutineScope] which will continually recompose
@@ -23,8 +38,10 @@ public fun <InputT : Any, ModelT : BaseModel> CoroutineScope.launchMoleculePrese
   return object : Presenter<ModelT> {
     override val model: StateFlow<ModelT> =
       launchMolecule(recompositionMode) {
-        val inputElement by input.collectAsState()
-        presenter.present(inputElement)
+        returningCompositionLocalProvider(LocalRecompositionMode provides recompositionMode) {
+          val inputElement by input.collectAsState()
+          presenter.present(inputElement)
+        }
       }
   }
 }
@@ -54,3 +71,94 @@ public fun <InputT : Any, ModelT : BaseModel> MoleculeScope.launchMoleculePresen
   input: InputT,
 ): Presenter<ModelT> =
   launchMoleculePresenter(presenter = presenter, input = MutableStateFlow(input))
+
+/**
+ * Presents this [MoleculePresenter] in a detached Molecule composition and returns the latest
+ * [ModelT].
+ *
+ * Calling [MoleculePresenter.present] directly composes a child presenter inline with its parent.
+ * That keeps the hierarchy simple, but every parent recomposition also invokes every inline child
+ * presenter below it. [presentDetached] creates a separate presenter hierarchy instead. Parent
+ * recompositions keep collecting the detached model, but the detached presenter only recomposes
+ * when its own [input] or its own state changes.
+ *
+ * Use this for presenter subtrees that are expensive to compute and whose input changes less often
+ * than the parent presenter. Prefer a direct [MoleculePresenter.present] call for cheap presenters
+ * or presenters that need to participate in the parent's composition locals beyond the App Platform
+ * locals that [presentDetached] explicitly preserves.
+ *
+ * By default, this function uses the [RecompositionMode] from the current presenter hierarchy. Pass
+ * [recompositionMode] explicitly if this is called from a composition that was not created through
+ * [launchMoleculePresenter].
+ *
+ * When [input] changes, the parent presenter can emit one model with the new parent input and the
+ * previous detached child model before the detached hierarchy catches up. Use a direct
+ * [MoleculePresenter.present] call instead if parent and child model state must be updated
+ * atomically in the same emission. This is not a concern when the detached presenter always
+ * receives the same input, such as [Unit]; in that case, child presenter updates are driven by the
+ * detached hierarchy's own state changes.
+ */
+@Composable
+@ExperimentalAppPlatform
+public fun <InputT : Any, ModelT : BaseModel> MoleculePresenter<InputT, ModelT>.presentDetached(
+  input: InputT,
+  recompositionMode: RecompositionMode = LocalRecompositionMode.current,
+): ModelT {
+  val parentCoroutineScope = rememberCoroutineScope()
+  val presenter = this
+  val detachedObserver =
+    remember(presenter, recompositionMode) {
+      val inputFlow = MutableStateFlow(input)
+      // launchMoleculePresenter() returns a Presenter with a StateFlow, but not the Job running
+      // the composition. Use a child scope so this detached hierarchy can be canceled when it
+      // leaves composition, without canceling the parent presenter scope.
+      val detachedCoroutineScope = parentCoroutineScope.createChildScope()
+      DetachedObserver(
+        coroutineScope = detachedCoroutineScope,
+        input = inputFlow,
+        model =
+          detachedCoroutineScope
+            .launchMoleculePresenter(
+              presenter = presenter,
+              input = inputFlow,
+              recompositionMode = recompositionMode,
+            )
+            .model,
+      )
+    }
+
+  SideEffect { detachedObserver.input.value = input }
+
+  return detachedObserver.model.collectAsState().value
+}
+
+private class DetachedObserver<InputT : Any, ModelT : BaseModel>(
+  private val coroutineScope: CoroutineScope,
+  val input: MutableStateFlow<InputT>,
+  val model: StateFlow<ModelT>,
+) : RememberObserver {
+  override fun onRemembered() = Unit
+
+  override fun onForgotten() {
+    cancel()
+  }
+
+  override fun onAbandoned() {
+    cancel()
+  }
+
+  private fun cancel() {
+    coroutineScope.cancel()
+  }
+}
+
+/**
+ * Creates a scope that is linked to this parent scope but can also be canceled on its own.
+ *
+ * This lets the detached Molecule composition stop when [DetachedObserver] is forgotten or
+ * abandoned. If the parent composition is canceled first, structured cancellation still cancels the
+ * detached composition through the parent [Job].
+ */
+private fun CoroutineScope.createChildScope(): CoroutineScope {
+  return CoroutineScope(coroutineContext + Job(coroutineContext[Job]))
+}

--- a/presenter-molecule/public/src/commonTest/kotlin/software/amazon/app/platform/presenter/molecule/LaunchMoleculePresenterTest.kt
+++ b/presenter-molecule/public/src/commonTest/kotlin/software/amazon/app/platform/presenter/molecule/LaunchMoleculePresenterTest.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import software.amazon.app.platform.ExperimentalAppPlatform
 import software.amazon.app.platform.internal.IgnoreNative
@@ -73,6 +74,142 @@ class LaunchMoleculePresenterTest {
       assertThat(awaitItem().value).isEqualTo("3")
     }
   }
+
+  @Test
+  fun `the recomposition mode is available in the presenter hierarchy`() = runTest {
+    data class Model(val recompositionMode: RecompositionMode) : BaseModel
+
+    val presenter =
+      object : MoleculePresenter<Unit, Model> {
+        @Composable
+        override fun present(input: Unit): Model {
+          return Model(LocalRecompositionMode.current)
+        }
+      }
+
+    presenter.test(this, Unit) {
+      assertThat(awaitItem().recompositionMode).isEqualTo(RecompositionMode.Immediate)
+    }
+  }
+
+  @Test
+  fun `presentDetached does not recompose child presenters when the parent recomposes`() = runTest {
+    data class ChildModel(val presentCalls: Int) : BaseModel
+    data class ParentModel(val input: Int, val childPresentCalls: Int) : BaseModel
+
+    var childPresentCalls = 0
+
+    val childPresenter =
+      object : MoleculePresenter<Unit, ChildModel> {
+        @Composable
+        override fun present(input: Unit): ChildModel {
+          childPresentCalls++
+
+          return ChildModel(childPresentCalls)
+        }
+      }
+
+    val parentPresenter =
+      object : MoleculePresenter<Int, ParentModel> {
+        @Composable
+        override fun present(input: Int): ParentModel {
+          val childModel = childPresenter.presentDetached(Unit)
+
+          return ParentModel(input = input, childPresentCalls = childModel.presentCalls)
+        }
+      }
+
+    val inputFlow = MutableStateFlow(1)
+
+    parentPresenter.test(this, inputFlow) {
+      assertThat(awaitItem()).isEqualTo(ParentModel(input = 1, childPresentCalls = 1))
+      assertThat(childPresentCalls).isEqualTo(1)
+
+      inputFlow.value = 2
+      assertThat(awaitItem()).isEqualTo(ParentModel(input = 2, childPresentCalls = 1))
+      runCurrent()
+      expectNoEvents()
+      assertThat(childPresentCalls).isEqualTo(1)
+
+      inputFlow.value = 3
+      assertThat(awaitItem()).isEqualTo(ParentModel(input = 3, childPresentCalls = 1))
+      runCurrent()
+      expectNoEvents()
+      assertThat(childPresentCalls).isEqualTo(1)
+    }
+  }
+
+  @Test
+  fun `presentDetached recomposes child presenters when the detached input changes`() = runTest {
+    data class Model(val input: Int, val presentCalls: Int) : BaseModel
+
+    var childPresentCalls = 0
+
+    val childPresenter =
+      object : MoleculePresenter<Int, Model> {
+        @Composable
+        override fun present(input: Int): Model {
+          childPresentCalls++
+
+          return Model(input = input, presentCalls = childPresentCalls)
+        }
+      }
+
+    val parentPresenter =
+      object : MoleculePresenter<Int, Model> {
+        @Composable
+        override fun present(input: Int): Model {
+          return childPresenter.presentDetached(input)
+        }
+      }
+
+    val inputFlow = MutableStateFlow(1)
+
+    parentPresenter.test(this, inputFlow) {
+      assertThat(awaitItem()).isEqualTo(Model(input = 1, presentCalls = 1))
+      assertThat(childPresentCalls).isEqualTo(1)
+
+      inputFlow.value = 2
+      assertThat(awaitItem()).isEqualTo(Model(input = 2, presentCalls = 2))
+      assertThat(childPresentCalls).isEqualTo(2)
+    }
+  }
+
+  @Test
+  fun `presentDetached emits the current parent model before detached input catches up`() =
+    runTest {
+      data class ChildModel(val input: Int) : BaseModel
+      data class ParentModel(val input: Int, val childInput: Int) : BaseModel
+
+      val childPresenter =
+        object : MoleculePresenter<Int, ChildModel> {
+          @Composable
+          override fun present(input: Int): ChildModel {
+            return ChildModel(input)
+          }
+        }
+
+      val parentPresenter =
+        object : MoleculePresenter<Int, ParentModel> {
+          @Composable
+          override fun present(input: Int): ParentModel {
+            val childModel = childPresenter.presentDetached(input)
+
+            return ParentModel(input = input, childInput = childModel.input)
+          }
+        }
+
+      val inputFlow = MutableStateFlow(1)
+
+      parentPresenter.test(this, inputFlow) {
+        assertThat(awaitItem()).isEqualTo(ParentModel(input = 1, childInput = 1))
+
+        inputFlow.value = 2
+
+        assertThat(awaitItem()).isEqualTo(ParentModel(input = 2, childInput = 1))
+        assertThat(awaitItem()).isEqualTo(ParentModel(input = 2, childInput = 2))
+      }
+    }
 
   @Test
   fun `launching a presenter on a canceled scope throws an error`() = runTest {

--- a/presenter-molecule/public/src/commonTest/kotlin/software/amazon/app/platform/presenter/molecule/LaunchMoleculePresenterTest.kt
+++ b/presenter-molecule/public/src/commonTest/kotlin/software/amazon/app/platform/presenter/molecule/LaunchMoleculePresenterTest.kt
@@ -21,12 +21,13 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import software.amazon.app.platform.ExperimentalAppPlatform
 import software.amazon.app.platform.internal.IgnoreNative
 import software.amazon.app.platform.internal.IgnoreWasm
 import software.amazon.app.platform.internal.currentThreadName
 import software.amazon.app.platform.presenter.BaseModel
 
-@OptIn(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalAppPlatform::class)
 class LaunchMoleculePresenterTest {
 
   @Test

--- a/settings.gradle
+++ b/settings.gradle
@@ -38,6 +38,7 @@ develocity {
 
 rootProject.name = 'app-platform'
 
+include ':common:public'
 include ':di-common:public'
 include ':internal:testing'
 include ':kotlin-inject:impl'


### PR DESCRIPTION
* **Introduce `@ExperimentalAppPlatform`:** This new annotation can be used to mark APIs as experimental and consumers need to use an explicit opt-in to use these APIs. Neither source nor binary compatibility is guaranteed for these APIs. The annotation is placed in a new module, because it should be allowed to reuse it across App Platform modules.
* **Add detached Molecule presenter API:** Add the experimental `presentDetached()` API to `:presenter-molecule:public` so a child `MoleculePresenter` can run in a separate Molecule hierarchy while the parent collects its latest `BaseModel`. Preserve the active `RecompositionMode` with `LocalRecompositionMode` and cancel detached compositions through a child coroutine scope managed by `DetachedObserver`. Document the `presentDetached()` tradeoff in `docs/presenter.md`: input changes propagate asynchronously, so a parent can emit one model that combines the new parent input with the previous detached child model. Add coverage in `LaunchMoleculePresenterTest.kt` for recomposition isolation, detached input updates, the delayed-input caveat, and recomposition-mode propagation, and update the public API dumps.