### PR TITLE
Allow opt-in impl-to-impl dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- Add an opt-in `allowLibraryImplToImplDependencies` module structure option for dependencies between
+  `:impl` modules within the same library.
+
 ### Changed
 
 - Upgrade Kotlin to `2.4.0`, Android Lint to `9.2.1`, KSP to `2.3.9`, and kotlin-compile-testing to `0.13.0`.

--- a/docs/module-structure.md
+++ b/docs/module-structure.md
@@ -236,8 +236,8 @@ To make code easier to discover, it’s recommended to put all Gradle modules in
 
 This module structure reduces coupling between libraries and increases cohesion within modules, which are two
 desired attributes in a modularized codebase. `:impl` modules can change and be modified without impacting any
-other library. Our build dependency graph stays flat and all `:impl` modules can be compiled and assembled in
-parallel.
+other library. By default, the build dependency graph stays flat and all `:impl` modules can be compiled and
+assembled in parallel.
 
 The `:public / :impl` module split is recommended whenever dependency inversion is needed for code, because of
 all the benefits mentioned above. The split becomes more natural over time and the benefit increases. Rare
@@ -262,10 +262,15 @@ such as static utilities, extension functions and UI components.
 zero or more `:impl` modules. If a library contains multiple `:impl` modules, then they’re suffixed with a name,
 e.g. `:login:impl-amazon` and `:login:impl-google`.
 
+By default, `:impl` modules cannot depend on each other. The `allowLibraryImplToImplDependencies` option relaxes this
+rule only for `:impl` modules in the same library. Cross-library and external `:impl` dependencies remain
+forbidden.
+
 ### `:internal`
 
 `:internal` modules are used when code should be shared between multiple `:impl` modules of the same library,
 but the code should not be exposed through the `:public` module. This code is *internal* to this library.
+They remain available whether or not `allowLibraryImplToImplDependencies` is enabled.
 
 ### `:testing`
 
