### PR TITLE
Add experimental `PresenterTextFieldState`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add `@ExperimentalAppPlatform` in `:common:public` for APIs that require explicit consumer opt-in.
 - Add experimental `MoleculePresenter.presentDetached()` to compose presenter subtrees in detached Molecule hierarchies so busy parent presenters do not recompose slower child presenters.
+- Add experimental Molecule presenter-backed text field state helpers for sharing text input state between presenters and Compose renderers.
 
 ### Changed
 

--- a/docs/presenter.md
+++ b/docs/presenter.md
@@ -873,6 +873,55 @@ class ChildPresenter : MoleculePresenter<Unit, Model> {
 While `CompositionLocals` are powerful, their biggest downsides are unit tests. In a unit test for `ChildPresenter`
 a value for `LocalYourType.current` must be provided, otherwise the call will throw an exception.
 
+### Presenter-backed text fields
+
+Text inputs have renderer-specific editing state, such as cursor position and selection, but presenters
+often still need to own the actual text value. `PresenterTextFieldState` stores the text value in the presenter 
+layer without depending on Compose Foundation's `TextFieldState`.
+
+```kotlin
+@OptIn(ExperimentalAppPlatform::class)
+class SearchPresenter : MoleculePresenter<Unit, SearchPresenter.Model> {
+  @Composable
+  override fun present(input: Unit): Model {
+    val query = remember { PresenterTextFieldState() }
+
+    return Model(
+      query = query,
+      clearQuery = query::clearText,
+    )
+  }
+
+  data class Model(
+    val query: PresenterTextFieldState,
+    val clearQuery: () -> Unit,
+  ) : BaseModel
+}
+```
+
+Compose renderers can bridge the presenter-owned text value to Compose Foundation's `TextFieldState`
+with the experimental `rememberPresenterBackedTextFieldState()` helper:
+
+```kotlin
+@OptIn(ExperimentalAppPlatform::class)
+@ContributesRenderer
+class SearchRenderer : ComposeRenderer<SearchPresenter.Model>() {
+  @Composable
+  override fun Compose(model: SearchPresenter.Model, modifier: Modifier) {
+    val queryState = rememberPresenterBackedTextFieldState(model.query)
+
+    BasicTextField(
+      state = queryState,
+      modifier = modifier,
+    )
+  }
+}
+```
+
+Edits made by the user are copied back to the `PresenterTextFieldState`, and presenter changes such
+as `replaceText()` or `clearText()` are copied into the Compose text field. When presenter text is
+applied to the renderer state, the cursor is placed at the end of the new value.
+
 ### App Bar
 
 The Recipes app implements an app bar for all its screens and allows child presenters to change the content.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -81,6 +81,7 @@ auto-service-annotations = { module = "com.google.auto.service:auto-service-anno
 auto-service-ksp = { module = "dev.zacsweers.autoservice:auto-service-ksp", version.ref = "auto-service-ksp" }
 build-config-gradle-plugin = { module = "com.github.gmazzo.buildconfig:plugin", version.ref = "build-config" }
 compose-gradle-plugin = { module = "org.jetbrains.compose:compose-gradle-plugin", version.ref = "compose-multiplatform" }
+compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "compose-multiplatform" }
 compose-ui-back-handler = { module = "org.jetbrains.compose.ui:ui-backhandler", version.ref = "compose-multiplatform" }
 compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "android-compose-version" }
 compose-ui-test-junit4-android = { module = "androidx.compose.ui:ui-test-junit4-android", version.ref = "android-compose-version" }

--- a/presenter-molecule/public/api/android/public.api
+++ b/presenter-molecule/public/api/android/public.api
@@ -63,3 +63,14 @@ public final class software/amazon/app/platform/presenter/molecule/backgesture/B
 	public static final fun getLocalBackGestureDispatcherPresenter ()Landroidx/compose/runtime/ProvidableCompositionLocal;
 }
 
