### PR TITLE
Replace ktfmt Gradle plugin with standalone runner

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -867,6 +867,7 @@ ij_kotlin_continuation_indent_in_elvis = false
 ij_kotlin_continuation_indent_in_if_conditions = false
 ij_kotlin_continuation_indent_in_parameter_lists = false
 ij_kotlin_continuation_indent_in_supertype_lists = false
+ij_kotlin_continuation_indent_size = 2
 ij_kotlin_else_on_new_line = false
 ij_kotlin_enum_constants_wrap = off
 ij_kotlin_extends_list_wrap = normal
@@ -874,6 +875,7 @@ ij_kotlin_field_annotation_wrap = split_into_lines
 ij_kotlin_finally_on_new_line = false
 ij_kotlin_if_rparen_on_new_line = false
 ij_kotlin_import_nested_classes = false
+ij_kotlin_imports_layout = *
 ij_kotlin_insert_whitespaces_in_simple_one_line_method = true
 ij_kotlin_keep_blank_lines_before_right_brace = 2
 ij_kotlin_keep_blank_lines_in_code = 2
@@ -919,6 +921,7 @@ ij_kotlin_while_on_new_line = false
 ij_kotlin_wrap_elvis_expressions = 1
 ij_kotlin_wrap_expression_body_functions = 1
 ij_kotlin_wrap_first_method_in_call_chain = false
+ktfmt_trailing_comma_management_strategy = complete
 
 [{*.har,*.json}]
 indent_size = 2

--- a/.github/workflows/blueprints-starter-ci.yml
+++ b/.github/workflows/blueprints-starter-ci.yml
@@ -76,29 +76,3 @@ jobs:
           gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
       - name: Build Desktop binary
         run: ./gradlew :app:desktopMainClasses
-
-  ktfmt:
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
-    defaults:
-      run:
-        working-directory: blueprints/starter
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup
-        uses: ./.github/actions/setup-action
-        with:
-          gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-
-      - name: Install ktfmt
-        run: |
-          KTFMT_VERSION="$(sed -n 's/^ktfmt = "\(.*\)"$/\1/p' gradle/libs.versions.toml)"
-          test -n "$KTFMT_VERSION"
-          curl -fsSL \
-            "https://github.com/facebook/ktfmt/releases/download/v${KTFMT_VERSION}/ktfmt-${KTFMT_VERSION}-with-dependencies.jar" \
-            -o "$RUNNER_TEMP/ktfmt.jar"
-
-      - name: Run ktfmt
-        run: |
-          java -jar "$RUNNER_TEMP/ktfmt.jar" --google-style --dry-run --set-exit-if-changed \
-            $(find . -type f -name "*.kt")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,8 +311,8 @@ jobs:
         with:
           gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
-      - name: ktfmt
-        run: ./gradlew ktfmtCheck --stacktrace --show-version --continue
+      - name: Run ktfmt
+        run: ./ktfmt.sh --dry-run --set-exit-if-changed
 
   android-lint:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,7 +199,7 @@ These are the main root-level quality gates used by GitHub Actions:
 ./gradlew linuxX64Test
 ./gradlew wasmJsTest
 ./gradlew apiCheck
-./gradlew ktfmtCheck
+./ktfmt.sh --dry-run --set-exit-if-changed
 ./gradlew detekt
 ./gradlew lint
 ./gradlew checkModuleStructureDependencies
@@ -252,7 +252,6 @@ Run these from the repo root:
 ./gradlew :metro-extensions:contribute:impl-compiler-plugin:test --tests 'software.amazon.app.platform.metro.compiler.runners.BoxTestGenerated$Metro.testTinyGraph'
 ./gradlew :metro-extensions:contribute:impl-compiler-plugin:test -PupdateTestData
 ./gradlew :metro-extensions:contribute:impl-compiler-plugin:generateTests
-./gradlew :metro-extensions:contribute:impl-compiler-plugin:ktfmtCheck
 ```
 
 Use this workflow for compiler tests:

--- a/blueprints/starter/README.md
+++ b/blueprints/starter/README.md
@@ -67,16 +67,6 @@ This template demonstrates:
 ```
 
 > This runs the desktop Compose app using the JVM target.