@@ -318,6 +323,29 @@ appPlatform {
   enableModuleStructure true
 }
 ```
+
+By default, `:impl` modules cannot depend on other `:impl` modules. This can be relaxed for dependencies within
+the same library while preserving the cross-library boundary:
+
+=== "build.gradle"
+
+    ```groovy
+    appPlatform {
+      enableModuleStructure {
+        allowLibraryImplToImplDependencies true
+      }
+    }
+    ```
+
+=== "build.gradle.kts"
+
+    ```kotlin
+    appPlatform {
+      enableModuleStructure {
+        allowLibraryImplToImplDependencies(true)
+      }
+    }
+    ```
 
 With this setting enabled, several checks and features are enabled:
 

--- a/gradle-plugin/api/gradle-plugin.api
+++ b/gradle-plugin/api/gradle-plugin.api
@@ -5,6 +5,7 @@ public class software/amazon/app/platform/gradle/AppPlatformExtension {
 	public final fun enableComposeUi (Z)V
 	public final fun enableKotlinInject (Z)V
 	public final fun enableMetro (Z)V
+	public final fun enableModuleStructure (Lorg/gradle/api/Action;)V
 	public final fun enableModuleStructure (Z)V
 	public final fun enableMoleculePresenterBackstack (Z)V
 	public final fun enableMoleculePresenters (Z)V
@@ -26,6 +27,7 @@ public abstract class software/amazon/app/platform/gradle/ModuleStructureDepende
 	public static final field Companion Lsoftware/amazon/app/platform/gradle/ModuleStructureDependencyCheckTask$Companion;
 	public fun <init> ()V
 	public final fun checkDependencies ()V
+	public abstract fun getAllowLibraryImplToImplDependencies ()Lorg/gradle/api/provider/Property;
 	public abstract fun getIgnoredOutputFile ()Ljava/io/File;
 	public abstract fun getModuleCompileClasspath ()Ljava/util/Set;
 	public abstract fun getModulePath ()Ljava/lang/String;
@@ -36,6 +38,11 @@ public abstract class software/amazon/app/platform/gradle/ModuleStructureDepende
 
 public final class software/amazon/app/platform/gradle/ModuleStructureDependencyCheckTask$Companion {
 	public final fun registerModuleStructureDependencyCheckTask (Lorg/gradle/api/Project;)V
+}
+
+public class software/amazon/app/platform/gradle/ModuleStructureOptions {
+	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
+	public final fun allowLibraryImplToImplDependencies (Z)V
 }
 
 public class software/amazon/app/platform/gradle/ModuleStructurePlugin : org/gradle/api/Plugin {

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -64,6 +64,14 @@ dependencies {
     compileOnly libs.kotlin.multiplatform.gradle.plugin
 
     lintChecks libs.androidx.lint.gradle
+
+    testImplementation gradleTestKit()
+    testImplementation libs.assertk
+    testImplementation libs.kotlin.test.junit5
+}
+
+test {
+    useJUnitPlatform()
 }
 
 java {

--- a/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/AppPlatformExtension.kt
+++ b/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/AppPlatformExtension.kt
@@ -9,6 +9,7 @@ import gradle_plugin.BuildConfig.KOTLIN_INJECT_ANVIL_VERSION
 import gradle_plugin.BuildConfig.KOTLIN_INJECT_VERSION
 import gradle_plugin.BuildConfig.MOLECULE_VERSION
 import javax.inject.Inject
+import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.model.ObjectFactory
@@ -29,6 +30,9 @@ import software.amazon.app.platform.gradle.ModuleStructurePlugin.Companion.testi
  *   enableMoleculePresenters true // false is the default
  *   enableMoleculePresenterBackstack true // false is the default
  *   enableModuleStructure true // false is the default
+ *   enableModuleStructure {
+ *     allowLibraryImplToImplDependencies true // false is the default
+ *   }
  *   enableComposeUi true // false is the default
  *
  *   addPublicModuleDependencies true // false is the default
@@ -166,6 +170,8 @@ constructor(objects: ObjectFactory, private val project: Project) {
 
   private val enableModuleStructure: Property<Boolean> =
     objects.property(Boolean::class.java).convention(false)
+  private val moduleStructureOptions: ModuleStructureOptions =
+    objects.newInstance(ModuleStructureOptions::class.java)
 
   /** Sets up this module to use our recommended module structure and applies certain defaults. */
   public fun enableModuleStructure(enable: Boolean) {
@@ -179,7 +185,15 @@ constructor(objects: ObjectFactory, private val project: Project) {
     }
   }
 
+  /** Sets up and configures this module to use our recommended module structure. */
+  public fun enableModuleStructure(action: Action<ModuleStructureOptions>) {
+    action.execute(moduleStructureOptions)
+    enableModuleStructure(true)
+  }
+
   internal fun isModuleStructureEnabled(): Property<Boolean> = enableModuleStructure
+
+  internal fun moduleStructureOptions(): ModuleStructureOptions = moduleStructureOptions
 
   internal companion object {
     internal val Project.appPlatform: AppPlatformExtension

--- a/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/ModuleStructureDependencyCheckTask.kt
+++ b/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/ModuleStructureDependencyCheckTask.kt
@@ -7,11 +7,13 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ExternalDependency
 import org.gradle.api.artifacts.ProjectDependency
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
+import software.amazon.app.platform.gradle.AppPlatformExtension.Companion.appPlatform
 
 /** Checks that our module structure dependency rules are followed. */
 @CacheableTask
@@ -23,12 +25,16 @@ public abstract class ModuleStructureDependencyCheckTask : DefaultTask() {
   /** All Gradle modules on the compile classpath. */
   @get:Input public abstract var moduleCompileClasspath: Set<String>
 
+  /** Whether `:impl` dependencies within the same library are allowed. */
+  @get:Input public abstract val allowLibraryImplToImplDependencies: Property<Boolean>
+
   /** An empty output makes the task work with up-to-date checks. */
   @Suppress("unused") @get:OutputFile @get:Optional public abstract var ignoredOutputFile: File
 
   init {
     description = "Checks that our module structure dependency rules are followed."
     group = "Verification"
+    allowLibraryImplToImplDependencies.convention(false)
   }
 
   @TaskAction
@@ -40,7 +46,7 @@ public abstract class ModuleStructureDependencyCheckTask : DefaultTask() {
       checkOnlyPublicModule()
     }
     if (moduleType != ModuleType.APP && moduleType != ModuleType.IMPL_ROBOTS) {
-      checkNoImplImport()
+      checkNoImplImport(moduleType)
     }
     if (moduleType != ModuleType.TESTING && !moduleType.isRobotsModule) {
       checkNoTestingImport()
@@ -65,8 +71,15 @@ public abstract class ModuleStructureDependencyCheckTask : DefaultTask() {
     }
   }
 
-  private fun checkNoImplImport() {
-    val forbiddenDependencies = moduleCompileClasspath.filter { it.moduleType == ModuleType.IMPL }
+  private fun checkNoImplImport(moduleType: ModuleType) {
+    val forbiddenDependencies =
+      moduleCompileClasspath
+        .filter { it.moduleType == ModuleType.IMPL }
+        .filterNot { dependency ->
+          allowLibraryImplToImplDependencies.get() &&
+            moduleType == ModuleType.IMPL &&
+            dependency.isProjectDependencyWithinSameLibrary()
+        }
 
     if (forbiddenDependencies.isNotEmpty()) {
       throw GradleException(
@@ -116,12 +129,7 @@ public abstract class ModuleStructureDependencyCheckTask : DefaultTask() {
           //
           // For external dependencies this check is much harder and for now we simply
           // assume that the internal dependency isn't allowed.
-          if (dependency.startsWith(":")) {
-            dependency.substringBeforeLast(':') != modulePath.substringBeforeLast(':')
-          } else {
-            // It's an external dependency
-            true
-          }
+          !dependency.isProjectDependencyWithinSameLibrary()
         }
 
     if (forbiddenDependencies.isNotEmpty()) {
@@ -140,6 +148,9 @@ public abstract class ModuleStructureDependencyCheckTask : DefaultTask() {
       } else {
         substringAfter(':').substringBefore(':').moduleTypeFromArtifactId()
       }
+
+  private fun String.isProjectDependencyWithinSameLibrary(): Boolean =
+    startsWith(":") && substringBeforeLast(':') == modulePath.substringBeforeLast(':')
 
   public companion object {
     /** Registers the task in the given project. */
@@ -160,6 +171,9 @@ public abstract class ModuleStructureDependencyCheckTask : DefaultTask() {
             ModuleStructureDependencyCheckTask::class.java,
           ) { task ->
             task.modulePath = path
+            task.allowLibraryImplToImplDependencies.set(
+              appPlatform.moduleStructureOptions().isLibraryImplToImplDependenciesAllowed()
+            )
             task.moduleCompileClasspath =
               configuration()
                 .allDependencies

--- a/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/ModuleStructureOptions.kt
+++ b/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/ModuleStructureOptions.kt
@@ -1,0 +1,23 @@
+package software.amazon.app.platform.gradle
+
+import javax.inject.Inject
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+
+/** Options for configuring the App Platform module structure. */
+public open class ModuleStructureOptions @Inject constructor(objects: ObjectFactory) {
+  private val allowLibraryImplToImplDependencies: Property<Boolean> =
+    objects.property(Boolean::class.java).convention(false)
+
+  /**
+   * Allows an `:impl` module to depend on another `:impl` module in the same library. Dependencies
+   * on `:impl` modules from other libraries remain forbidden.
+   */
+  public fun allowLibraryImplToImplDependencies(allow: Boolean) {
+    allowLibraryImplToImplDependencies.set(allow)
+    allowLibraryImplToImplDependencies.finalizeValueOnRead()
+  }
+
+  internal fun isLibraryImplToImplDependenciesAllowed(): Property<Boolean> =
+    allowLibraryImplToImplDependencies
+}

--- a/gradle-plugin/src/test/kotlin/software/amazon/app/platform/gradle/AppPlatformExtensionTest.kt
+++ b/gradle-plugin/src/test/kotlin/software/amazon/app/platform/gradle/AppPlatformExtensionTest.kt
@@ -1,0 +1,75 @@
+package software.amazon.app.platform.gradle
+
+import assertk.assertThat
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import groovy.lang.Binding
+import groovy.lang.GroovyShell
+import kotlin.test.Test
+import org.gradle.api.Action
+import org.gradle.testfixtures.ProjectBuilder
+
+class AppPlatformExtensionTest {
+
+  @Test
+  fun `module structure options are disabled by default`() {
+    val extension = createExtension()
+
+    assertThat(extension.isModuleStructureEnabled().get()).isFalse()
+    assertThat(extension.moduleStructureOptions().isLibraryImplToImplDependenciesAllowed().get())
+      .isFalse()
+  }
+
+  @Test
+  fun `module structure can be enabled and configured with an action`() {
+    val extension = createExtension()
+
+    extension.enableModuleStructure(
+      Action { options -> options.allowLibraryImplToImplDependencies(true) }
+    )
+
+    assertThat(extension.isModuleStructureEnabled().get()).isTrue()
+    assertThat(extension.moduleStructureOptions().isLibraryImplToImplDependenciesAllowed().get())
+      .isTrue()
+  }
+
+  @Test
+  fun `module structure options can be configured after it was already enabled`() {
+    val extension = createExtension()
+    extension.enableModuleStructure(true)
+
+    extension.enableModuleStructure(
+      Action { options -> options.allowLibraryImplToImplDependencies(true) }
+    )
+
+    assertThat(extension.moduleStructureOptions().isLibraryImplToImplDependenciesAllowed().get())
+      .isTrue()
+  }
+
+  @Test
+  fun `module structure can be enabled and configured with the Groovy DSL`() {
+    val extension = createExtension()
+    val binding = Binding(mapOf("appPlatform" to extension))
+
+    GroovyShell(binding)
+      .evaluate(
+        """
+        appPlatform.enableModuleStructure {
+          allowLibraryImplToImplDependencies true
+        }
+        """
+          .trimIndent()
+      )
+
+    assertThat(extension.isModuleStructureEnabled().get()).isTrue()
+    assertThat(extension.moduleStructureOptions().isLibraryImplToImplDependenciesAllowed().get())
+      .isTrue()
+  }
+
+  private fun createExtension(): AppPlatformExtension {
+    val rootProject = ProjectBuilder.builder().withName("root").build()
+    val moduleProject = ProjectBuilder.builder().withName("impl").withParent(rootProject).build()
+    moduleProject.plugins.apply(AppPlatformPlugin::class.java)
+    return moduleProject.extensions.getByType(AppPlatformExtension::class.java)
+  }
+}

--- a/gradle-plugin/src/test/kotlin/software/amazon/app/platform/gradle/ModuleStructureDependencyCheckTaskTest.kt
+++ b/gradle-plugin/src/test/kotlin/software/amazon/app/platform/gradle/ModuleStructureDependencyCheckTaskTest.kt
@@ -1,0 +1,105 @@
+package software.amazon.app.platform.gradle
+
+import assertk.assertFailure
+import assertk.assertions.isInstanceOf
+import kotlin.test.Test
+import org.gradle.api.GradleException
+import org.gradle.testfixtures.ProjectBuilder
+
+class ModuleStructureDependencyCheckTaskTest {
+
+  @Test
+  fun `impl dependency within the same library is forbidden by default`() {
+    assertFailure {
+        checkDependencies(
+          modulePath = ":library:impl-specific",
+          moduleCompileClasspath = setOf(":library:impl-common"),
+        )
+      }
+      .isInstanceOf<GradleException>()
+  }
+
+  @Test
+  fun `impl dependency within the same library can be allowed`() {
+    checkDependencies(
+      modulePath = ":library:impl-specific",
+      moduleCompileClasspath = setOf(":library:impl-common"),
+      allowLibraryImplToImplDependencies = true,
+    )
+  }
+
+  @Test
+  fun `impl dependency from another library remains forbidden`() {
+    assertFailure {
+        checkDependencies(
+          modulePath = ":library:impl-specific",
+          moduleCompileClasspath = setOf(":other-library:impl-common"),
+          allowLibraryImplToImplDependencies = true,
+        )
+      }
+      .isInstanceOf<GradleException>()
+  }
+
+  @Test
+  fun `external impl dependency remains forbidden`() {
+    assertFailure {
+        checkDependencies(
+          modulePath = ":library:impl-specific",
+          moduleCompileClasspath = setOf("com.example:library-impl-common:1.0"),
+          allowLibraryImplToImplDependencies = true,
+        )
+      }
+      .isInstanceOf<GradleException>()
+  }
+
+  @Test
+  fun `non-impl module cannot use the option to import an impl module`() {
+    assertFailure {
+        checkDependencies(
+          modulePath = ":library:internal",
+          moduleCompileClasspath = setOf(":library:impl-common"),
+          allowLibraryImplToImplDependencies = true,
+        )
+      }
+      .isInstanceOf<GradleException>()
+  }
+
+  @Test
+  fun `internal dependency within the same library remains allowed`() {
+    checkDependencies(
+      modulePath = ":library:impl",
+      moduleCompileClasspath = setOf(":library:internal"),
+    )
+  }
+
+  @Test
+  fun `internal dependency from another library remains forbidden`() {
+    assertFailure {
+        checkDependencies(
+          modulePath = ":library:impl",
+          moduleCompileClasspath = setOf(":other-library:internal"),
+        )
+      }
+      .isInstanceOf<GradleException>()
+  }
+
+  private fun checkDependencies(
+    modulePath: String,
+    moduleCompileClasspath: Set<String>,
+    allowLibraryImplToImplDependencies: Boolean? = null,
+  ) {
+    val project = ProjectBuilder.builder().build()
+    val task =
+      project.tasks
+        .register(
+          "checkModuleStructureDependencies",
+          ModuleStructureDependencyCheckTask::class.java,
+        )
+        .get()
+
+    task.modulePath = modulePath
+    task.moduleCompileClasspath = moduleCompileClasspath
+    allowLibraryImplToImplDependencies?.let(task.allowLibraryImplToImplDependencies::set)
+    task.checkDependencies()
+  }
+}


### PR DESCRIPTION
Add nested `enableModuleStructure` options with `allowLibraryImplToImplDependencies`, preserving the existing Boolean overload and a false default. This lets sibling implementation variants reuse code without forcing an otherwise-empty `:internal` module.

Thread the option through the cacheable dependency checker while keeping cross-library and external implementation dependencies forbidden and retaining existing internal-module semantics. Update the public API snapshot and consumer documentation for both Groovy and Kotlin DSL usage.