+public final class software/amazon/app/platform/presenter/molecule/text/PresenterTextFieldState : androidx/compose/runtime/State {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun clearText ()V
+	public synthetic fun getValue ()Ljava/lang/Object;
+	public fun getValue ()Ljava/lang/String;
+	public final fun replaceText (Ljava/lang/String;)V
+}
+

--- a/presenter-molecule/public/api/desktop/public.api
+++ b/presenter-molecule/public/api/desktop/public.api
@@ -63,3 +63,14 @@ public final class software/amazon/app/platform/presenter/molecule/backgesture/B
 	public static final fun getLocalBackGestureDispatcherPresenter ()Landroidx/compose/runtime/ProvidableCompositionLocal;
 }
 
+public final class software/amazon/app/platform/presenter/molecule/text/PresenterTextFieldState : androidx/compose/runtime/State {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun clearText ()V
+	public synthetic fun getValue ()Ljava/lang/Object;
+	public fun getValue ()Ljava/lang/String;
+	public final fun replaceText (Ljava/lang/String;)V
+}
+

--- a/presenter-molecule/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/text/PresenterTextFieldState.kt
+++ b/presenter-molecule/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/text/PresenterTextFieldState.kt
@@ -1,0 +1,60 @@
+package software.amazon.app.platform.presenter.molecule.text
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import software.amazon.app.platform.ExperimentalAppPlatform
+
+/**
+ * Presenter-owned text input state.
+ *
+ * Use this when a presenter needs to own the current text for an input field while the renderer
+ * still needs a platform UI text state, such as Compose Foundation's `TextFieldState`, for cursor,
+ * selection, and editing behavior. [PresenterTextFieldState] keeps only the text value, making it
+ * suitable for presenter models without depending on Compose Foundation.
+ *
+ * In a Molecule presenter, remember one instance for each logical text field and expose it through
+ * the model:
+ * ```kotlin
+ * @OptIn(ExperimentalAppPlatform::class)
+ * class SearchPresenter : MoleculePresenter<Unit, SearchPresenter.Model> {
+ *   @Composable
+ *   override fun present(input: Unit): Model {
+ *     val query = remember { PresenterTextFieldState() }
+ *
+ *     return Model(
+ *       query = query,
+ *       clearQuery = query::clearText,
+ *     )
+ *   }
+ *
+ *   data class Model(
+ *     val query: PresenterTextFieldState,
+ *     val clearQuery: () -> Unit,
+ *   ) : BaseModel
+ * }
+ * ```
+ *
+ * Compose renderers can connect this presenter state to a Compose Foundation text field with
+ * `rememberPresenterBackedTextFieldState()`.
+ */
+@ExperimentalAppPlatform
+@Stable
+public class PresenterTextFieldState(initialText: String = "") : State<String> {
+  private var text by mutableStateOf(initialText)
+
+  override val value: String
+    get() = text
+
+  /** Replaces the current text value. */
+  public fun replaceText(text: String) {
+    this.text = text
+  }
+
+  /** Clears the current text value. */
+  public fun clearText() {
+    replaceText("")
+  }
+}

--- a/presenter-molecule/public/src/commonTest/kotlin/software/amazon/app/platform/presenter/molecule/text/PresenterTextFieldStateTest.kt
+++ b/presenter-molecule/public/src/commonTest/kotlin/software/amazon/app/platform/presenter/molecule/text/PresenterTextFieldStateTest.kt
@@ -1,0 +1,27 @@
+package software.amazon.app.platform.presenter.molecule.text
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+import software.amazon.app.platform.ExperimentalAppPlatform
+
+@OptIn(ExperimentalAppPlatform::class)
+class PresenterTextFieldStateTest {
+  @Test
+  fun `exposes the initial text value`() {
+    val state = PresenterTextFieldState("initial")
+
+    assertThat(state.value).isEqualTo("initial")
+  }
+
+  @Test
+  fun `replaces and clears text`() {
+    val state = PresenterTextFieldState("initial")
+
+    state.replaceText("updated")
+    assertThat(state.value).isEqualTo("updated")
+
+    state.clearText()
+    assertThat(state.value).isEqualTo("")
+  }
+}