- 
-
-## Formatting
-
-### ktfmt
-```bash
-ktfmt **/*.kt --google-style
-```
-
-> This will run through all the kt files and format them.
 
 ## Configuration
 

--- a/blueprints/starter/gradle/libs.versions.toml
+++ b/blueprints/starter/gradle/libs.versions.toml
@@ -11,7 +11,6 @@ compose-material3 = "1.9.0"
 compose-multiplatform = "1.10.3"
 coroutines = "1.10.2"
 kotlin = "2.3.20"
-ktfmt = "0.64"
 metro = "1.0.0-RC2"
 
 [libraries]

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -2,18 +2,11 @@
 plugins {
     id 'java-gradle-plugin'
     alias libs.plugins.kotlin.jvm
-    alias libs.plugins.ktfmt
     alias libs.plugins.build.config
 }
 
 buildConfig {
     buildConfigField(String, 'APP_PLATFORM_GROUP', property('GROUP'))
-}
-
-ktfmt {
-    googleStyle()
-    trailingCommaManagementStrategy.set(com.ncorti.ktfmt.gradle.TrailingCommaManagementStrategy.COMPLETE)
-    removeUnusedImports.set(true)
 }
 
 java {
@@ -75,7 +68,6 @@ dependencies {
 
     implementation libs.graphviz.java
     implementation libs.kotlin.hierarchy.plugin
-    implementation libs.ktfmt.gradle.plugin
     implementation libs.maven.publish.gradle.plugin
     implementation libs.metro.gradle.plugin
     implementation libs.detekt.gradle.plugin
@@ -83,5 +75,5 @@ dependencies {
 }
 
 tasks.register('release') {
-    dependsOn('build', 'check', 'ktfmtCheck')
+    dependsOn('build', 'check')
 }

--- a/buildSrc/src/main/kotlin/software/amazon/app/platform/gradle/buildsrc/JvmLibraryPlugin.kt
+++ b/buildSrc/src/main/kotlin/software/amazon/app/platform/gradle/buildsrc/JvmLibraryPlugin.kt
@@ -5,7 +5,6 @@ import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import software.amazon.app.platform.gradle.buildsrc.AppPlatformExtension.Companion.appPlatformBuildSrc
-import software.amazon.app.platform.gradle.buildsrc.KmpPlugin.Companion.configureKtfmt
 
 public open class JvmLibraryPlugin : Plugin<Project> {
   override fun apply(target: Project) {
@@ -15,7 +14,6 @@ public open class JvmLibraryPlugin : Plugin<Project> {
     target.configureKotlin()
     target.configureTests()
     target.configureCoroutines()
-    target.configureKtfmt()
   }
 
   private fun Project.configureKotlin() {

--- a/buildSrc/src/main/kotlin/software/amazon/app/platform/gradle/buildsrc/KmpPlugin.kt
+++ b/buildSrc/src/main/kotlin/software/amazon/app/platform/gradle/buildsrc/KmpPlugin.kt
@@ -1,8 +1,6 @@
 package software.amazon.app.platform.gradle.buildsrc
 
 import com.google.devtools.ksp.gradle.KspExtension
-import com.ncorti.ktfmt.gradle.KtfmtExtension
-import com.ncorti.ktfmt.gradle.TrailingCommaManagementStrategy
 import dev.detekt.gradle.Detekt
 import dev.detekt.gradle.DetektCreateBaselineTask
 import dev.detekt.gradle.extensions.DetektExtension
@@ -27,7 +25,6 @@ public open class KmpPlugin : Plugin<Project> {
 
     target.configureCommonKotlin()
     target.configureCoroutines()
-    target.configureKtfmt()
     target.configureTests()
     target.configureDetekt()
 
@@ -345,18 +342,6 @@ public open class KmpPlugin : Plugin<Project> {
       kmpExtension.sourceSets.getByName("commonMain").dependencies {
         implementation(libs.findLibrary("molecule.runtime").get().get().toString())
       }
-    }
-
-    fun Project.configureKtfmt() {
-      plugins.apply(Plugins.KTFMT)
-
-      extensions.getByType(KtfmtExtension::class.java).apply {
-        googleStyle()
-        trailingCommaManagementStrategy.set(TrailingCommaManagementStrategy.COMPLETE)
-        removeUnusedImports.set(true)
-      }
-
-      releaseTask.configure { releaseTask -> releaseTask.dependsOn("ktfmtCheck") }
     }
 
     private fun Project.configureDetekt() {

--- a/buildSrc/src/main/kotlin/software/amazon/app/platform/gradle/buildsrc/Plugins.kt
+++ b/buildSrc/src/main/kotlin/software/amazon/app/platform/gradle/buildsrc/Plugins.kt
@@ -12,7 +12,6 @@ internal object Plugins {
   const val KOTLIN_HIERARCHY = "io.github.terrakok.kmp-hierarchy"
   const val KOTLIN_JVM = "org.jetbrains.kotlin.jvm"
   const val KSP = "com.google.devtools.ksp"
-  const val KTFMT = "com.ncorti.ktfmt.gradle"
   const val MAVEN_PUBLISH = "com.vanniktech.maven.publish"
   const val METRO = "dev.zacsweers.metro"
 }

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -2,18 +2,11 @@
 plugins {
     id 'java-gradle-plugin'
     alias libs.plugins.kotlin.jvm
-    alias libs.plugins.ktfmt
     alias libs.plugins.build.config
     alias libs.plugins.maven.publish
     alias libs.plugins.detekt
     alias libs.plugins.kotlinx.binaryCompatibilityValidator
     alias libs.plugins.android.lint
-}
-
-ktfmt {
-    googleStyle()
-    trailingCommaManagementStrategy.set(com.ncorti.ktfmt.gradle.TrailingCommaManagementStrategy.COMPLETE)
-    removeUnusedImports.set(true)
 }
 
 mavenPublishing {
@@ -109,5 +102,5 @@ detekt {
 }
 
 tasks.register('release') {
-    dependsOn('build', 'check', 'ktfmtCheck', 'detekt', 'apiCheck')
+    dependsOn('build', 'check', 'detekt', 'apiCheck')
 }

--- a/gradle-plugin/src/test/kotlin/software/amazon/app/platform/gradle/ModuleStructureDependencyCheckTaskTest.kt
+++ b/gradle-plugin/src/test/kotlin/software/amazon/app/platform/gradle/ModuleStructureDependencyCheckTaskTest.kt
@@ -11,11 +11,11 @@ class ModuleStructureDependencyCheckTaskTest {
   @Test
   fun `impl dependency within the same library is forbidden by default`() {
     assertFailure {
-        checkDependencies(
-          modulePath = ":library:impl-specific",
-          moduleCompileClasspath = setOf(":library:impl-common"),
-        )
-      }
+      checkDependencies(
+        modulePath = ":library:impl-specific",
+        moduleCompileClasspath = setOf(":library:impl-common"),
+      )
+    }
       .isInstanceOf<GradleException>()
   }
 
@@ -31,36 +31,36 @@ class ModuleStructureDependencyCheckTaskTest {
   @Test
   fun `impl dependency from another library remains forbidden`() {
     assertFailure {
-        checkDependencies(
-          modulePath = ":library:impl-specific",
-          moduleCompileClasspath = setOf(":other-library:impl-common"),
-          allowLibraryImplToImplDependencies = true,
-        )
-      }
+      checkDependencies(
+        modulePath = ":library:impl-specific",
+        moduleCompileClasspath = setOf(":other-library:impl-common"),
+        allowLibraryImplToImplDependencies = true,
+      )
+    }
       .isInstanceOf<GradleException>()
   }
 
   @Test
   fun `external impl dependency remains forbidden`() {
     assertFailure {
-        checkDependencies(
-          modulePath = ":library:impl-specific",
-          moduleCompileClasspath = setOf("com.example:library-impl-common:1.0"),
-          allowLibraryImplToImplDependencies = true,
-        )
-      }
+      checkDependencies(
+        modulePath = ":library:impl-specific",
+        moduleCompileClasspath = setOf("com.example:library-impl-common:1.0"),
+        allowLibraryImplToImplDependencies = true,
+      )
+    }
       .isInstanceOf<GradleException>()
   }
 
   @Test
   fun `non-impl module cannot use the option to import an impl module`() {
     assertFailure {
-        checkDependencies(
-          modulePath = ":library:internal",
-          moduleCompileClasspath = setOf(":library:impl-common"),
-          allowLibraryImplToImplDependencies = true,
-        )
-      }
+      checkDependencies(
+        modulePath = ":library:internal",
+        moduleCompileClasspath = setOf(":library:impl-common"),
+        allowLibraryImplToImplDependencies = true,
+      )
+    }
       .isInstanceOf<GradleException>()
   }
 
@@ -75,11 +75,11 @@ class ModuleStructureDependencyCheckTaskTest {
   @Test
   fun `internal dependency from another library remains forbidden`() {
     assertFailure {
-        checkDependencies(
-          modulePath = ":library:impl",
-          moduleCompileClasspath = setOf(":other-library:internal"),
-        )
-      }
+      checkDependencies(
+        modulePath = ":library:impl",
+        moduleCompileClasspath = setOf(":other-library:internal"),
+      )
+    }
       .isInstanceOf<GradleException>()
   }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,7 +47,7 @@ kotlin-inject = "0.9.0"
 kotlin-inject-anvil = "0.1.7"
 kotlin-poet = "2.3.0"
 kotlinx-binaryCompatibilityValidator = "0.18.1"
-ktfmt-gradle = "0.26.0"
+ktfmt = "0.64"
 ksp = "2.3.9"
 maven-publish = "0.37.0"
 metro = "1.3.0"
@@ -120,7 +120,6 @@ kotlin-test-junit5 = { module = "org.jetbrains.kotlin:kotlin-test-junit5", versi
 kotlinx-binaryCompatibilityValidator = { module = "org.jetbrains.kotlinx:binary-compatibility-validator", version.ref = "kotlinx-binaryCompatibilityValidator" }
 kotlin-poet = { module = "com.squareup:kotlinpoet", version.ref = "kotlin-poet" }
 kotlin-poet-ksp = { module = "com.squareup:kotlinpoet-ksp", version.ref = "kotlin-poet" }
-ktfmt-gradle-plugin = { module = "com.ncorti.ktfmt.gradle:plugin", version.ref = "ktfmt-gradle" }
 ksp = { module = "com.google.devtools.ksp:symbol-processing", version.ref = "ksp" }
 ksp-api = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
 ksp-embeddable = { module = "com.google.devtools.ksp:symbol-processing-aa-embeddable", version.ref = "ksp" }
@@ -151,7 +150,6 @@ detekt = { id = "dev.detekt", version.ref = "detekt" }
 kotlin-hierarchy = { id = "io.github.terrakok.kmp-hierarchy", version.ref = "kotlin-hierarchy" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlinx-binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "kotlinx-binaryCompatibilityValidator" }
-ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt-gradle" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }
 metro = { id = "dev.zacsweers.metro", version.ref = "metro" }

--- a/ktfmt.sh
+++ b/ktfmt.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ROOT_DIR"
+
+KTFMT_VERSION="$(sed -n 's/^ktfmt = "\(.*\)"$/\1/p' gradle/libs.versions.toml)"
+if [[ -z "$KTFMT_VERSION" ]]; then
+  echo "Could not find ktfmt version in gradle/libs.versions.toml" >&2
+  exit 1
+fi
+
+if [[ -z "${KTFMT_JAR:-}" ]]; then
+  KTFMT_CACHE_DIR="${KTFMT_CACHE_DIR:-${RUNNER_TEMP:-$ROOT_DIR/.gradle/ktfmt}}"
+  mkdir -p "$KTFMT_CACHE_DIR"
+  KTFMT_JAR="$KTFMT_CACHE_DIR/ktfmt-${KTFMT_VERSION}-with-dependencies.jar"
+
+  if [[ ! -f "$KTFMT_JAR" ]]; then
+    curl -fsSL \
+      "https://github.com/facebook/ktfmt/releases/download/v${KTFMT_VERSION}/ktfmt-${KTFMT_VERSION}-with-dependencies.jar" \
+      -o "$KTFMT_JAR"
+  fi
+fi
+
+files=()
+while IFS= read -r file; do
+  files+=("$file")
+done < <(
+  git ls-files -- \
+    "*.kt" \
+    ":!metro-extensions/contribute/impl-compiler-plugin/src/test/resources/**"
+)
+
+if [[ ${#files[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+exec java -jar "$KTFMT_JAR" --google-style "$@" "${files[@]}"

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/fir/TypeResolution.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/fir/TypeResolution.kt
@@ -118,23 +118,22 @@ private fun resolveUserType(
   val file = findContainingFile(owner, session) ?: return typeRef.coneTypeOrNull ?: manualType
   val scopes = createImportingScopes(file, session, ScopeSession())
   val configuration = TypeResolutionConfiguration(scopes, emptyList(), useSiteFile = file)
-  val resolvedType =
-    runCatching {
-        session.typeResolver
-          .resolveType(
-            typeRef = typeRef,
-            configuration = configuration,
-            areBareTypesAllowed = true,
-            isOperandOfIsOperator = false,
-            resolveDeprecations = false,
-            supertypeSupplier = SupertypeSupplier.Default,
-            expandTypeAliases = false,
-          )
-          .type
-      }
-      .getOrElse {
-        return manualType ?: throw it
-      }
+  val resolvedType = runCatching {
+    session.typeResolver
+      .resolveType(
+        typeRef = typeRef,
+        configuration = configuration,
+        areBareTypesAllowed = true,
+        isOperandOfIsOperator = false,
+        resolveDeprecations = false,
+        supertypeSupplier = SupertypeSupplier.Default,
+        expandTypeAliases = false,
+      )
+      .type
+  }
+    .getOrElse {
+      return manualType ?: throw it
+    }
 
   if (resolvedType.classId?.shortClassName?.asString() != "<error>") {
     return resolvedType

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/renderer/ContributesRendererFir.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/renderer/ContributesRendererFir.kt
@@ -317,41 +317,41 @@ public class ContributesRendererFir(session: FirSession) :
     var returnTarget: FirFunctionTarget? = null
 
     return buildNamedFunction {
-        isLocal = false
-        resolvePhase = FirResolvePhase.BODY_RESOLVE
-        moduleData = session.moduleData
-        origin = Keys.ContributesRendererGeneratorKey.origin
-        source = owner.source
-        symbol = functionSymbol
-        name = callableId.callableName
-        returnTypeRef = owner.defaultType().toFirResolvedTypeRef()
-        dispatchReceiverType = generatedGraphType(graphClassId)
-        status =
-          FirResolvedDeclarationStatusImpl(
-            Visibilities.Public,
-            Modality.OPEN,
-            Visibilities.Public.toEffectiveVisibility(owner, forClass = true),
+      isLocal = false
+      resolvePhase = FirResolvePhase.BODY_RESOLVE
+      moduleData = session.moduleData
+      origin = Keys.ContributesRendererGeneratorKey.origin
+      source = owner.source
+      symbol = functionSymbol
+      name = callableId.callableName
+      returnTypeRef = owner.defaultType().toFirResolvedTypeRef()
+      dispatchReceiverType = generatedGraphType(graphClassId)
+      status =
+        FirResolvedDeclarationStatusImpl(
+          Visibilities.Public,
+          Modality.OPEN,
+          Visibilities.Public.toEffectiveVisibility(owner, forClass = true),
+        )
+      annotations += buildSimpleAnnotationCall(ClassIds.PROVIDES, functionSymbol, session)
+      valueParameters += generatedParameters
+      if (constructor != null) {
+        body =
+          buildSingleExpressionBlock(
+            buildReturnExpression {
+              val target = FirFunctionTarget(labelName = null, isLambda = false)
+              returnTarget = target
+              this.target = target
+              result =
+                buildConstructorCall(
+                  owner,
+                  constructor.symbol,
+                  constructor.parameters,
+                  generatedParameters,
+                )
+            }
           )
-        annotations += buildSimpleAnnotationCall(ClassIds.PROVIDES, functionSymbol, session)
-        valueParameters += generatedParameters
-        if (constructor != null) {
-          body =
-            buildSingleExpressionBlock(
-              buildReturnExpression {
-                val target = FirFunctionTarget(labelName = null, isLambda = false)
-                returnTarget = target
-                this.target = target
-                result =
-                  buildConstructorCall(
-                    owner,
-                    constructor.symbol,
-                    constructor.parameters,
-                    generatedParameters,
-                  )
-              }
-            )
-        }
       }
+    }
       .also { function -> returnTarget?.bind(function) }
   }
 

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/robot/ContributesRobotFir.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/robot/ContributesRobotFir.kt
@@ -281,41 +281,41 @@ public class ContributesRobotFir(session: FirSession) :
     var returnTarget: FirFunctionTarget? = null
 
     return buildNamedFunction {
-        isLocal = false
-        resolvePhase = FirResolvePhase.BODY_RESOLVE
-        moduleData = session.moduleData
-        origin = Keys.ContributesRobotGeneratorKey.origin
-        source = owner.source
-        symbol = functionSymbol
-        name = callableId.callableName
-        returnTypeRef = owner.defaultType().toFirResolvedTypeRef()
-        dispatchReceiverType = generatedGraphType(graphClassId)
-        status =
-          FirResolvedDeclarationStatusImpl(
-            Visibilities.Public,
-            Modality.OPEN,
-            Visibilities.Public.toEffectiveVisibility(owner, forClass = true),
+      isLocal = false
+      resolvePhase = FirResolvePhase.BODY_RESOLVE
+      moduleData = session.moduleData
+      origin = Keys.ContributesRobotGeneratorKey.origin
+      source = owner.source
+      symbol = functionSymbol
+      name = callableId.callableName
+      returnTypeRef = owner.defaultType().toFirResolvedTypeRef()
+      dispatchReceiverType = generatedGraphType(graphClassId)
+      status =
+        FirResolvedDeclarationStatusImpl(
+          Visibilities.Public,
+          Modality.OPEN,
+          Visibilities.Public.toEffectiveVisibility(owner, forClass = true),
+        )
+      annotations += buildSimpleAnnotationCall(ClassIds.PROVIDES, functionSymbol, session)
+      valueParameters += generatedParameters
+      if (constructor != null) {
+        body =
+          buildSingleExpressionBlock(
+            buildReturnExpression {
+              val target = FirFunctionTarget(labelName = null, isLambda = false)
+              returnTarget = target
+              this.target = target
+              result =
+                buildConstructorCall(
+                  owner,
+                  constructor.symbol,
+                  constructor.parameters,
+                  generatedParameters,
+                )
+            }
           )
-        annotations += buildSimpleAnnotationCall(ClassIds.PROVIDES, functionSymbol, session)
-        valueParameters += generatedParameters
-        if (constructor != null) {
-          body =
-            buildSingleExpressionBlock(
-              buildReturnExpression {
-                val target = FirFunctionTarget(labelName = null, isLambda = false)
-                returnTarget = target
-                this.target = target
-                result =
-                  buildConstructorCall(
-                    owner,
-                    constructor.symbol,
-                    constructor.parameters,
-                    generatedParameters,
-                  )
-              }
-            )
-        }
       }
+    }
       .also { function -> returnTarget?.bind(function) }
   }
 

--- a/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/scoped/ContributesScopedFir.kt
+++ b/metro-extensions/contribute/impl-compiler-plugin/src/main/kotlin/software/amazon/app/platform/metro/compiler/scoped/ContributesScopedFir.kt
@@ -319,51 +319,51 @@ public class ContributesScopedFir(session: FirSession) :
     var returnTarget: FirFunctionTarget? = null
 
     return buildNamedFunction {
-        isLocal = false
-        resolvePhase = FirResolvePhase.BODY_RESOLVE
-        moduleData = session.moduleData
-        origin = Keys.ContributesScopedGeneratorKey.origin
-        source = owner.source
-        symbol = functionSymbol
-        name = callableId.callableName
-        returnTypeRef = owner.defaultType().toFirResolvedTypeRef()
-        dispatchReceiverType = contributionType(contributionClassId)
-        status =
-          FirResolvedDeclarationStatusImpl(
-            Visibilities.Public,
-            Modality.OPEN,
-            Visibilities.Public.toEffectiveVisibility(owner, forClass = true),
+      isLocal = false
+      resolvePhase = FirResolvePhase.BODY_RESOLVE
+      moduleData = session.moduleData
+      origin = Keys.ContributesScopedGeneratorKey.origin
+      source = owner.source
+      symbol = functionSymbol
+      name = callableId.callableName
+      returnTypeRef = owner.defaultType().toFirResolvedTypeRef()
+      dispatchReceiverType = contributionType(contributionClassId)
+      status =
+        FirResolvedDeclarationStatusImpl(
+          Visibilities.Public,
+          Modality.OPEN,
+          Visibilities.Public.toEffectiveVisibility(owner, forClass = true),
+        )
+      annotations += buildSimpleAnnotationCall(ClassIds.PROVIDES, functionSymbol, session)
+      extractScopeClassId(owner, ClassIds.SINGLE_IN, session)?.let { scopeClassId ->
+        annotations +=
+          buildAnnotationCallWithArgument(
+            ClassIds.SINGLE_IN,
+            Name.identifier("scope"),
+            buildClassExpression(scopeClassId, session),
+            functionSymbol,
+            session,
           )
-        annotations += buildSimpleAnnotationCall(ClassIds.PROVIDES, functionSymbol, session)
-        extractScopeClassId(owner, ClassIds.SINGLE_IN, session)?.let { scopeClassId ->
-          annotations +=
-            buildAnnotationCallWithArgument(
-              ClassIds.SINGLE_IN,
-              Name.identifier("scope"),
-              buildClassExpression(scopeClassId, session),
-              functionSymbol,
-              session,
-            )
-        }
-        valueParameters += generatedParameters
-        if (constructor != null) {
-          body =
-            buildSingleExpressionBlock(
-              buildReturnExpression {
-                val target = FirFunctionTarget(labelName = null, isLambda = false)
-                returnTarget = target
-                this.target = target
-                result =
-                  buildConstructorCall(
-                    owner,
-                    constructor.symbol,
-                    constructor.parameters,
-                    generatedParameters,
-                  )
-              }
-            )
-        }
       }
+      valueParameters += generatedParameters
+      if (constructor != null) {
+        body =
+          buildSingleExpressionBlock(
+            buildReturnExpression {
+              val target = FirFunctionTarget(labelName = null, isLambda = false)
+              returnTarget = target
+              this.target = target
+              result =
+                buildConstructorCall(
+                  owner,
+                  constructor.symbol,
+                  constructor.parameters,
+                  generatedParameters,
+                )
+            }
+          )
+      }
+    }
       .also { function -> returnTarget?.bind(function) }
   }
 

--- a/robot/public/src/androidUnitTest/kotlin/software/amazon/app/platform/robot/WaiterTest.kt
+++ b/robot/public/src/androidUnitTest/kotlin/software/amazon/app/platform/robot/WaiterTest.kt
@@ -77,14 +77,14 @@ class WaiterTest {
   @Test
   fun `waitUntilCatching throws an error when condition is never met`() {
     assertFailure {
-        waitUntilCatching(
-          condition = "Wait for test condition",
-          timeout = 200.milliseconds,
-          delay = 20.milliseconds,
-        ) {
-          error("Test exception")
-        }
+      waitUntilCatching(
+        condition = "Wait for test condition",
+        timeout = 200.milliseconds,
+        delay = 20.milliseconds,
+      ) {
+        error("Test exception")
       }
+    }
       .all {
         messageContains("Waiting until 'Wait for test condition' never succeeded.")
         cause().isNotNull().messageContains("Test exception")


### PR DESCRIPTION
Decoupling formatting from the Gradle plugin keeps CI on the current `ktfmt` release instead of relying on lagging generated Gradle tasks. The new root `ktfmt.sh` runner centralizes the pinned formatter invocation, removes plugin wiring from convention builds, and skips compiler-plugin fixtures whose diagnostic marker syntax is not parseable Kotlin source.