### PR TITLE
Align build JDK with JDK 25

### DIFF
--- a/.github/actions/setup-action/action.yml
+++ b/.github/actions/setup-action/action.yml
@@ -16,7 +16,7 @@ runs:
     - uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
-        java-version: 21
+        java-version: 25
 
     - name: Select Xcode 26
       if: ${{ runner.os == 'macOS' && inputs['select-xcode-26'] == 'true' }}

--- a/buildSrc/src/main/kotlin/software/amazon/app/platform/gradle/buildsrc/KmpPlugin.kt
+++ b/buildSrc/src/main/kotlin/software/amazon/app/platform/gradle/buildsrc/KmpPlugin.kt
@@ -3,11 +3,11 @@ package software.amazon.app.platform.gradle.buildsrc
 import com.google.devtools.ksp.gradle.KspExtension
 import com.ncorti.ktfmt.gradle.KtfmtExtension
 import com.ncorti.ktfmt.gradle.TrailingCommaManagementStrategy
+import dev.detekt.gradle.Detekt
+import dev.detekt.gradle.DetektCreateBaselineTask
+import dev.detekt.gradle.extensions.DetektExtension
 import guru.nidi.graphviz.engine.Format
 import io.github.terrakok.KmpHierarchyConfig
-import io.gitlab.arturbosch.detekt.Detekt
-import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
-import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.dsl.DependencyHandler
@@ -378,14 +378,14 @@ public open class KmpPlugin : Plugin<Project> {
 
       // Make Detekt use the right version of Java
       tasks.withType(Detekt::class.java).configureEach { detekt ->
-        detekt.jvmTarget = javaVersion.toString()
+        detekt.jvmTarget.set(javaVersion.toString())
 
         if (detekt.name == "detekt") {
           detekt.configureDefaultDetektTask()
         }
       }
       tasks.withType(DetektCreateBaselineTask::class.java).configureEach {
-        it.jvmTarget = javaVersion.toString()
+        it.jvmTarget.set(javaVersion.toString())
 
         if (it.name == "detektBaseline") {
           it.configureDefaultDetektTask()
@@ -394,10 +394,10 @@ public open class KmpPlugin : Plugin<Project> {
       with(extensions.getByType(DetektExtension::class.java)) {
         // From the Groovy DSL at https://detekt.github.io/detekt/gradle.html#groovy-dsl-3
         // This produces baselines named "detekt-baseline.xml"
-        baseline = file("detekt/detekt-baseline.xml")
+        baseline.set(file("detekt/detekt-baseline.xml"))
         // Config overrides
         config.from(rootProject.file("gradle/detekt-config.yml"))
-        buildUponDefaultConfig = true
+        buildUponDefaultConfig.set(true)
       }
 
       releaseTask.configure { releaseTask -> releaseTask.dependsOn("detekt") }

--- a/buildSrc/src/main/kotlin/software/amazon/app/platform/gradle/buildsrc/Plugins.kt
+++ b/buildSrc/src/main/kotlin/software/amazon/app/platform/gradle/buildsrc/Plugins.kt
@@ -7,7 +7,7 @@ internal object Plugins {
   const val BINARY_COMPAT_VALIDATOR = "org.jetbrains.kotlinx.binary-compatibility-validator"
   const val COMPOSE_COMPILER = "org.jetbrains.kotlin.plugin.compose"
   const val COMPOSE_MULTIPLATFORM = "org.jetbrains.compose"
-  const val DETEKT = "io.gitlab.arturbosch.detekt"
+  const val DETEKT = "dev.detekt"
   const val KOTLIN_MULTIPLATFORM = "org.jetbrains.kotlin.multiplatform"
   const val KOTLIN_HIERARCHY = "io.github.terrakok.kmp-hierarchy"
   const val KOTLIN_JVM = "org.jetbrains.kotlin.jvm"

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -92,20 +92,20 @@ tasks.withType(ValidatePlugins).configureEach {
     it.enableStricterValidation = true
 }
 
-tasks.withType(io.gitlab.arturbosch.detekt.Detekt).configureEach {
-    it.jvmTarget = libs.versions.jvm.compatibility.get()
+tasks.withType(dev.detekt.gradle.Detekt).configureEach {
+    it.jvmTarget.set(libs.versions.jvm.compatibility.get())
     it.setSource(layout.files("src"))
 }
 
 //noinspection UnnecessaryQualifiedReference
-tasks.withType(io.gitlab.arturbosch.detekt.DetektCreateBaselineTask).configureEach {
-    it.jvmTarget = libs.versions.jvm.compatibility.get()
+tasks.withType(dev.detekt.gradle.DetektCreateBaselineTask).configureEach {
+    it.jvmTarget.set(libs.versions.jvm.compatibility.get())
     it.setSource(layout.files("src"))
 }
 
 detekt {
     config.from(file('../gradle/detekt-config.yml'))
-    buildUponDefaultConfig = true
+    buildUponDefaultConfig.set(true)
 }
 
 tasks.register('release') {

--- a/gradle/detekt-config.yml
+++ b/gradle/detekt-config.yml
@@ -1,6 +1,6 @@
 # Detekt configuration tweaks. These are documented at
-#   https://detekt.github.io/detekt/configurations.html
-#   https://detekt.github.io/detekt/comments.html
+#   https://detekt.dev/docs/rules/configurations/
+#   https://detekt.dev/docs/rules/comments/
 # Also helpful are the Detekt default settings at
 #   https://github.com/detekt/detekt/blob/main/detekt-core/src/main/resources/default-detekt-config.yml
 style:
@@ -12,7 +12,13 @@ style:
     # The next two parameters are recommended for Compose: https://detekt.dev/docs/introduction/compose/
     ignorePropertyDeclaration: true
     ignoreCompanionObjectPropertyDeclaration: true
-  UnusedPrivateMember:
+  UnusedPrivateClass:
+    # Recommended for Compose: https://detekt.dev/docs/introduction/compose/
+    ignoreAnnotated: ['Preview']
+  UnusedPrivateFunction:
+    # Recommended for Compose: https://detekt.dev/docs/introduction/compose/
+    ignoreAnnotated: ['Preview']
+  UnusedPrivateProperty:
     # Recommended for Compose: https://detekt.dev/docs/introduction/compose/
     ignoreAnnotated: ['Preview']
   MaxLineLength:
@@ -43,12 +49,12 @@ comments:
     ]
 complexity:
   LongParameterList:
-    constructorThreshold: 12
-    ignoreAnnotated: [
-      ‘Inject’,
+    allowedConstructorParameters: 12
+    ignoreAnnotatedParameter: [
+      'Inject',
     ]
     # The next two parameters are recommended for Compose: https://detekt.dev/docs/introduction/compose/
-    functionThreshold: 12
+    allowedFunctionParameters: 12
     ignoreDefaultParameters: true
   TooManyFunctions:
     excludes: [

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ build-config = "6.0.9"
 # https://github.com/JetBrains/compose-multiplatform/releases
 compose-multiplatform = "1.11.0"
 coroutines = "1.11.0"
-detekt = "1.23.8"
+detekt = "2.0.0-alpha.5"
 graphviz-java = "0.18.1"
 jvm-compatibility = "11"
 # BuildSrc runs on the same JDK as CI. Metro requires at least JDK 21, and CI now uses JDK 25, so compile buildSrc
@@ -92,7 +92,7 @@ compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", ve
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "coroutines" }
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
-detekt-gradle-plugin = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
+detekt-gradle-plugin = { module = "dev.detekt:detekt-gradle-plugin", version.ref = "detekt" }
 graphviz-java = { module = "guru.nidi:graphviz-java", version.ref = "graphviz-java" }
 kotlin-atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "kotlin-atomicfu" }
 kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }
@@ -147,7 +147,7 @@ android-library = { id = "com.android.library", version.ref = "agp" }
 android-lint = { id = "com.android.lint", version.ref = "agp" }
 app-platform = { id = "software.amazon.app.platform" }
 build-config = { id = "com.github.gmazzo.buildconfig", version.ref = "build-config" }
-detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+detekt = { id = "dev.detekt", version.ref = "detekt" }
 kotlin-hierarchy = { id = "io.github.terrakok.kmp-hierarchy", version.ref = "kotlin-hierarchy" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlinx-binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "kotlinx-binaryCompatibilityValidator" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,9 +36,9 @@ coroutines = "1.11.0"
 detekt = "1.23.8"
 graphviz-java = "0.18.1"
 jvm-compatibility = "11"
-# We need a newer version for buildSrc. This project uses JDK 21, Metro requires JDK 21, and therefore we should
-# compile buildSrc with 21.
-jvm-buildsrc = "21"
+# BuildSrc runs on the same JDK as CI. Metro requires at least JDK 21, and CI now uses JDK 25, so compile buildSrc
+# with 25.
+jvm-buildsrc = "25"
 kotlin = "2.4.0"
 kotlin-atomicfu = "0.32.1"
 kotlin-compile-testing = "0.13.0"


### PR DESCRIPTION
Move CI's shared Java setup and the `buildSrc` JVM target to JDK 25 so local and CI builds exercise the same toolchain while published modules keep their existing `jvm-compatibility` target.