--- a/renderer-compose-multiplatform/public/api/android/public.api
+++ b/renderer-compose-multiplatform/public/api/android/public.api
@@ -46,3 +46,7 @@ public final class software/amazon/app/platform/renderer/ComposeRendererFactoryK
 	public static synthetic fun getComposeRenderer$default (Lsoftware/amazon/app/platform/renderer/RendererFactory;Lsoftware/amazon/app/platform/presenter/BaseModel;IILjava/lang/Object;)Lsoftware/amazon/app/platform/renderer/BaseComposeRenderer;
 }
 
+public final class software/amazon/app/platform/renderer/text/PresenterBackedTextFieldStateKt {
+	public static final fun rememberPresenterBackedTextFieldState (Lsoftware/amazon/app/platform/presenter/molecule/text/PresenterTextFieldState;Landroidx/compose/runtime/Composer;I)Landroidx/compose/foundation/text/input/TextFieldState;
+}
+

--- a/renderer-compose-multiplatform/public/api/desktop/public.api
+++ b/renderer-compose-multiplatform/public/api/desktop/public.api
@@ -37,3 +37,7 @@ public final class software/amazon/app/platform/renderer/ComposeRendererFactoryK
 	public static synthetic fun getComposeRenderer$default (Lsoftware/amazon/app/platform/renderer/RendererFactory;Lsoftware/amazon/app/platform/presenter/BaseModel;IILjava/lang/Object;)Lsoftware/amazon/app/platform/renderer/BaseComposeRenderer;
 }
 
+public final class software/amazon/app/platform/renderer/text/PresenterBackedTextFieldStateKt {
+	public static final fun rememberPresenterBackedTextFieldState (Lsoftware/amazon/app/platform/presenter/molecule/text/PresenterTextFieldState;Landroidx/compose/runtime/Composer;I)Landroidx/compose/foundation/text/input/TextFieldState;
+}
+

