### PR TITLE
Recognize app module path groups

### DIFF
--- a/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/ModuleType.kt
+++ b/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/ModuleType.kt
@@ -98,10 +98,23 @@ internal fun String.moduleTypeFromProjectPath(): ModuleType {
     name == "testing" -> TESTING
     name.startsWith("impl") -> if (isRobots) IMPL_ROBOTS else IMPL
     name.startsWith("internal") -> if (isRobots) INTERNAL_ROBOTS else INTERNAL
-    contains(":app:") || name.startsWith("app") -> APP
+    isAppModulePath() -> APP
     else -> UNKNOWN
   }
 }
+
+private fun String.isAppModulePath(): Boolean {
+  val name = substringAfterLast(':')
+
+  return name.isAppSegment() ||
+    contains(":app:") ||
+    contains(":apps:") ||
+    contains(":app-") ||
+    contains(":apps-")
+}
+
+private fun String.isAppSegment(): Boolean =
+  this == "app" || this == "apps" || startsWith("app-") || startsWith("apps-")
 
 internal fun String.moduleTypeFromArtifactId(): ModuleType {
   // E.g. abc-public, def-impl-xyz-robots

--- a/gradle-plugin/src/test/kotlin/software/amazon/app/platform/gradle/ModuleStructureDependencyCheckTaskTest.kt
+++ b/gradle-plugin/src/test/kotlin/software/amazon/app/platform/gradle/ModuleStructureDependencyCheckTaskTest.kt
@@ -65,6 +65,26 @@ class ModuleStructureDependencyCheckTaskTest {
   }
 
   @Test
+  fun `app modules can import impl modules`() {
+    listOf(
+        ":app",
+        ":app-mobile",
+        ":feature:app:feature",
+        ":apps:feature",
+        ":app-mobile:feature",
+        ":feature:app-mobile:feature",
+        ":apps-mobile:feature",
+        ":feature:apps-mobile:feature",
+      )
+      .forEach { modulePath ->
+        checkDependencies(
+          modulePath = modulePath,
+          moduleCompileClasspath = setOf(":library:impl-common"),
+        )
+      }
+  }
+
+  @Test
   fun `internal dependency within the same library remains allowed`() {
     checkDependencies(
       modulePath = ":library:impl",

--- a/gradle-plugin/src/test/kotlin/software/amazon/app/platform/gradle/ModuleTypeTest.kt
+++ b/gradle-plugin/src/test/kotlin/software/amazon/app/platform/gradle/ModuleTypeTest.kt
@@ -1,0 +1,53 @@
+package software.amazon.app.platform.gradle
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+import software.amazon.app.platform.gradle.ModuleType.APP
+import software.amazon.app.platform.gradle.ModuleType.IMPL
+import software.amazon.app.platform.gradle.ModuleType.INTERNAL
+import software.amazon.app.platform.gradle.ModuleType.PUBLIC
+import software.amazon.app.platform.gradle.ModuleType.TESTING
+import software.amazon.app.platform.gradle.ModuleType.UNKNOWN
+
+class ModuleTypeTest {
+
+  @Test
+  fun `project path is app for app and hyphenated app module names`() {
+    listOf(
+        ":app",
+        ":app-mobile",
+        ":apps",
+        ":apps-mobile",
+        ":feature:app-public",
+      )
+      .forEach { modulePath -> assertThat(modulePath.moduleTypeFromProjectPath()).isEqualTo(APP) }
+  }
+
+  @Test
+  fun `project path is app when app segment is part of path`() {
+    listOf(
+        ":app:feature",
+        ":apps:feature",
+        ":app-mobile:feature",
+        ":apps-mobile:feature",
+      )
+      .forEach { modulePath -> assertThat(modulePath.moduleTypeFromProjectPath()).isEqualTo(APP) }
+  }
+
+  @Test
+  fun `project path keeps explicit module type when app segment is part of path`() {
+    assertThat(":feature:app:public".moduleTypeFromProjectPath()).isEqualTo(PUBLIC)
+    assertThat(":apps:abc:impl".moduleTypeFromProjectPath()).isEqualTo(IMPL)
+    assertThat(":feature:app-mobile:testing".moduleTypeFromProjectPath()).isEqualTo(TESTING)
+    assertThat(":feature:apps-mobile:internal".moduleTypeFromProjectPath()).isEqualTo(INTERNAL)
+  }
+
+  @Test
+  fun `project path does not treat app lookalike parent segment as app`() {
+    assertThat(":application:public".moduleTypeFromProjectPath()).isEqualTo(PUBLIC)
+    assertThat(":feature:appstate".moduleTypeFromProjectPath()).isEqualTo(UNKNOWN)
+    assertThat(":feature:appspecific:impl".moduleTypeFromProjectPath()).isEqualTo(IMPL)
+    assertThat(":feature:appspecific:feature".moduleTypeFromProjectPath()).isEqualTo(UNKNOWN)
+  }
+}


### PR DESCRIPTION
App modules are the boundary allowed to import `:impl` modules, so path groups such as `:apps:`, `:app-*:`, and `:apps-*:` need to be classified consistently with `:app:`. This keeps module-structure checks from rejecting app-specific modules nested under those Gradle paths.