### PR TITLE
Run starter ktfmt check on Linux

### DIFF
--- a/.github/workflows/blueprints-starter-ci.yml
+++ b/.github/workflows/blueprints-starter-ci.yml
@@ -78,7 +78,7 @@ jobs:
         run: ./gradlew :app:desktopMainClasses
 
   ktfmt:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 25
     defaults:
       run:
@@ -91,7 +91,14 @@ jobs:
           gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Install ktfmt
-        run: brew install ktfmt
+        run: |
+          KTFMT_VERSION="$(sed -n 's/^ktfmt = "\(.*\)"$/\1/p' gradle/libs.versions.toml)"
+          test -n "$KTFMT_VERSION"
+          curl -fsSL \
+            "https://github.com/facebook/ktfmt/releases/download/v${KTFMT_VERSION}/ktfmt-${KTFMT_VERSION}-with-dependencies.jar" \
+            -o "$RUNNER_TEMP/ktfmt.jar"
 
       - name: Run ktfmt
-        run: ktfmt --google-style --dry-run --set-exit-if-changed $(find . -type f -name "*.kt")
+        run: |
+          java -jar "$RUNNER_TEMP/ktfmt.jar" --google-style --dry-run --set-exit-if-changed \
+            $(find . -type f -name "*.kt")

--- a/blueprints/starter/gradle/libs.versions.toml
+++ b/blueprints/starter/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ compose-material3 = "1.9.0"
 compose-multiplatform = "1.10.3"
 coroutines = "1.10.2"
 kotlin = "2.3.20"
+ktfmt = "0.64"
 metro = "1.0.0-RC2"
 
 [libraries]


### PR DESCRIPTION
Use an Ubuntu runner for the starter blueprint `ktfmt` check so formatting validation no longer consumes a macOS runner just to install the formatter with Homebrew. Keep the `ktfmt` version in the starter version catalog so CI uses a reviewable, pinned formatter release.