--- a/renderer-compose-multiplatform/public/build.gradle
+++ b/renderer-compose-multiplatform/public/build.gradle
@@ -10,10 +10,11 @@ appPlatformBuildSrc {
 
 dependencies {
     commonMainApi project(':presenter:public')
+    commonMainApi project(':presenter-molecule:public')
     commonMainApi project(':renderer:public')
     commonMainApi project(':scope:public')
+    commonMainApi libs.compose.foundation
 
-    commonMainImplementation project(':presenter-molecule:public')
     commonMainImplementation libs.navigation.event.compose
 
     androidMainApi project(':renderer-android-view:public')

--- a/renderer-compose-multiplatform/public/src/commonMain/kotlin/software/amazon/app/platform/renderer/text/PresenterBackedTextFieldState.kt
+++ b/renderer-compose-multiplatform/public/src/commonMain/kotlin/software/amazon/app/platform/renderer/text/PresenterBackedTextFieldState.kt
@@ -1,0 +1,69 @@
+package software.amazon.app.platform.renderer.text
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.flow.collectLatest
+import software.amazon.app.platform.ExperimentalAppPlatform
+import software.amazon.app.platform.presenter.molecule.text.PresenterTextFieldState
+
+/**
+ * Remembers a Compose Foundation [TextFieldState] backed by [presenterState].
+ *
+ * The returned [TextFieldState] is initialized from [presenterState]. Edits made by the user in the
+ * renderer are copied back to [presenterState], and text changes made by the presenter are copied
+ * into the returned [TextFieldState].
+ *
+ * Use this in Compose renderers when the presenter owns the text value but Compose Foundation owns
+ * editing details such as cursor position and selection:
+ * ```kotlin
+ * data class Model(
+ *   val query: PresenterTextFieldState,
+ * ) : BaseModel
+ *
+ * @OptIn(ExperimentalAppPlatform::class)
+ * @Composable
+ * fun SearchContent(model: Model, modifier: Modifier = Modifier) {
+ *   val queryState = rememberPresenterBackedTextFieldState(model.query)
+ *
+ *   BasicTextField(
+ *     state = queryState,
+ *     modifier = modifier,
+ *   )
+ * }
+ * ```
+ *
+ * If the presenter replaces the text, the cursor is placed at the end of the new value. This avoids
+ * preserving a renderer selection that may no longer be valid for the presenter's text.
+ */
+@ExperimentalAppPlatform
+@Composable
+public fun rememberPresenterBackedTextFieldState(
+  presenterState: PresenterTextFieldState
+): TextFieldState {
+  val presenterText = presenterState.value
+  val presenterTextState by rememberUpdatedState(presenterState)
+  val textFieldState = rememberTextFieldState(presenterText)
+
+  LaunchedEffect(textFieldState) {
+    snapshotFlow { textFieldState.text.toString() }
+      .collectLatest { text ->
+        if (text != presenterTextState.value) {
+          presenterTextState.replaceText(text)
+        }
+      }
+  }
+
+  LaunchedEffect(presenterText, textFieldState) {
+    if (presenterText != textFieldState.text.toString()) {
+      textFieldState.setTextAndPlaceCursorAtEnd(presenterText)
+    }
+  }
+
+  return textFieldState
+}

--- a/renderer-compose-multiplatform/public/src/desktopTest/kotlin/software/amazon/app/platform/renderer/text/PresenterBackedTextFieldStateTest.kt
+++ b/renderer-compose-multiplatform/public/src/desktopTest/kotlin/software/amazon/app/platform/renderer/text/PresenterBackedTextFieldStateTest.kt
@@ -1,0 +1,59 @@
+package software.amazon.app.platform.renderer.text
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+import software.amazon.app.platform.ExperimentalAppPlatform
+import software.amazon.app.platform.presenter.molecule.text.PresenterTextFieldState
+
+@OptIn(ExperimentalAppPlatform::class, ExperimentalTestApi::class)
+class PresenterBackedTextFieldStateTest {
+  @Test
+  fun `initializes the renderer text state from the presenter text state`() {
+    runComposeUiTest {
+      val presenterState = PresenterTextFieldState("initial")
+      var textFieldState: TextFieldState? = null
+
+      setContent { textFieldState = rememberPresenterBackedTextFieldState(presenterState) }
+
+      waitForIdle()
+      assertThat(textFieldState!!.text.toString()).isEqualTo("initial")
+    }
+  }
+
+  @Test
+  fun `updates the presenter text state when the renderer text state changes`() {
+    runComposeUiTest {
+      val presenterState = PresenterTextFieldState("initial")
+      var textFieldState: TextFieldState? = null
+
+      setContent { textFieldState = rememberPresenterBackedTextFieldState(presenterState) }
+      waitForIdle()
+
+      runOnIdle { textFieldState!!.setTextAndPlaceCursorAtEnd("updated") }
+      waitForIdle()
+
+      assertThat(presenterState.value).isEqualTo("updated")
+    }
+  }
+
+  @Test
+  fun `updates the renderer text state when the presenter text state changes`() {
+    runComposeUiTest {
+      val presenterState = PresenterTextFieldState("initial")
+      var textFieldState: TextFieldState? = null
+
+      setContent { textFieldState = rememberPresenterBackedTextFieldState(presenterState) }
+      waitForIdle()
+
+      runOnIdle { presenterState.replaceText("updated") }
+      waitForIdle()
+
+      assertThat(textFieldState!!.text.toString()).isEqualTo("updated")
+    }
+  }
+}


### PR DESCRIPTION
Add `PresenterTextFieldState` in `:presenter-molecule:public` for Molecule presenters that need to own text input values without depending on Compose Foundation text field APIs.

Add `rememberPresenterBackedTextFieldState()` in `:renderer-compose-multiplatform:public` to bridge that state to Compose Foundation `TextFieldState`, syncing renderer edits back to the presenter and presenter text changes back to the renderer.

Expose `compose-foundation` through `gradle/libs.versions.toml`, update API dumps, document the recipe in `docs/presenter.md`, update `CHANGELOG.md`, and cover the presenter state and renderer bridge with tests.
