### PR TITLE
Update repository and publish workflow configuration

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -70,7 +70,7 @@ jobs:
 
   deploy-mkdocs:
     needs: build-mkdocs
-    if: github.repository == 'amzn/app-platform'
+    if: github.repository == 'vRallev/app-platform'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -20,7 +20,7 @@ jobs:
     permissions:
       contents: write
 
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     if: github.repository == 'vRallev/app-platform'
     timeout-minutes: 60
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,7 +21,7 @@ jobs:
       contents: write
 
     runs-on: macos-latest
-    if: github.repository == 'amzn/app-platform'
+    if: github.repository == 'vRallev/app-platform'
     timeout-minutes: 60
 
     steps:

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   publish-snapshot:
     runs-on: macos-latest
-    if: github.repository == 'amzn/app-platform'
+    if: github.repository == 'vRallev/app-platform'
     timeout-minutes: 60
 
     steps:

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   publish-snapshot:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     if: github.repository == 'vRallev/app-platform'
     timeout-minutes: 60
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,7 @@
 
 ### Added
 
-- Convert the sample app to [Metro](https://zacsweers.github.io/metro/), see #173. With the recent Kotlin and Metro version updates, issues we saw with Metro and targets other than Android/JVM are solved, and Metro is now the [recommended default](https://amzn.github.io/app-platform/di/) for dependency injection.
+- Convert the sample app to [Metro](https://zacsweers.github.io/metro/), see #173. With the recent Kotlin and Metro version updates, issues we saw with Metro and targets other than Android/JVM are solved, and Metro is now the [recommended default](https://vrallev.github.io/app-platform/di/) for dependency injection.
 
 ### Changed
 
@@ -135,7 +135,7 @@
 
 ### Added
 
-- Added support for [Metro](https://zacsweers.github.io/metro/) as dependency injection framework. User can choose between [`kotlin-inject-anvil`](https://github.com/amzn/kotlin-inject-anvil) and [Metro](https://zacsweers.github.io/metro/). For more details see the [documentation](https://amzn.github.io/app-platform/di/) for how to setup and use both dependency injection frameworks with App Platform.
+- Added support for [Metro](https://zacsweers.github.io/metro/) as dependency injection framework. User can choose between [`kotlin-inject-anvil`](https://github.com/amzn/kotlin-inject-anvil) and [Metro](https://zacsweers.github.io/metro/). For more details see the [documentation](https://vrallev.github.io/app-platform/di/) for how to setup and use both dependency injection frameworks with App Platform.
 
 ### Changed
 
@@ -158,7 +158,7 @@
 ### Added
 
 - Added support for the new [Android-KMP library plugin](https://developer.android.com/kotlin/multiplatform/plugin) in App Platform's Gradle plugin.
-- Added a [recipe](https://amzn.github.io/app-platform/presenter/#navigation-3) for how to use the Navigation 3 library with App Platform.
+- Added a [recipe](https://vrallev.github.io/app-platform/presenter/#navigation-3) for how to use the Navigation 3 library with App Platform.
 
 ### Changed
 
@@ -170,9 +170,9 @@
 ### Added
 
 - Added a search field to the wiki.
-- Added a [blueprint project](https://github.com/amzn/app-platform/tree/main/blueprints/starter) for App Platform that can be copied to spin up new projects faster, see #63.
-- Added support for back press events in `Presenters`. The API is similar to the one from Compose Multiplatform and Android Compose. See the [documentation in the wiki](https://amzn.github.io/app-platform/presenter/#back-gestures) for more details.
-- Added a [recipes application](https://amzn.github.io/app-platform/#web-recipe-app) showing solutions to common problems. All solutions have been [documented in the wiki](https://amzn.github.io/app-platform/presenter/#recipes).
+- Added a [blueprint project](https://github.com/vRallev/app-platform/tree/main/blueprints/starter) for App Platform that can be copied to spin up new projects faster, see #63.
+- Added support for back press events in `Presenters`. The API is similar to the one from Compose Multiplatform and Android Compose. See the [documentation in the wiki](https://vrallev.github.io/app-platform/presenter/#back-gestures) for more details.
+- Added a [recipes application](https://vrallev.github.io/app-platform/#web-recipe-app) showing solutions to common problems. All solutions have been [documented in the wiki](https://vrallev.github.io/app-platform/presenter/#recipes).
 
 ### Changed
 
@@ -219,19 +219,19 @@
 
 - Initial release.
 
-[Unreleased]: https://github.com/amzn/app-platform/compare/0.0.15...HEAD
-[0.0.15]: https://github.com/amzn/app-platform/compare/0.0.15
-[0.0.14]: https://github.com/amzn/app-platform/compare/0.0.14
-[0.0.13]: https://github.com/amzn/app-platform/compare/0.0.13
-[0.0.12]: https://github.com/amzn/app-platform/compare/0.0.12
-[0.0.11]: https://github.com/amzn/app-platform/compare/0.0.11
-[0.0.10]: https://github.com/amzn/app-platform/compare/0.0.10
-[0.0.9]: https://github.com/amzn/app-platform/compare/0.0.9
-[0.0.8]: https://github.com/amzn/app-platform/compare/0.0.8
-[0.0.7]: https://github.com/amzn/app-platform/compare/0.0.7
-[0.0.6]: https://github.com/amzn/app-platform/compare/0.0.6
-[0.0.5]: https://github.com/amzn/app-platform/compare/0.0.5
-[0.0.4]: https://github.com/amzn/app-platform/compare/0.0.4
-[0.0.3]: https://github.com/amzn/app-platform/compare/0.0.3
-[0.0.2]: https://github.com/amzn/app-platform/compare/0.0.2
-[0.0.1]: https://github.com/amzn/app-platform/compare/0.0.1
+[Unreleased]: https://github.com/vRallev/app-platform/compare/0.0.15...HEAD
+[0.0.15]: https://github.com/vRallev/app-platform/compare/0.0.15
+[0.0.14]: https://github.com/vRallev/app-platform/compare/0.0.14
+[0.0.13]: https://github.com/vRallev/app-platform/compare/0.0.13
+[0.0.12]: https://github.com/vRallev/app-platform/compare/0.0.12
+[0.0.11]: https://github.com/vRallev/app-platform/compare/0.0.11
+[0.0.10]: https://github.com/vRallev/app-platform/compare/0.0.10
+[0.0.9]: https://github.com/vRallev/app-platform/compare/0.0.9
+[0.0.8]: https://github.com/vRallev/app-platform/compare/0.0.8
+[0.0.7]: https://github.com/vRallev/app-platform/compare/0.0.7
+[0.0.6]: https://github.com/vRallev/app-platform/compare/0.0.6
+[0.0.5]: https://github.com/vRallev/app-platform/compare/0.0.5
+[0.0.4]: https://github.com/vRallev/app-platform/compare/0.0.4
+[0.0.3]: https://github.com/vRallev/app-platform/compare/0.0.3
+[0.0.2]: https://github.com/vRallev/app-platform/compare/0.0.2
+[0.0.1]: https://github.com/vRallev/app-platform/compare/0.0.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,4 +56,4 @@ If you discover a potential security issue in this project we ask that you notif
 
 ## Licensing
 
-See the [LICENSE](https://github.com/amzn/app-platform/blob/main/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+See the [LICENSE](https://github.com/vRallev/app-platform/blob/main/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # App Platform
 
 [![Maven Central](https://img.shields.io/maven-central/v/software.amazon.app.platform/gradle-plugin.svg?label=Maven%20Central)](https://central.sonatype.com/search?smo=true&namespace=software.amazon.app.platform)
-[![CI](https://github.com/amzn/app-platform/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/amzn/app-platform/actions/workflows/ci.yml)
+[![CI](https://github.com/vRallev/app-platform/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/vRallev/app-platform/actions/workflows/ci.yml)
 
 <img src="docs/images/app-platform-logo.png" alt="App Platform" style="width:150px" align="left"/>
 
@@ -11,7 +11,7 @@ dependency inversion and dependency injection (DI) design patterns first class p
 features and support the variety of platforms. The UI layer is entirely decoupled from the business logic,
 which allows different application targets to change the look and feel.
 
-### [amzn.github.io/app-platform](https://amzn.github.io/app-platform/)
+### [vrallev.github.io/app-platform](https://vrallev.github.io/app-platform/)
 
 ## Security
 

--- a/blueprints/README.md
+++ b/blueprints/README.md
@@ -1,6 +1,6 @@
 # Blueprints
 
-This folder contains reusable templates ("blueprints") to help you quickly get started with projects using [App Platform](https://github.com/amzn/app-platform).
+This folder contains reusable templates ("blueprints") to help you quickly get started with projects using [App Platform](https://github.com/vRallev/app-platform).
 
 ## 📁 `starter/`
 

--- a/blueprints/starter/README.md
+++ b/blueprints/starter/README.md
@@ -1,13 +1,13 @@
 # Template App for Amazon App Platform
 
-This is a Kotlin Multiplatform template application built using the [Amazon App Platform](https://github.com/amzn/app-platform). It provides a modern, opinionated starting point for building scalable, testable, and multiplatform Compose applications.
+This is a Kotlin Multiplatform template application built using the [Amazon App Platform](https://github.com/vRallev/app-platform). It provides a modern, opinionated starting point for building scalable, testable, and multiplatform Compose applications.
 
 ## Overview
 
 This template demonstrates:
 
 - Kotlin Multiplatform targeting Android, iOS, WebAssembly (WASM), and Desktop (JVM)
-- [App Platform](https://github.com/amzn/app-platform) conventions for Metro DI, state, rendering, and navigation
+- [App Platform](https://github.com/vRallev/app-platform) conventions for Metro DI, state, rendering, and navigation
 - Molecule-powered presenters
 - Scoped dependency injection using Metro graphs, `@ContributesBinding`, `@SingleIn`, `@ContributesScoped`, and `@ContributesRenderer`
 - Reactive state with `StateFlow`
@@ -78,8 +78,8 @@ You can modify app behavior by editing:
 
 ## Contributing
 
-Feel free to fork and adapt this template for your own projects. If you find bugs or improvements related to App Platform usage, consider opening issues or PRs against [amzn/app-platform](https://github.com/amzn/app-platform).
+Feel free to fork and adapt this template for your own projects. If you find bugs or improvements related to App Platform usage, consider opening issues or PRs against [vRallev/app-platform](https://github.com/vRallev/app-platform).
 
 ## License
 
-This project inherits the license of the [Amazon App Platform](https://github.com/amzn/app-platform).
+This project inherits the license of the [Amazon App Platform](https://github.com/vRallev/app-platform).

--- a/blueprints/starter/navigation/impl/src/commonMain/kotlin/software/amazon/app/platform/template/navigation/NavigationDetailRenderer.kt
+++ b/blueprints/starter/navigation/impl/src/commonMain/kotlin/software/amazon/app/platform/template/navigation/NavigationDetailRenderer.kt
@@ -26,7 +26,7 @@ class NavigationDetailRenderer : ComposeRenderer<Model>() {
       horizontalAlignment = Alignment.CenterHorizontally,
     ) {
       Text(
-        text = "Hello, welcome to amzn/app-platform Template App",
+        text = "Hello, welcome to vRallev/app-platform Template App",
         style = MaterialTheme.typography.headlineMedium,
         textAlign = TextAlign.Center,
         modifier = Modifier.padding(16.dp),

--- a/docs/di.md
+++ b/docs/di.md
@@ -181,11 +181,11 @@ from the `Application` class and the Metro object graph is found through the `me
 
 ??? example "Sample"
 
-    The `ViewModel` example comes from the [sample app](https://github.com/amzn/app-platform/blob/main/sample/app/src/androidMain/kotlin/software/amazon/app/platform/sample/MainActivityViewModel.kt).
+    The `ViewModel` example comes from the [sample app](https://github.com/vRallev/app-platform/blob/main/sample/app/src/androidMain/kotlin/software/amazon/app/platform/sample/MainActivityViewModel.kt).
     `ViewModels` can use constructor injection, but this requires more setup. This approach of using a graph
     interface was simpler and faster.
 
-    Another example where this approach is handy is in [`NavigationPresenterImpl`](https://github.com/amzn/app-platform/blob/main/sample/navigation/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/navigation/NavigationPresenterImpl.kt).
+    Another example where this approach is handy is in [`NavigationPresenterImpl`](https://github.com/vRallev/app-platform/blob/main/sample/navigation/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/navigation/NavigationPresenterImpl.kt).
     This class waits for the user scope to be available and then optionally retrieves the `Presenter` that is part
     of the user graph. Constructor injection cannot be used, because `NavigationPresenterImpl` is part of the app
     scope and cannot inject dependencies from the user scope, which is a child scope of app scope. This would violate
@@ -232,7 +232,7 @@ class SampleClass(
 
     The `CoroutineScope` uses the IO dispatcher by default. The qualifier `@ForScope(AppScope::class)` is needed to
     allow other scopes to have their own `CoroutineScope`. For example, the sample app provides a `CoroutineScope`
-    [for the user scope](https://github.com/amzn/app-platform/blob/main/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserComponent.kt),
+    [for the user scope](https://github.com/vRallev/app-platform/blob/main/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserComponent.kt),
     which gets canceled when the user scope gets destroyed. The `CoroutineScope` for the user scope uses the qualifier
     `@ForScope(UserScope::class)
 
@@ -315,7 +315,7 @@ Metro and `kotlin-inject-anvil` are conceptually very similar. Since Metro is th
 default, migrating existing `kotlin-inject-anvil` code is usually mostly mechanical. Errors will be
 reported at compile time and not runtime.
 
-Steps could like this. [PR/173](https://github.com/amzn/app-platform/pull/173) highlights this migration for the
+Steps could like this. [PR/173](https://github.com/vRallev/app-platform/pull/173) highlights this migration for the
 `:sample` application.
 
 * It's strongly recommended to use the latest Kotlin and Metro version. Metro is a compiler plugin and tied to the compiler to a certain degree.
@@ -506,11 +506,11 @@ from the `Application` class and the `kotlin-inject-anvil` component is found th
 
 ??? example "Sample"
 
-    The `ViewModel` example comes from the [sample app](https://github.com/amzn/app-platform/blob/main/sample/app/src/androidMain/kotlin/software/amazon/app/platform/sample/MainActivityViewModel.kt).
+    The `ViewModel` example comes from the [sample app](https://github.com/vRallev/app-platform/blob/main/sample/app/src/androidMain/kotlin/software/amazon/app/platform/sample/MainActivityViewModel.kt).
     `ViewModels` can use constructor injection, but this requires more setup. This approach of using a component
     interface was simpler and faster.
 
-    Another example where this approach is handy is in [`NavigationPresenterImpl`](https://github.com/amzn/app-platform/blob/main/sample/navigation/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/navigation/NavigationPresenterImpl.kt).
+    Another example where this approach is handy is in [`NavigationPresenterImpl`](https://github.com/vRallev/app-platform/blob/main/sample/navigation/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/navigation/NavigationPresenterImpl.kt).
     This class waits for the user scope to be available and then optionally retrieves the `Presenter` that is part
     of the user component. Constructor injection cannot be used, because `NavigationPresenterImpl` is part of the app
     scope and cannot inject dependencies from the user scope, which is a child scope of app scope. This would violate
@@ -557,7 +557,7 @@ class SampleClass(
 
     The `CoroutineScope` uses the IO dispatcher by default. The qualifier `@ForScope(AppScope::class)` is needed to
     allow other scopes to have their own `CoroutineScope`. For example, the sample app provides a `CoroutineScope`
-    [for the user scope](https://github.com/amzn/app-platform/blob/main/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserComponent.kt),
+    [for the user scope](https://github.com/vRallev/app-platform/blob/main/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserComponent.kt),
     which gets canceled when the user scope gets destroyed. The `CoroutineScope` for the user scope uses the qualifier
     `@ForScope(UserScope::class)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -98,14 +98,14 @@ structure is enabled.
 
 ## Getting Started
 
-App Platform gives you a working Kotlin Multiplatform setup out of the box, with support for Android, iOS, Desktop, and Web (WASM). The fastest way to get started is by using the [blueprints/starter](https://github.com/amzn/app-platform/tree/main/blueprints/starter) project — a fully functional example app that already uses App Platform and applies everything the platform provides, including the module structure, dependency injection, scopes, presenters, and renderers.
+App Platform gives you a working Kotlin Multiplatform setup out of the box, with support for Android, iOS, Desktop, and Web (WASM). The fastest way to get started is by using the [blueprints/starter](https://github.com/vRallev/app-platform/tree/main/blueprints/starter) project — a fully functional example app that already uses App Platform and applies everything the platform provides, including the module structure, dependency injection, scopes, presenters, and renderers.
 
 ### Copy the Starter App
 
 To begin a new project:
 
 ```bash
-git clone https://github.com/amzn/app-platform.git
+git clone https://github.com/vRallev/app-platform.git
 cp -r app-platform/blueprints/starter my-kmp-app
 cd my-kmp-app
 ```
@@ -114,7 +114,7 @@ The starter blueprint comes preconfigured with App Platform and is ready to buil
 
 ### Build and Run
 
-The starter project includes a detailed [README](https://github.com/amzn/app-platform/blob/main/blueprints/starter/README.md) with instructions for building and running the app on each platform:
+The starter project includes a detailed [README](https://github.com/vRallev/app-platform/blob/main/blueprints/starter/README.md) with instructions for building and running the app on each platform:
 
 - Android
 - iOS

--- a/docs/module-structure.md
+++ b/docs/module-structure.md
@@ -23,7 +23,7 @@
 
 !!! example "Sample"
 
-    App Platform itself and the [sample app](https://github.com/amzn/app-platform/tree/main/sample) use the module
+    App Platform itself and the [sample app](https://github.com/vRallev/app-platform/tree/main/sample) use the module
     structure to separate APIs from implementations. The sample app highlights how we structure code and make use
     of the various module types.
 
@@ -351,9 +351,9 @@ With this setting enabled, several checks and features are enabled:
 
 * App Platform ensures that the Gradle module follows the naming convention, e.g. it's named `:public` or `:impl`.
 * Default dependencies are added, e.g. an `:impl` module imports its `:public` module by default, or `:impl-robots` imports its `:impl` module by default.
-* An [Android namespace](https://developer.android.com/build/configure-app-module#set-namespace) is set [automatically](https://github.com/amzn/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/ModuleStructurePlugin.kt#L90-L110) if it hasn't been configured yet.
+* An [Android namespace](https://developer.android.com/build/configure-app-module#set-namespace) is set [automatically](https://github.com/vRallev/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/ModuleStructurePlugin.kt#L90-L110) if it hasn't been configured yet.
 * A Gradle task `:checkModuleStructureDependencies` is registered, which verifies that module structure dependency rules are followed. The `:check` Gradle task automatically depends on `:checkModuleStructureDependencies`.
-* A consistent API for an [`Project.artifactId`](https://github.com/amzn/app-platform/blob/main/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/ModuleStructurePlugin.kt#L125-L135) is available, e.g. for `:my-module:public` it would return `my-module-public`.
+* A consistent API for an [`Project.artifactId`](https://github.com/vRallev/app-platform/blob/main/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/ModuleStructurePlugin.kt#L125-L135) is available, e.g. for `:my-module:public` it would return `my-module-public`.
 
 ??? example "Sample"
 
@@ -366,7 +366,7 @@ With this setting enabled, several checks and features are enabled:
 
     App Platform uses the `Project.artifactId()` API for its own modules. Publishing using the
     [Gradle Maven Publish Plugin](https://vanniktech.github.io/gradle-maven-publish-plugin/) is configured
-    [here](https://github.com/amzn/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/buildSrc/src/main/kotlin/software/amazon/app/platform/gradle/buildsrc/SdkPlugin.kt#L16-L34).
+    [here](https://github.com/vRallev/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/buildSrc/src/main/kotlin/software/amazon/app/platform/gradle/buildsrc/SdkPlugin.kt#L16-L34).
 
     ```kotlin
     private fun mavenPublishing(project: Project) {

--- a/docs/presenter.md
+++ b/docs/presenter.md
@@ -37,7 +37,7 @@ use case of Compose is handling, creating and modifying tree-like data structure
 UI frameworks. Molecule reuses Compose to handle state management and state transitions to implement business
 logic in the form of `@Composable` functions with all the benefits that Compose provides.
 
-The [MoleculePresenter](https://github.com/amzn/app-platform/blob/main/presenter-molecule/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/MoleculePresenter.kt)
+The [MoleculePresenter](https://github.com/vRallev/app-platform/blob/main/presenter-molecule/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/MoleculePresenter.kt)
 interface looks like this:
 
 ```kotlin
@@ -47,7 +47,7 @@ interface MoleculePresenter<InputT : Any, ModelT : BaseModel> {
 }
 ```
 
-[`Models`](https://github.com/amzn/app-platform/blob/main/presenter/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/BaseModel.kt)
+[`Models`](https://github.com/vRallev/app-platform/blob/main/presenter/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/BaseModel.kt)
 represent the state of a `Presenter`. Usually, they’re implemented as immutable, inner data classes of the `Presenter`.
 Using sealed hierarchies is a good practice to allow to differentiate between different states:
 
@@ -69,9 +69,9 @@ an interface and there can be multiple implementations.
 ??? example "Sample"
 
     The sample application follows the same principle of dependency inversion. E.g. the API of the
-    [`LoginPresenter`](https://github.com/amzn/app-platform/blob/main/sample/login/public/src/commonMain/kotlin/software/amazon/app/platform/sample/login/LoginPresenter.kt)
-    is part of the `:public` module, while the implementation [`LoginPresenterImpl`](https://github.com/amzn/app-platform/blob/main/sample/login/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/login/LoginPresenterImpl.kt)
-    lives in the `:impl` module. This abstraction is used in tests, where [`FakeLoginPresenter`](https://github.com/amzn/app-platform/blob/main/sample/navigation/impl/src/commonTest/kotlin/software/amazon/app/platform/sample/navigation/NavigationPresenterImplTest.kt#L45-L49)
+    [`LoginPresenter`](https://github.com/vRallev/app-platform/blob/main/sample/login/public/src/commonMain/kotlin/software/amazon/app/platform/sample/login/LoginPresenter.kt)
+    is part of the `:public` module, while the implementation [`LoginPresenterImpl`](https://github.com/vRallev/app-platform/blob/main/sample/login/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/login/LoginPresenterImpl.kt)
+    lives in the `:impl` module. This abstraction is used in tests, where [`FakeLoginPresenter`](https://github.com/vRallev/app-platform/blob/main/sample/navigation/impl/src/commonTest/kotlin/software/amazon/app/platform/sample/navigation/NavigationPresenterImplTest.kt#L45-L49)
     simplifies the test setup of classes relying on `LoginPresenter`.
 
 Observers of the state of a `Presenter`, such as the UI layer, communicate back to the `Presenter` through events.
@@ -166,10 +166,10 @@ a regular function to compute their model and return it.
 
 ??? example "Sample"
 
-    [`NavigationPresenterImpl`](https://github.com/amzn/app-platform/blob/main/sample/navigation/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/navigation/NavigationPresenterImpl.kt)
+    [`NavigationPresenterImpl`](https://github.com/vRallev/app-platform/blob/main/sample/navigation/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/navigation/NavigationPresenterImpl.kt)
     is another example that highlights this principle.
 
-    [`UserPagePresenterImpl`](https://github.com/amzn/app-platform/blob/main/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserPagePresenterImpl.kt)
+    [`UserPagePresenterImpl`](https://github.com/vRallev/app-platform/blob/main/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserPagePresenterImpl.kt)
     goes a step further. Its `BaseModel` is composed of two sub-models. The `listModel` is even an input for the
     detail-presenter.
 
@@ -304,7 +304,7 @@ In this example the `LoginPresenter` model is computed from an iOS Compose Multi
 In other scenarios a composable context may not be available and it's necessary to turn the `@Composable` functions
 into a `StateFlow` for consumption.
 
-[`MoleculeScope`](https://github.com/amzn/app-platform/blob/main/presenter-molecule/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/MoleculeScope.kt)
+[`MoleculeScope`](https://github.com/vRallev/app-platform/blob/main/presenter-molecule/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/MoleculeScope.kt)
 helps to turn a `MoleculePresenter` into a `Presenter`, which then exposes a `StateFlow`:
 
 ```kotlin
@@ -322,7 +322,7 @@ val stateFlow = moleculeScope
     until the `MoleculeScope` is canceled. If the `MoleculeScope` is never canceled, then presenters leak and will
     cause issues later.
 
-    Use [`MoleculeScopeFactory`](https://github.com/amzn/app-platform/blob/main/presenter-molecule/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/MoleculeScopeFactory.kt)
+    Use [`MoleculeScopeFactory`](https://github.com/vRallev/app-platform/blob/main/presenter-molecule/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/MoleculeScopeFactory.kt)
     to create a new `MoleculeScope` instance and call `cancel()` when you don't need it anymore.
 
     On Android an implementation using `ViewModels` may look like this:
@@ -414,7 +414,7 @@ in that case, child presenter updates are driven by the detached hierarchy's own
 
 ## Testing
 
-A [`test()`](https://github.com/amzn/app-platform/blob/main/presenter-molecule/testing/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/TestPresenter.kt)
+A [`test()`](https://github.com/vRallev/app-platform/blob/main/presenter-molecule/testing/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/TestPresenter.kt)
 utility function is provided to make testing `MoleculePresenters` easy using the [Turbine](https://github.com/cashapp/turbine/)
 library:
 
@@ -438,9 +438,9 @@ The `test()` function uses the `TestScope.backgroundScope` to run the presenter.
 ??? example "Sample"
 
     The sample application implements multiple tests for its presenters, e.g.
-    [`LoginPresenterImplTest`](https://github.com/amzn/app-platform/blob/main/sample/login/impl/src/commonTest/kotlin/software/amazon/app/platform/sample/login/LoginPresenterImplTest.kt),
-    [`NavigationPresenterImplTest`](https://github.com/amzn/app-platform/blob/main/sample/navigation/impl/src/commonTest/kotlin/software/amazon/app/platform/sample/navigation/NavigationPresenterImplTest.kt)
-    and [`UserPagePresenterImplTest`](https://github.com/amzn/app-platform/blob/main/sample/user/impl/src/commonTest/kotlin/software/amazon/app/platform/sample/user/UserPagePresenterImplTest.kt).
+    [`LoginPresenterImplTest`](https://github.com/vRallev/app-platform/blob/main/sample/login/impl/src/commonTest/kotlin/software/amazon/app/platform/sample/login/LoginPresenterImplTest.kt),
+    [`NavigationPresenterImplTest`](https://github.com/vRallev/app-platform/blob/main/sample/navigation/impl/src/commonTest/kotlin/software/amazon/app/platform/sample/navigation/NavigationPresenterImplTest.kt)
+    and [`UserPagePresenterImplTest`](https://github.com/vRallev/app-platform/blob/main/sample/user/impl/src/commonTest/kotlin/software/amazon/app/platform/sample/user/UserPagePresenterImplTest.kt).
 
 ## Back gestures
 
@@ -546,9 +546,9 @@ class MyPresenterTest {
 ??? example "Sample"
 
     The `BackHandlerPresenter {}` call has been integrated in the sample application with this recommended setup. All
-    necessary changes are part of this [commit](https://github.com/amzn/app-platform/pull/84/commits/a807a5673973eae26940cd1130dad836cb3dbd43).
+    necessary changes are part of this [commit](https://github.com/vRallev/app-platform/pull/84/commits/a807a5673973eae26940cd1130dad836cb3dbd43).
 
-    The same setup has been integrated in the recipes app part of this [commit](https://github.com/amzn/app-platform/pull/82/commits/fce1b3fbc0b2683ec6a93a499694f914bac34b18)
+    The same setup has been integrated in the recipes app part of this [commit](https://github.com/vRallev/app-platform/pull/82/commits/fce1b3fbc0b2683ec6a93a499694f914bac34b18)
     as well. 
 
 ## Compose runtime
@@ -715,7 +715,7 @@ is called with their initial state. These presenters only remember their state, 
 
 The Compose runtime provides `rememberSaveable { }` and `SaveableStateHolder` as a solution to save and restore small
 pieces of UI state. App Platform provides the experimental
-[`ReturningSaveableStateHolder`](https://github.com/amzn/app-platform/blob/main/presenter-molecule/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/saveable/ReturningSaveableStateHolder.kt)
+[`ReturningSaveableStateHolder`](https://github.com/vRallev/app-platform/blob/main/presenter-molecule/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/molecule/saveable/ReturningSaveableStateHolder.kt)
 API for `@Composable` functions that return a value. This matters for `MoleculePresenter` functions, because a presenter
 doesn't render UI directly; it returns a model.
 
@@ -835,7 +835,7 @@ class CrossSlideBackstackPresenter(
 
 `presenterBackstack()` always keeps the initial presenter as the root entry. It composes every presenter in the stack,
 returns the resulting model list to the `content` lambda, and provides
-[`PresenterBackstackScope`](https://github.com/amzn/app-platform/blob/main/presenter-backstack-nav3/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/backstack/nav3/PresenterBackstackScope.kt)
+[`PresenterBackstackScope`](https://github.com/vRallev/app-platform/blob/main/presenter-backstack-nav3/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/backstack/nav3/PresenterBackstackScope.kt)
 to the presenter subtree. The scope exposes `push()`, `pop()`, and `replaceTop()`.
 
 The model's `onBack` callback is the only back hook the presenter needs for renderer-driven back navigation.
@@ -1071,7 +1071,7 @@ The `SampleAppTemplateRenderer` has access to `appBarModel` from the `FullScreen
 to configure the app bar UI.
 
 The Recipe app has chosen a different implementation, where any `BaseModel` class from a `Presenter` can implement the
-specific [`AppBarConfigModel`](https://github.com/amzn/app-platform/blob/main/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/appbar/AppBarConfigModel.kt)
+specific [`AppBarConfigModel`](https://github.com/vRallev/app-platform/blob/main/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/appbar/AppBarConfigModel.kt)
 interface, which provides the configuration for the app bar. Implementing this interface is optional:
 
 ```kotlin
@@ -1092,7 +1092,7 @@ class MenuPresenter : MoleculePresenter<Unit, Model> {
 ```
 
 If a `BaseModel` implementing `AppBarConfigModel` bubbles all the way up to the
-[`RootPresenter`](https://github.com/amzn/app-platform/blob/main/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/template/RootPresenter.kt),
+[`RootPresenter`](https://github.com/vRallev/app-platform/blob/main/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/template/RootPresenter.kt),
 then the `BaseModel` from the child `Presenter` will provide the config for the `Template` or otherwise the
 `RootPresenter` will provide a default:
 
@@ -1124,7 +1124,7 @@ in the business logic. With the right integration strategy, this downside can be
 
 The presenter backstack API is the recommended integration strategy when a Compose renderer should use Navigation 3
 but presenter code should still own navigation state. The Recipes app's
-[`Navigation3HomePresenter`](https://github.com/amzn/app-platform/blob/main/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/nav3/Navigation3HomePresenter.kt)
+[`Navigation3HomePresenter`](https://github.com/vRallev/app-platform/blob/main/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/nav3/Navigation3HomePresenter.kt)
 hosts a nested presenter stack:
 
 ```kotlin
@@ -1157,7 +1157,7 @@ override fun present(input: Unit): Model {
 ```
 
 The
-[`Renderer`](https://github.com/amzn/app-platform/blob/main/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/nav3/Navigation3HomeRenderer.kt)
+[`Renderer`](https://github.com/vRallev/app-platform/blob/main/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/nav3/Navigation3HomeRenderer.kt)
 extends `PresenterBackstackRenderer`. The base renderer wraps the model stack in `NavDisplay`, gives each entry a
 stable Navigation 3 key, invokes the individual renderer for each model, and forwards back gestures to the presenter
 model's `onBack` callback:
@@ -1220,7 +1220,7 @@ the renderer-level navigation container and back gesture integration.
 #### `Presenters` and SwiftUI `Views`
 
 In iOS it's possible to connect `Presenters` to SwiftUI `Views` so `Presenter` logic can be shared while keeping UI
-native. The Recipes app demonstrates a [set of Swift APIs](https://github.com/amzn/app-platform/tree/main/recipes/recipesIosApp/recipesIosApp/PresenterViews)
+native. The Recipes app demonstrates a [set of Swift APIs](https://github.com/vRallev/app-platform/tree/main/recipes/recipesIosApp/recipesIosApp/PresenterViews)
 that demonstrate how to launch a `Presenter` and render SwiftUI `Views` in the iOS flavor. Note that App Platform 
 does not provide an API equivalent of SwiftUI `Renderers`. As such, we need to decide how to observe the flow of models 
 from a given `Presenter` and create `Views` from them.
@@ -1325,12 +1325,12 @@ detail, and we want ensure that all back events are handled appropriately and th
 
     We provide a recipe for integration with `NavigationStack` for single column navigation based on back gesture. For 
     other kinds of navigation with `NavigationSplitView` or `NavigationLink` it is possible to integrate following our
-    [model driven navigation](https://amzn.github.io/app-platform/presenter/#model-driven-navigation) pattern. However,
+    [model driven navigation](https://vrallev.github.io/app-platform/presenter/#model-driven-navigation) pattern. However,
     we don't provide an explicit recipe for it. If you're missing some use cases here, please let us know.
 
 The Recipes app demonstrates how SwiftUI navigation APIs can be used while following App Platform's philosophy of 
 unidirectional data flow. As navigation is a part of business logic, the recipe [implements navigation with 
-a backstack of `Presenters`](https://github.com/amzn/app-platform/blob/main/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/swiftui/SwiftUiHomePresenter.kt).
+a backstack of `Presenters`](https://github.com/vRallev/app-platform/blob/main/recipes/common/impl/src/commonMain/kotlin/software/amazon/app/platform/recipes/swiftui/SwiftUiHomePresenter.kt).
 The root `Presenter` responsible for the `Presenter` backstack computes the `Model` backstack:
 
 ```kotlin
@@ -1356,7 +1356,7 @@ The root `Presenter` responsible for the `Presenter` backstack computes the `Mod
   }
 ```
 The `Presenter` forwards the `Models` and event callbacks to a SwiftUI `View`, which
-integrates these models with a [`NavigationStack`](https://github.com/amzn/app-platform/blob/main/recipes/recipesIosApp/recipesIosApp/SwiftUI/SwiftUiHomePresenterView.swift).
+integrates these models with a [`NavigationStack`](https://github.com/vRallev/app-platform/blob/main/recipes/recipesIosApp/recipesIosApp/SwiftUI/SwiftUiHomePresenterView.swift).
 Note that to integrate we create a [`Binding`](https://developer.apple.com/documentation/swiftui/binding) that is passed
 in to the `NavigationStack`. The `Binding's` value type must conform to `Hashable` and by default `BaseModel` does not
 conform. To resolve this in the recipe we simply represent each `Model` by the index of its position in the `Model`

--- a/docs/renderer.md
+++ b/docs/renderer.md
@@ -14,7 +14,7 @@
 
 ## Renderer basics
 
-A [`Renderer`](https://github.com/amzn/app-platform/blob/main/renderer/public/src/commonMain/kotlin/software/amazon/app/platform/renderer/Renderer.kt)
+A [`Renderer`](https://github.com/vRallev/app-platform/blob/main/renderer/public/src/commonMain/kotlin/software/amazon/app/platform/renderer/Renderer.kt)
 is the counterpart to a `Presenter`. It consumes `Models` and turns them into UI, which is shown on screen.
 
 ```kotlin
@@ -24,9 +24,9 @@ interface Renderer<in ModelT : BaseModel> {
 ```
 
 The `Renderer` interface is rarely used directly, instead platform specific implementations like
-[`ComposeRenderer`](https://github.com/amzn/app-platform/blob/main/renderer-compose-multiplatform/public/src/commonMain/kotlin/software/amazon/app/platform/renderer/ComposeRenderer.kt)
+[`ComposeRenderer`](https://github.com/vRallev/app-platform/blob/main/renderer-compose-multiplatform/public/src/commonMain/kotlin/software/amazon/app/platform/renderer/ComposeRenderer.kt)
 for [Compose Multiplatform](https://www.jetbrains.com/compose-multiplatform/) and
-[`ViewRenderer`](https://github.com/amzn/app-platform/blob/main/renderer-android-view/public/src/androidMain/kotlin/software/amazon/app/platform/renderer/ViewRenderer.kt)
+[`ViewRenderer`](https://github.com/vRallev/app-platform/blob/main/renderer-android-view/public/src/androidMain/kotlin/software/amazon/app/platform/renderer/ViewRenderer.kt)
 for Android are used. App Platform doesn’t provide any other implementations for now, e.g. a SwiftUI or UIKit
 implementation for iOS is missing.
 
@@ -67,7 +67,7 @@ class LoginRenderer : ViewRenderer<Model>() {
 !!! warning
 
     Note that `ComposeRenderer` like `ViewRenderer` implements the common `Renderer` interface, but calling the
-    `render(model)` function [is an error](https://github.com/amzn/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/renderer-compose-multiplatform/public/src/commonMain/kotlin/software/amazon/app/platform/renderer/ComposeRenderer.kt#L52-L58).
+    `render(model)` function [is an error](https://github.com/vRallev/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/renderer-compose-multiplatform/public/src/commonMain/kotlin/software/amazon/app/platform/renderer/ComposeRenderer.kt#L52-L58).
     Instead, `ComposeRenderer` defines its own function to preserve the composable context:
 
     ```kotlin
@@ -124,28 +124,28 @@ class LoginRenderer : ComposeRenderer<Model>() {
 
 ??? example "Sample"
 
-    The sample app implements multiple `ComposeRenderers`, e.g. [`LoginRenderer`](https://github.com/amzn/app-platform/blob/main/sample/login/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/login/LoginRenderer.kt),
-    [`UserPageListRenderer`](https://github.com/amzn/app-platform/blob/main/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserPageListRenderer.kt)
-    and [`UserPageDetailRenderer`](https://github.com/amzn/app-platform/blob/main/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserPageDetailRenderer.kt).
+    The sample app implements multiple `ComposeRenderers`, e.g. [`LoginRenderer`](https://github.com/vRallev/app-platform/blob/main/sample/login/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/login/LoginRenderer.kt),
+    [`UserPageListRenderer`](https://github.com/vRallev/app-platform/blob/main/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserPageListRenderer.kt)
+    and [`UserPageDetailRenderer`](https://github.com/vRallev/app-platform/blob/main/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserPageDetailRenderer.kt).
 
 ## `RendererFactory`
 
-How `Renderers` are initialized depends on [`RendererFactory`](https://github.com/amzn/app-platform/blob/main/renderer/public/src/commonMain/kotlin/software/amazon/app/platform/renderer/RendererFactory.kt),
+How `Renderers` are initialized depends on [`RendererFactory`](https://github.com/vRallev/app-platform/blob/main/renderer/public/src/commonMain/kotlin/software/amazon/app/platform/renderer/RendererFactory.kt),
 which only responsibility is to create and cache `Renderers` based on the given model. App Platform comes with three
 different implementations:
 
-[`ComposeRendererFactory`](https://github.com/amzn/app-platform/blob/main/renderer-compose-multiplatform/public/src/commonMain/kotlin/software/amazon/app/platform/renderer/ComposeRendererFactory.kt)
+[`ComposeRendererFactory`](https://github.com/vRallev/app-platform/blob/main/renderer-compose-multiplatform/public/src/commonMain/kotlin/software/amazon/app/platform/renderer/ComposeRendererFactory.kt)
 
 :   `ComposeRendererFactory` is an implementation for Compose Multiplatform and can be used on all supported
     platforms. It can only create instances of `ComposeRenderer`.
 
-[`AndroidRendererFactory`](https://github.com/amzn/app-platform/blob/main/renderer-android-view/public/src/androidMain/kotlin/software/amazon/app/platform/renderer/AndroidRendererFactory.kt)
+[`AndroidRendererFactory`](https://github.com/vRallev/app-platform/blob/main/renderer-android-view/public/src/androidMain/kotlin/software/amazon/app/platform/renderer/AndroidRendererFactory.kt)
 
 :   `AndroidRendererFactory` is only suitable for Android. It can be used to create `ViewRenderer` instances and its
     subtypes. It does not support `ComposeRenderer`. Use `ComposeAndroidRendererFactory` if you need to mix and
     match `ViewRenderer` with `ComposeRenderer`.
 
-[`ComposeAndroidRendererFactory`](https://github.com/amzn/app-platform/blob/main/renderer-compose-multiplatform/public/src/androidMain/kotlin/software/amazon/app/platform/renderer/ComposeAndroidRendererFactory.kt)
+[`ComposeAndroidRendererFactory`](https://github.com/vRallev/app-platform/blob/main/renderer-compose-multiplatform/public/src/androidMain/kotlin/software/amazon/app/platform/renderer/ComposeAndroidRendererFactory.kt)
 
 :   `ComposeAndroidRendererFactory` is only suitable for Android when using `ComposeRenderer` together with
     `ViewRenderer`. The factory wraps the Renderers for seamless interop.
@@ -158,7 +158,7 @@ the app graph or component. Those generated bindings lazily provide all renderer
 multibindings feature. To participate in the lookup, renderers must tell Metro or
 `kotlin-inject-anvil` which models they can render. This is done through generated bindings, which
 are automatically added to the renderer scope by using the
-[`@ContributesRenderer` annotation](https://github.com/amzn/app-platform/blob/main/kotlin-inject-extensions/contribute/public/src/commonMain/kotlin/software/amazon/app/platform/inject/ContributesRenderer.kt).
+[`@ContributesRenderer` annotation](https://github.com/vRallev/app-platform/blob/main/kotlin-inject-extensions/contribute/public/src/commonMain/kotlin/software/amazon/app/platform/inject/ContributesRenderer.kt).
 
 Which `Model` type is used for the binding is determined based on the super type. In the following example
 `LoginPresenter.Model` is used.
@@ -254,9 +254,9 @@ class MainActivity : ComponentActivity() {
 
 ??? example "Sample"
 
-    The sample app uses `ComposeAndroidRendererFactory` in [Android application](https://github.com/amzn/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/sample/app/src/androidMain/kotlin/software/amazon/app/platform/sample/MainActivity.kt#L30-L35)
-    and `ComposeRendererFactory` for [iOS](https://github.com/amzn/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/sample/app/src/iosMain/kotlin/software/amazon/app/platform/sample/MainViewController.kt#L40)
-    and [Desktop](https://github.com/amzn/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/sample/app/src/desktopMain/kotlin/software/amazon/app/platform/sample/DesktopApp.kt#L36).
+    The sample app uses `ComposeAndroidRendererFactory` in [Android application](https://github.com/vRallev/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/sample/app/src/androidMain/kotlin/software/amazon/app/platform/sample/MainActivity.kt#L30-L35)
+    and `ComposeRendererFactory` for [iOS](https://github.com/vRallev/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/sample/app/src/iosMain/kotlin/software/amazon/app/platform/sample/MainViewController.kt#L40)
+    and [Desktop](https://github.com/vRallev/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/sample/app/src/desktopMain/kotlin/software/amazon/app/platform/sample/DesktopApp.kt#L36).
 
 ### Creating `Renderers`
 
@@ -330,8 +330,8 @@ class SampleRenderer(
 
 ??? example "Sample"
 
-    The sample app injects `RendererFactory` in [`ComposeSampleAppTemplateRenderer`](https://github.com/amzn/app-platform/blob/main/sample/templates/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/template/ComposeSampleAppTemplateRenderer.kt)
-    to create `Renderers` dynamically for unknown `Model` types. There is also an [Android sample implementation](https://github.com/amzn/app-platform/blob/main/sample/templates/impl/src/androidMain/kotlin/software/amazon/app/platform/sample/template/AndroidSampleAppTemplateRenderer.kt).
+    The sample app injects `RendererFactory` in [`ComposeSampleAppTemplateRenderer`](https://github.com/vRallev/app-platform/blob/main/sample/templates/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/template/ComposeSampleAppTemplateRenderer.kt)
+    to create `Renderers` dynamically for unknown `Model` types. There is also an [Android sample implementation](https://github.com/vRallev/app-platform/blob/main/sample/templates/impl/src/androidMain/kotlin/software/amazon/app/platform/sample/template/AndroidSampleAppTemplateRenderer.kt).
 
 !!! note
 
@@ -365,11 +365,11 @@ from Android Views to Compose UI by simply migrating renderers one by one.
 
 ### `ViewRenderer` subtypes
 
-[`ViewBindingRenderer`](https://github.com/amzn/app-platform/blob/main/renderer-android-view/public/src/androidMain/kotlin/software/amazon/app/platform/renderer/ViewBindingRenderer.kt).
+[`ViewBindingRenderer`](https://github.com/vRallev/app-platform/blob/main/renderer-android-view/public/src/androidMain/kotlin/software/amazon/app/platform/renderer/ViewBindingRenderer.kt).
 
 :   View binding is supported out of the box using `ViewBindingRenderer`.
 
-[`RecyclerViewViewHolderRenderer`](https://github.com/amzn/app-platform/blob/main/renderer-android-view/public/src/androidMain/kotlin/software/amazon/app/platform/renderer/RecyclerViewViewHolderRenderer.kt)
+[`RecyclerViewViewHolderRenderer`](https://github.com/vRallev/app-platform/blob/main/renderer-android-view/public/src/androidMain/kotlin/software/amazon/app/platform/renderer/RecyclerViewViewHolderRenderer.kt)
 
 :   `RecyclerViewViewHolderRenderer` allows you to implement elements of a `RecyclerView` as a `Renderer`.
 
@@ -403,6 +403,6 @@ class LoginRendererTest {
 
 ??? example "Sample"
 
-    The sample app demonstrates this with the [`LoginRendererTest`](https://github.com/amzn/app-platform/blob/main/sample/login/impl/src/appleAndDesktopTest/kotlin/software/amazon/app/platform/sample/login/LoginRendererTest.kt).
+    The sample app demonstrates this with the [`LoginRendererTest`](https://github.com/vRallev/app-platform/blob/main/sample/login/impl/src/appleAndDesktopTest/kotlin/software/amazon/app/platform/sample/login/LoginRendererTest.kt).
     To avoid duplicating the test in the `desktopTest` and `iosTest` source folders, the sample app has a custom
     source set `appleAndDesktop`, which is a shared parent source set for `apple` and `desktop`.

--- a/docs/scope.md
+++ b/docs/scope.md
@@ -34,7 +34,7 @@ We need to be in charge of our own scopes. In simple terms this means having an 
 destroyed.
 
 The App Platform provides the
-[Scope](https://github.com/amzn/app-platform/blob/main/scope/public/src/commonMain/kotlin/software/amazon/app/platform/scope/Scope.kt)
+[Scope](https://github.com/vRallev/app-platform/blob/main/scope/public/src/commonMain/kotlin/software/amazon/app/platform/scope/Scope.kt)
 interface to implement this concept.
 
 ```kotlin title="Scope.kt"
@@ -57,7 +57,7 @@ interface Scope {
 ## Creating a `Scope`
 
 A `Scope` is created through the builder function. The
-[Builder](https://github.com/amzn/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/scope/public/src/commonMain/kotlin/software/amazon/app/platform/scope/Scope.kt#L57)
+[Builder](https://github.com/vRallev/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/scope/public/src/commonMain/kotlin/software/amazon/app/platform/scope/Scope.kt#L57)
 allows you to add services before the Scope is finalized:
 
 ```kotlin
@@ -77,12 +77,12 @@ rootScope.buildChild("user scope") {
 ??? example "Sample"
 
     The root scope is usually created when the application is launched. The sample application creates its
-    root scope [here](https://github.com/amzn/app-platform/blob/main/sample/app/src/commonMain/kotlin/software/amazon/app/platform/sample/DemoApplication.kt).
+    root scope [here](https://github.com/vRallev/app-platform/blob/main/sample/app/src/commonMain/kotlin/software/amazon/app/platform/sample/DemoApplication.kt).
     This `Scope` is never destroyed and stays alive for the entire app lifetime.
 
     The sample application has a child scope for the logged in user. This `Scope` is created during
-    [login](https://github.com/amzn/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserManagerImpl.kt#L47-L52)
-    and [destroyed](https://github.com/amzn/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserManagerImpl.kt#L68)
+    [login](https://github.com/vRallev/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserManagerImpl.kt#L47-L52)
+    and [destroyed](https://github.com/vRallev/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserManagerImpl.kt#L68)
     during logout.
 
     ```kotlin
@@ -126,7 +126,7 @@ fun `my test`() = runTestWithScope { scope ->
 ??? example "Sample"
 
     Classes implementing the `Scoped` interface usually make use of the `runTestWithScope` function in their tests.
-    Notice in [this sample](https://github.com/amzn/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/sample/user/impl/src/commonTest/kotlin/software/amazon/app/platform/sample/user/SessionTimeoutTest.kt#L36-L48)
+    Notice in [this sample](https://github.com/vRallev/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/sample/user/impl/src/commonTest/kotlin/software/amazon/app/platform/sample/user/SessionTimeoutTest.kt#L36-L48)
     how `SessionTimeout`, which implements the `Scoped` interface, is registered in the `Scope`.
 
     ```kotlin hl_lines="7"
@@ -208,7 +208,7 @@ rootScope.kotlinInjectComponent<AbcComponent>()
     is used by default and added to `Scope` instance.
 
 It's strongly recommended to add a `CoroutineScope` to each `Scope`. App Platform provides a `CoroutineScope`
-[by default for the `AppScope`](https://github.com/amzn/app-platform/blob/main/kotlin-inject/impl/src/commonMain/kotlin/software/amazon/app/platform/scope/coroutine/AppScopeCoroutineScopeComponent.kt).
+[by default for the `AppScope`](https://github.com/vRallev/app-platform/blob/main/kotlin-inject/impl/src/commonMain/kotlin/software/amazon/app/platform/scope/coroutine/AppScopeCoroutineScopeComponent.kt).
 It is important to register this `CoroutineScope` in the created app `Scope` instance in order to cancel the
 `CoroutineScope` in case the `AppScope` ever gets destroyed. The same applies to any child scope.
 
@@ -305,7 +305,7 @@ override fun onEnterScope(scope: Scope) {
 ## `Scoped`
 
 Service objects can tie themselves to the lifecycle of a scope by implementing the
-[`Scoped`](https://github.com/amzn/app-platform/blob/main/scope/public/src/commonMain/kotlin/software/amazon/app/platform/scope/Scoped.kt)
+[`Scoped`](https://github.com/vRallev/app-platform/blob/main/scope/public/src/commonMain/kotlin/software/amazon/app/platform/scope/Scoped.kt)
 interface:
 
 ```kotlin
@@ -434,7 +434,7 @@ With Metro, or alternatively `kotlin-inject-anvil`, for the app scope it would b
 
 ??? example "Sample"
 
-    Another example in the sample app is [`SessionTimeout`](https://github.com/amzn/app-platform/blob/main/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/SessionTimeout.kt).
+    Another example in the sample app is [`SessionTimeout`](https://github.com/vRallev/app-platform/blob/main/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/SessionTimeout.kt).
     This class is part of the `UserScope` and implements the `Scoped` interface. `onEnterScope()` will be called when
     the user logs in and `onExitScope()` when the user logs out.
 
@@ -525,8 +525,8 @@ instances, but don't automatically register them in the `Scope`. This has to be 
 ??? example "Sample"
 
     The sample application implements this mechanism for the
-    [`AppScope`](https://github.com/amzn/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/sample/app/src/commonMain/kotlin/software/amazon/app/platform/sample/DemoApplication.kt#L31-L33)
-    and the [`UserScope`](https://github.com/amzn/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserManagerImpl.kt#L58-L60).
+    [`AppScope`](https://github.com/vRallev/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/sample/app/src/commonMain/kotlin/software/amazon/app/platform/sample/DemoApplication.kt#L31-L33)
+    and the [`UserScope`](https://github.com/vRallev/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/sample/user/impl/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserManagerImpl.kt#L58-L60).
 
 ### `onExit`
 
@@ -614,15 +614,15 @@ highlighted above.
 
 ??? example "Sample"
 
-    The sample application has a common class [DemoApplication](https://github.com/amzn/app-platform/blob/main/sample/app/src/commonMain/kotlin/software/amazon/app/platform/sample/DemoApplication.kt)
+    The sample application has a common class [DemoApplication](https://github.com/vRallev/app-platform/blob/main/sample/app/src/commonMain/kotlin/software/amazon/app/platform/sample/DemoApplication.kt)
     that is responsible for creating the app scope. The Android app instantiates `DemoApplication` in the
-    [`Application` class](https://github.com/amzn/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/sample/app/src/androidMain/kotlin/software/amazon/app/platform/sample/AndroidApplication.kt#L19).
-    The iOS sample creates the `DemoApplication` in the [`UIApplicationDelegate`](https://github.com/amzn/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/sample/iosApp/iosApp/iOSApp.swift#L6).
-    On Desktop `DemoApplication` is created part of the [`main()` function](https://github.com/amzn/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/sample/app/src/desktopMain/kotlin/software/amazon/app/platform/sample/Main.kt#L8).
+    [`Application` class](https://github.com/vRallev/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/sample/app/src/androidMain/kotlin/software/amazon/app/platform/sample/AndroidApplication.kt#L19).
+    The iOS sample creates the `DemoApplication` in the [`UIApplicationDelegate`](https://github.com/vRallev/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/sample/iosApp/iosApp/iOSApp.swift#L6).
+    On Desktop `DemoApplication` is created part of the [`main()` function](https://github.com/vRallev/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/sample/app/src/desktopMain/kotlin/software/amazon/app/platform/sample/Main.kt#L8).
 
 ### `RootScopeProvider`
 
-[`RootScopeProvider`](https://github.com/amzn/app-platform/blob/main/scope/public/src/commonMain/kotlin/software/amazon/app/platform/scope/RootScopeProvider.kt),
+[`RootScopeProvider`](https://github.com/vRallev/app-platform/blob/main/scope/public/src/commonMain/kotlin/software/amazon/app/platform/scope/RootScopeProvider.kt),
 as the name suggests, gives access to the root `Scope` ("AppScope"). Usually, this interface is implemented by the application
 object of the individual platform to get access to the root `Scope` from a platform context, e.g. on Android this is
 handy in an `Activity`:
@@ -640,7 +640,7 @@ class MainActivity : Activity() {
 ??? example "Sample"
 
     The sample application implements `RootScopeProvider` in the Android
-    [`Application` class](https://github.com/amzn/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/sample/app/src/androidMain/kotlin/software/amazon/app/platform/sample/AndroidApplication.kt#L19)
-    and the iOS [`UIApplicationDelegate`](https://github.com/amzn/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/sample/iosApp/iosApp/iOSApp.swift#L6).
+    [`Application` class](https://github.com/vRallev/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/sample/app/src/androidMain/kotlin/software/amazon/app/platform/sample/AndroidApplication.kt#L19)
+    and the iOS [`UIApplicationDelegate`](https://github.com/vRallev/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/sample/iosApp/iosApp/iOSApp.swift#L6).
     On Desktop there is no concept of a singleton application object by default, but in the sample app we created an
-    equivalent with [`DesktopApp`](https://github.com/amzn/app-platform/blob/main/sample/app/src/desktopMain/kotlin/software/amazon/app/platform/sample/DesktopApp.kt).
+    equivalent with [`DesktopApp`](https://github.com/vRallev/app-platform/blob/main/sample/app/src/desktopMain/kotlin/software/amazon/app/platform/sample/DesktopApp.kt).

--- a/docs/template.md
+++ b/docs/template.md
@@ -1,6 +1,6 @@
 # Template
 
-[`Templates`](https://github.com/amzn/app-platform/blob/main/presenter/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/template/Template.kt)
+[`Templates`](https://github.com/vRallev/app-platform/blob/main/presenter/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/template/Template.kt)
 are an abstraction between `Presenters` and `Renderers` and represent the root of the presenter and renderer tree.
 Practically, a template is one particular type of `BaseModel` that hosts other models (a container of models).
 However, instead of using a weak type like `List<BaseModel>`, a template carries semantics about what content should
@@ -25,7 +25,7 @@ sealed interface SampleAppTemplate : Template {
 
 ??? example "Sample"
 
-    A [similar hierarchy](https://github.com/amzn/app-platform/blob/main/sample/templates/public/src/commonMain/kotlin/software/amazon/app/platform/sample/template/SampleAppTemplate.kt)
+    A [similar hierarchy](https://github.com/vRallev/app-platform/blob/main/sample/templates/public/src/commonMain/kotlin/software/amazon/app/platform/sample/template/SampleAppTemplate.kt)
     is implemented in the sample application.
 
 The `Template` interface extends `BaseModel` and each app must come with its own `TemplatePresenter` and
@@ -51,9 +51,9 @@ class SampleAppTemplatePresenter(
 
 ??? example "Sample"
 
-    The sample app has a [similar implementation](https://github.com/amzn/app-platform/blob/main/sample/templates/public/src/commonMain/kotlin/software/amazon/app/platform/sample/template/SampleAppTemplatePresenter.kt).
+    The sample app has a [similar implementation](https://github.com/vRallev/app-platform/blob/main/sample/templates/public/src/commonMain/kotlin/software/amazon/app/platform/sample/template/SampleAppTemplatePresenter.kt).
 
-The wrapped presenter can override which `Template` to use by implementing [`ModelDelegate`](https://github.com/amzn/app-platform/blob/main/presenter/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/template/ModelDelegate.kt),
+The wrapped presenter can override which `Template` to use by implementing [`ModelDelegate`](https://github.com/vRallev/app-platform/blob/main/presenter/public/src/commonMain/kotlin/software/amazon/app/platform/presenter/template/ModelDelegate.kt),
 e.g.
 
 ```kotlin
@@ -66,7 +66,7 @@ data class Model(
 
 ??? example "Sample"
 
-    The sample app makes use of this mechanism in the [user page](https://github.com/amzn/app-platform/blob/main/sample/user/public/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserPagePresenter.kt),
+    The sample app makes use of this mechanism in the [user page](https://github.com/vRallev/app-platform/blob/main/sample/user/public/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserPagePresenter.kt),
     where it the layout is split between a list presenter / renderer and detail presenter / renderer.
 
     ```kotlin

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -15,14 +15,14 @@ are functioning and tests don’t need to be repeated.
 !!! info "Instrumented tests"
 
     The sample application implements instrumented tests for two screens and navigates between the tests. The
-    [tests for Desktop](https://github.com/amzn/app-platform/blob/main/sample/app/src/desktopTest/kotlin/software/amazon/app/platform/sample/LoginUiTest.kt)
+    [tests for Desktop](https://github.com/vRallev/app-platform/blob/main/sample/app/src/desktopTest/kotlin/software/amazon/app/platform/sample/LoginUiTest.kt)
     highlight how templates are rendered and robots are used for verification. They also set up a Metro
-    [`TestDesktopAppGraph`](https://github.com/amzn/app-platform/blob/main/sample/app/src/desktopTest/kotlin/software/amazon/app/platform/sample/TestDesktopAppGraph.kt),
+    [`TestDesktopAppGraph`](https://github.com/vRallev/app-platform/blob/main/sample/app/src/desktopTest/kotlin/software/amazon/app/platform/sample/TestDesktopAppGraph.kt),
     which replaces the main desktop graph.
 
-    The same UI test is [implemented for Android](https://github.com/amzn/app-platform/blob/main/sample/app/src/androidInstrumentedTest/kotlin/software/amazon/app/platform/sample/AndroidLoginUiTest.kt).
+    The same UI test is [implemented for Android](https://github.com/vRallev/app-platform/blob/main/sample/app/src/androidInstrumentedTest/kotlin/software/amazon/app/platform/sample/AndroidLoginUiTest.kt).
     The Android tests reuse the same robots for verification and set up a
-    [`TestAndroidAppGraph`](https://github.com/amzn/app-platform/blob/main/sample/app/src/androidInstrumentedTest/kotlin/software/amazon/app/platform/sample/TestAndroidAppGraph.kt)
+    [`TestAndroidAppGraph`](https://github.com/vRallev/app-platform/blob/main/sample/app/src/androidInstrumentedTest/kotlin/software/amazon/app/platform/sample/TestAndroidAppGraph.kt)
     in a similar way. The sample now uses Metro throughout, while `kotlin-inject-anvil` remains
     available as the alternative path.
 
@@ -104,9 +104,9 @@ This avoids duplication.
 ??? example "Sample"
 
     The sample app uses `:testing` modules to implement and share fakes across modules, e.g.
-    [`:sample:user:testing`](https://github.com/amzn/app-platform/tree/main/sample/user/testing). In other modules
-    fakes are created next to the tests ad-hoc, e.g. [`FakeUserPagePresenter`](https://github.com/amzn/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/sample/navigation/impl/src/commonTest/kotlin/software/amazon/app/platform/sample/navigation/NavigationPresenterImplTest.kt#L51-L58)
-    and [`FakeAnimationHelper`](https://github.com/amzn/app-platform/blob/main/sample/user/impl/src/commonTest/kotlin/software/amazon/app/platform/sample/user/FakeAnimationHelper.kt).
+    [`:sample:user:testing`](https://github.com/vRallev/app-platform/tree/main/sample/user/testing). In other modules
+    fakes are created next to the tests ad-hoc, e.g. [`FakeUserPagePresenter`](https://github.com/vRallev/app-platform/blob/0f3e242ae08bb242fbd7080d33caa069c8fae2b4/sample/navigation/impl/src/commonTest/kotlin/software/amazon/app/platform/sample/navigation/NavigationPresenterImplTest.kt#L51-L58)
+    and [`FakeAnimationHelper`](https://github.com/vRallev/app-platform/blob/main/sample/user/impl/src/commonTest/kotlin/software/amazon/app/platform/sample/user/FakeAnimationHelper.kt).
 
     ```kotlin
     private class FakeUserPagePresenter : UserPagePresenter {
@@ -139,7 +139,7 @@ class LogoutRobot : Robot {
 }
 ```
 
-Test [`Robots`](https://github.com/amzn/app-platform/blob/main/robot/public/src/commonMain/kotlin/software/amazon/app/platform/robot/Robot.kt)
+Test [`Robots`](https://github.com/vRallev/app-platform/blob/main/robot/public/src/commonMain/kotlin/software/amazon/app/platform/robot/Robot.kt)
 are not limited to UI interactions such as verifying UI elements are shown or hidden and invoking
 actions on them. They can also be used to change fake implementations or make assertions on them. Imagine a
 robot toggling network connectivity. Tests do not interact with fake implementations directly similar to them
@@ -212,7 +212,7 @@ class ConnectionRobot : Robot {
 
 ### Robot types
 
-[`Robot`](https://github.com/amzn/app-platform/blob/main/robot/public/src/commonMain/kotlin/software/amazon/app/platform/robot/Robot.kt).
+[`Robot`](https://github.com/vRallev/app-platform/blob/main/robot/public/src/commonMain/kotlin/software/amazon/app/platform/robot/Robot.kt).
 
 :   Use this common interface for robots that don't interact with any UI, whether that's Compose Multiplatform or
     Android Views. To obtain an instance of such a robot use the `robot<Type>()` function:
@@ -234,7 +234,7 @@ class ConnectionRobot : Robot {
     }
     ```
 
-[`ComposeRobot`](https://github.com/amzn/app-platform/blob/main/robot-compose-multiplatform/public/src/commonMain/kotlin/software/amazon/app/platform/robot/ComposeRobot.kt)
+[`ComposeRobot`](https://github.com/vRallev/app-platform/blob/main/robot-compose-multiplatform/public/src/commonMain/kotlin/software/amazon/app/platform/robot/ComposeRobot.kt)
 
 :   `ComposeRobot` should be used as parent type when the robot interacts with Compose UI elements. These robots need
     access to a `SemanticsNodeInteractionsProvider` instance, which is for example provided by calling
@@ -274,7 +274,7 @@ class ConnectionRobot : Robot {
     }
     ```
 
-[`AndroidViewRobot`](https://github.com/amzn/app-platform/blob/main/robot/public/src/androidMain/kotlin/software/amazon/app/platform/robot/AndroidViewRobot.kt)
+[`AndroidViewRobot`](https://github.com/vRallev/app-platform/blob/main/robot/public/src/androidMain/kotlin/software/amazon/app/platform/robot/AndroidViewRobot.kt)
 
 :   `AndroidViewRobot` should be used as parent type when the robot interacts with Android Views.
     To obtain an instance of such a robot use the `robot<Type>()` function:
@@ -363,8 +363,8 @@ It’s strongly encouraged for features to create `:*-robots` modules and share 
 
 ??? example "Sample"
 
-    The sample application comes with two robot implementations [`LoginRobot`](https://github.com/amzn/app-platform/blob/main/sample/login/impl-robots/src/commonMain/kotlin/software/amazon/app/platform/sample/login/LoginRobot.kt)
-    and [`UserPageRobot`](https://github.com/amzn/app-platform/blob/main/sample/user/impl-robots/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserPageRobot.kt),
+    The sample application comes with two robot implementations [`LoginRobot`](https://github.com/vRallev/app-platform/blob/main/sample/login/impl-robots/src/commonMain/kotlin/software/amazon/app/platform/sample/login/LoginRobot.kt)
+    and [`UserPageRobot`](https://github.com/vRallev/app-platform/blob/main/sample/user/impl-robots/src/commonMain/kotlin/software/amazon/app/platform/sample/user/UserPageRobot.kt),
     each living in its feature specific `:robots` module.
 
 ## Mocks

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,10 +29,10 @@ RELEASE_SIGNING_ENABLED=false
 POM_DESCRIPTION=The App Platform is a lightweight application framework for state and memory management suitable for Kotlin Multiplatform projects, in particular Android, iOS, JVM, native and Web.
 POM_INCEPTION_YEAR=2025
 
-POM_URL=https://github.com/amzn/app-platform/
-POM_SCM_URL=https://github.com/amzn/app-platform/
-POM_SCM_CONNECTION=scm:git:git://github.com/amzn/app-platform.git
-POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/amzn/app-platform.git
+POM_URL=https://github.com/vRallev/app-platform/
+POM_SCM_URL=https://github.com/vRallev/app-platform/
+POM_SCM_CONNECTION=scm:git:git://github.com/vRallev/app-platform.git
+POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/vRallev/app-platform.git
 
 POM_LICENCE_NAME=Apache-2.0
 POM_LICENCE_URL=https://www.apache.org/licenses/LICENSE-2.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: App Platform
-site_url: https://amzn.github.io/app-platform/
+site_url: https://vrallev.github.io/app-platform/
 repo_name: app-platform
-repo_url: https://github.com/amzn/app-platform
+repo_url: https://github.com/vRallev/app-platform
 edit_uri: edit/main/docs/
 site_description: "A lightweight application framework for state and memory management suitable for Kotlin Multiplatform projects."
 remote_branch: gh-pages


### PR DESCRIPTION
**Update repository URLs after transfer:**
Point docs, publishing metadata, and workflow guards at `vRallev/app-platform` so badges, source links, Pages links, and release automation follow the transferred repository instead of the former `amzn/app-platform` owner.

**Use Ubuntu runners for publish workflows:**
Run release and snapshot publication on `ubuntu-latest` so these non-Apple publishing jobs no longer depend on macOS runner capacity. The workflow triggers, repository guards, and publishing commands stay unchanged.