### PR TITLE
Support AGP built-in Kotlin Android modules

### DIFF
--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -60,6 +60,7 @@ dependencies {
 
     testImplementation gradleTestKit()
     testImplementation libs.assertk
+    testImplementation libs.kotlin.multiplatform.gradle.plugin
     testImplementation libs.kotlin.test.junit5
 }
 

--- a/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/AppPlatformExtension.kt
+++ b/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/AppPlatformExtension.kt
@@ -252,7 +252,7 @@ private fun Project.enableKotlinInject() {
     }
   }
 
-  plugins.withIds(PluginIds.KOTLIN_ANDROID, PluginIds.KOTLIN_JVM) {
+  withJvmOrAndroidPlugin {
     dependencies.add("implementation", "$APP_PLATFORM_GROUP:di-common-public:$APP_PLATFORM_VERSION")
     dependencies.add(
       "implementation",
@@ -314,7 +314,7 @@ private fun Project.enableMetroKsp() {
     }
   }
 
-  plugins.withIds(PluginIds.KOTLIN_ANDROID, PluginIds.KOTLIN_JVM) {
+  withJvmOrAndroidPlugin {
     dependencies.add("implementation", "$APP_PLATFORM_GROUP:di-common-public:$APP_PLATFORM_VERSION")
     dependencies.add("implementation", "$APP_PLATFORM_GROUP:metro-public:$APP_PLATFORM_VERSION")
     dependencies.addKspProcessorDependencies("ksp")
@@ -322,15 +322,23 @@ private fun Project.enableMetroKsp() {
 }
 
 private fun Project.enableMetroCompilerPlugin() {
+  val compilerPluginDependency =
+    "$APP_PLATFORM_GROUP:metro-contribute-impl-compiler-plugin:$APP_PLATFORM_VERSION"
+
   fun DependencyHandler.addCompilerPluginDependencies() {
-    add(
-      PLUGIN_CLASSPATH_CONFIGURATION_NAME,
-      "$APP_PLATFORM_GROUP:metro-contribute-impl-compiler-plugin:$APP_PLATFORM_VERSION",
-    )
-    add(
-      NATIVE_COMPILER_PLUGIN_CLASSPATH_CONFIGURATION_NAME,
-      "$APP_PLATFORM_GROUP:metro-contribute-impl-compiler-plugin:$APP_PLATFORM_VERSION",
-    )
+    add(PLUGIN_CLASSPATH_CONFIGURATION_NAME, compilerPluginDependency)
+    add(NATIVE_COMPILER_PLUGIN_CLASSPATH_CONFIGURATION_NAME, compilerPluginDependency)
+  }
+
+  fun addAgpBuiltInKotlinCompilerPluginDependencies() {
+    configurations.configureEach { configuration ->
+      if (
+        configuration.name.startsWith(PLUGIN_CLASSPATH_CONFIGURATION_NAME) &&
+          configuration.name != PLUGIN_CLASSPATH_CONFIGURATION_NAME
+      ) {
+        dependencies.add(configuration.name, compilerPluginDependency)
+      }
+    }
   }
 
   plugins.withId(PluginIds.KOTLIN_MULTIPLATFORM) {
@@ -341,12 +349,18 @@ private fun Project.enableMetroCompilerPlugin() {
     dependencies.addCompilerPluginDependencies()
   }
 
-  plugins.withIds(PluginIds.KOTLIN_ANDROID, PluginIds.KOTLIN_JVM) {
+  withLegacyKotlinJvmOrAndroidPlugin {
     dependencies.add("implementation", "$APP_PLATFORM_GROUP:di-common-public:$APP_PLATFORM_VERSION")
 
     dependencies.add("implementation", "$APP_PLATFORM_GROUP:metro-public:$APP_PLATFORM_VERSION")
 
     dependencies.addCompilerPluginDependencies()
+  }
+
+  withAgpBuiltInKotlinAndroidPlugin {
+    dependencies.add("implementation", "$APP_PLATFORM_GROUP:di-common-public:$APP_PLATFORM_VERSION")
+    dependencies.add("implementation", "$APP_PLATFORM_GROUP:metro-public:$APP_PLATFORM_VERSION")
+    addAgpBuiltInKotlinCompilerPluginDependencies()
   }
 }
 
@@ -365,7 +379,7 @@ private fun Project.enableMoleculePresenters() {
     }
   }
 
-  plugins.withIds(PluginIds.KOTLIN_ANDROID, PluginIds.KOTLIN_JVM) {
+  withJvmOrAndroidPlugin {
     dependencies.add("implementation", "app.cash.molecule:molecule-runtime:$MOLECULE_VERSION")
     dependencies.add(
       "implementation",
@@ -392,7 +406,7 @@ private fun Project.enableMoleculePresenterBackstack() {
     }
   }
 
-  plugins.withIds(PluginIds.KOTLIN_ANDROID, PluginIds.KOTLIN_JVM) {
+  withJvmOrAndroidPlugin {
     dependencies.add(
       "implementation",
       "$APP_PLATFORM_GROUP:presenter-backstack-nav3-public:$APP_PLATFORM_VERSION",

--- a/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/AppPlatformPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/AppPlatformPlugin.kt
@@ -51,7 +51,7 @@ public open class AppPlatformPlugin : Plugin<Project> {
       }
     }
 
-    plugins.withIds(PluginIds.KOTLIN_ANDROID, PluginIds.KOTLIN_JVM) {
+    withJvmOrAndroidPlugin {
       implementationDependencies.forEach { dep -> dependencies.add("implementation", dep) }
       testingSourceSets.forEach { sourceSetName ->
         testImplementationDependencies.forEach { dep -> dependencies.add(sourceSetName, dep) }
@@ -104,7 +104,7 @@ public open class AppPlatformPlugin : Plugin<Project> {
       }
     }
 
-    plugins.withIds(PluginIds.KOTLIN_ANDROID, PluginIds.KOTLIN_JVM) {
+    withJvmOrAndroidPlugin {
       implementationDependencies.forEach { dep -> dependencies.add("implementation", dep) }
     }
   }

--- a/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/GradleExtensions.kt
+++ b/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/GradleExtensions.kt
@@ -18,6 +18,68 @@ internal fun PluginContainer.withIds(vararg pluginIds: String, action: (Plugin<*
   pluginIds.forEach { id -> withId(id) { action(it) } }
 }
 
+/**
+ * Runs [action] once for single-platform JVM and Android projects. Android projects may use either
+ * the legacy Kotlin Android plugin or AGP built-in Kotlin.
+ */
+internal fun Project.withJvmOrAndroidPlugin(action: () -> Unit) {
+  var didRun = false
+
+  fun runOnce() {
+    if (didRun || plugins.hasPlugin(PluginIds.KOTLIN_MULTIPLATFORM)) return
+
+    didRun = true
+    action()
+  }
+
+  plugins.withIds(
+    PluginIds.KOTLIN_ANDROID,
+    PluginIds.KOTLIN_JVM,
+    PluginIds.ANDROID_APP,
+    PluginIds.ANDROID_LIBRARY,
+  ) {
+    runOnce()
+  }
+}
+
+/** Runs [action] once for projects using the legacy Kotlin Android plugin or Kotlin JVM. */
+internal fun Project.withLegacyKotlinJvmOrAndroidPlugin(action: () -> Unit) {
+  var didRun = false
+
+  fun runOnce() {
+    if (didRun || plugins.hasPlugin(PluginIds.KOTLIN_MULTIPLATFORM)) return
+
+    didRun = true
+    action()
+  }
+
+  plugins.withIds(PluginIds.KOTLIN_ANDROID, PluginIds.KOTLIN_JVM) {
+    runOnce()
+  }
+}
+
+/** Runs [action] once for Android projects using AGP built-in Kotlin. */
+internal fun Project.withAgpBuiltInKotlinAndroidPlugin(action: () -> Unit) {
+  var didRun = false
+
+  fun runOnce() {
+    if (
+      didRun ||
+        plugins.hasPlugin(PluginIds.KOTLIN_MULTIPLATFORM) ||
+        plugins.hasPlugin(PluginIds.KOTLIN_ANDROID)
+    ) {
+      return
+    }
+
+    didRun = true
+    action()
+  }
+
+  plugins.withIds(PluginIds.ANDROID_APP, PluginIds.ANDROID_LIBRARY) {
+    runOnce()
+  }
+}
+
 // This is OK because no properties within parent are accessed
 // https://github.com/gradle/gradle/issues/33198
 @Suppress("GradleProjectIsolation")
@@ -26,9 +88,6 @@ internal fun Project.requireParent(): IsolatedProject =
       "The parent project for a module enabling the module structure should not be null."
     }
     .isolated
-
-internal val Project.isKmpModule: Boolean
-  get() = plugins.hasPlugin(PluginIds.KOTLIN_MULTIPLATFORM)
 
 internal val Project.android: CommonExtension
   get() = extensions.getByType(CommonExtension::class.java)

--- a/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/ModuleStructurePlugin.kt
+++ b/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/ModuleStructurePlugin.kt
@@ -20,25 +20,20 @@ public open class ModuleStructurePlugin : Plugin<Project> {
   }
 
   private fun Project.addModuleStructureDependencies() {
-    plugins.withIds(
-      PluginIds.KOTLIN_MULTIPLATFORM,
-      PluginIds.KOTLIN_JVM,
-      PluginIds.KOTLIN_ANDROID,
+    fun addModuleStructureDependencies(
+      publicModuleConfiguration: String,
+      implModuleConfiguration: String,
     ) {
       val parent = requireParent()
 
       // Nothing to add.
-      if (isPublicModule()) return@withIds
+      if (isPublicModule()) return
 
       fun addPublicModule() {
         // this is ok because no properties within publicModule are accessed
         @Suppress("GradleProjectIsolation") val publicModule = findProject("${parent.path}:public")
         if (publicModule != null) {
-          if (isKmpModule) {
-            dependencies.add("commonMainApi", publicModule)
-          } else {
-            dependencies.add("api", publicModule)
-          }
+          dependencies.add(publicModuleConfiguration, publicModule)
         }
       }
 
@@ -66,15 +61,23 @@ public open class ModuleStructurePlugin : Plugin<Project> {
           @Suppress("GradleProjectIsolation") // no properties within project are accessed
           findProject(path.substringBefore("-robots"))
             ?.takeIf { it.isImplModule() }
-            ?.let { implModule ->
-              if (isKmpModule) {
-                dependencies.add("commonMainImplementation", implModule)
-              } else {
-                dependencies.add("implementation", implModule)
-              }
-            }
+            ?.let { implModule -> dependencies.add(implModuleConfiguration, implModule) }
         }
       }
+    }
+
+    plugins.withId(PluginIds.KOTLIN_MULTIPLATFORM) {
+      addModuleStructureDependencies(
+        publicModuleConfiguration = "commonMainApi",
+        implModuleConfiguration = "commonMainImplementation",
+      )
+    }
+
+    withJvmOrAndroidPlugin {
+      addModuleStructureDependencies(
+        publicModuleConfiguration = "api",
+        implModuleConfiguration = "implementation",
+      )
     }
   }
 
@@ -160,7 +163,9 @@ public open class ModuleStructurePlugin : Plugin<Project> {
           }
 
           plugins.hasPlugin(PluginIds.KOTLIN_ANDROID) ||
-            plugins.hasPlugin(PluginIds.KOTLIN_JVM) -> {
+            plugins.hasPlugin(PluginIds.KOTLIN_JVM) ||
+            plugins.hasPlugin(PluginIds.ANDROID_APP) ||
+            plugins.hasPlugin(PluginIds.ANDROID_LIBRARY) -> {
             add("testImplementation")
             if (moduleType.useTestDependenciesInMain) {
               add("implementation")

--- a/gradle-plugin/src/test/kotlin/software/amazon/app/platform/gradle/AppPlatformPluginDependencyTest.kt
+++ b/gradle-plugin/src/test/kotlin/software/amazon/app/platform/gradle/AppPlatformPluginDependencyTest.kt
@@ -1,0 +1,173 @@
+package software.amazon.app.platform.gradle
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.doesNotContain
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import gradle_plugin.BuildConfig.APP_PLATFORM_GROUP
+import gradle_plugin.BuildConfig.APP_PLATFORM_VERSION
+import kotlin.test.Test
+import org.gradle.api.Project
+import org.gradle.api.artifacts.ExternalModuleDependency
+import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.testfixtures.ProjectBuilder
+import org.jetbrains.kotlin.gradle.plugin.PLUGIN_CLASSPATH_CONFIGURATION_NAME
+import software.amazon.app.platform.gradle.AppPlatformExtension.Companion.appPlatform
+
+class AppPlatformPluginDependencyTest {
+
+  @Test
+  fun `AGP built-in Kotlin Android application receives Metro public and impl dependencies`() {
+    val project = createProject(name = "app")
+    project.plugins.apply(PluginIds.ANDROID_APP)
+    project.plugins.apply(AppPlatformPlugin::class.java)
+
+    project.appPlatform.enableMetro(true)
+    project.appPlatform.addImplModuleDependencies(true)
+
+    project.evaluate()
+
+    project.assertHasDependency("implementation", appPlatformDependency("di-common-public"))
+    project.assertHasDependency("implementation", appPlatformDependency("metro-public"))
+    project.assertHasDependency("implementation", appPlatformDependency("metro-impl"))
+    project.assertHasDependency(
+      agpBuiltInKotlinDebugCompilerPluginConfiguration,
+      appPlatformDependency("metro-contribute-impl-compiler-plugin"),
+    )
+    project.assertDoesNotHaveDependency(
+      PLUGIN_CLASSPATH_CONFIGURATION_NAME,
+      appPlatformDependency("metro-contribute-impl-compiler-plugin"),
+    )
+    assertThat(project.plugins.hasPlugin(PluginIds.KOTLIN_ANDROID)).isFalse()
+  }
+
+  @Test
+  fun `AGP built-in Kotlin Android library receives Metro public dependencies`() {
+    val project = createProject(name = "impl")
+    project.plugins.apply(PluginIds.ANDROID_LIBRARY)
+    project.plugins.apply(AppPlatformPlugin::class.java)
+
+    project.appPlatform.enableMetro(true)
+
+    project.evaluate()
+
+    project.assertHasDependency("implementation", appPlatformDependency("di-common-public"))
+    project.assertHasDependency("implementation", appPlatformDependency("metro-public"))
+    project.assertHasDependency(
+      agpBuiltInKotlinDebugCompilerPluginConfiguration,
+      appPlatformDependency("metro-contribute-impl-compiler-plugin"),
+    )
+    project.assertDoesNotHaveDependency(
+      PLUGIN_CLASSPATH_CONFIGURATION_NAME,
+      appPlatformDependency("metro-contribute-impl-compiler-plugin"),
+    )
+    project.assertDoesNotHaveDependency("implementation", appPlatformDependency("metro-impl"))
+    assertThat(project.plugins.hasPlugin(PluginIds.KOTLIN_ANDROID)).isFalse()
+  }
+
+  @Test
+  fun `KMP Metro dependency wiring still works`() {
+    val project = createProject(name = "impl")
+    project.plugins.apply(PluginIds.KOTLIN_MULTIPLATFORM)
+    project.plugins.apply(AppPlatformPlugin::class.java)
+
+    project.appPlatform.enableMetro(true)
+    project.appPlatform.addImplModuleDependencies(true)
+
+    project.evaluate()
+
+    project.assertHasDependency(
+      "commonMainImplementation",
+      appPlatformDependency("di-common-public"),
+    )
+    project.assertHasDependency("commonMainImplementation", appPlatformDependency("metro-public"))
+    project.assertHasDependency("commonMainImplementation", appPlatformDependency("metro-impl"))
+    project.assertHasDependency(
+      PLUGIN_CLASSPATH_CONFIGURATION_NAME,
+      appPlatformDependency("metro-contribute-impl-compiler-plugin"),
+    )
+  }
+
+  @Test
+  fun `legacy JVM Metro dependency wiring still works`() {
+    val project = createProject(name = "impl")
+    project.plugins.apply(PluginIds.KOTLIN_JVM)
+    project.plugins.apply(AppPlatformPlugin::class.java)
+
+    project.appPlatform.enableMetro(true)
+    project.appPlatform.addImplModuleDependencies(true)
+
+    project.evaluate()
+
+    project.assertHasDependency("implementation", appPlatformDependency("di-common-public"))
+    project.assertHasDependency("implementation", appPlatformDependency("metro-public"))
+    project.assertHasDependency("implementation", appPlatformDependency("metro-impl"))
+    project.assertHasDependency(
+      PLUGIN_CLASSPATH_CONFIGURATION_NAME,
+      appPlatformDependency("metro-contribute-impl-compiler-plugin"),
+    )
+  }
+
+  @Test
+  fun `legacy Kotlin Android and Android application plugins do not duplicate Metro dependencies`() {
+    val project = createProject(name = "app")
+    project.plugins.apply(PluginIds.ANDROID_APP)
+    project.plugins.apply(PluginIds.KOTLIN_ANDROID)
+    project.plugins.apply(AppPlatformPlugin::class.java)
+
+    project.appPlatform.enableMetro(true)
+    project.appPlatform.addImplModuleDependencies(true)
+
+    project.evaluate()
+
+    project.assertHasDependencyOnce("implementation", appPlatformDependency("di-common-public"))
+    project.assertHasDependencyOnce("implementation", appPlatformDependency("metro-public"))
+    project.assertHasDependencyOnce("implementation", appPlatformDependency("metro-impl"))
+    project.assertHasDependencyOnce(
+      PLUGIN_CLASSPATH_CONFIGURATION_NAME,
+      appPlatformDependency("metro-contribute-impl-compiler-plugin"),
+    )
+    project.assertDoesNotHaveDependency(
+      agpBuiltInKotlinDebugCompilerPluginConfiguration,
+      appPlatformDependency("metro-contribute-impl-compiler-plugin"),
+    )
+  }
+
+  private fun createProject(name: String): Project {
+    val rootProject = ProjectBuilder.builder().withName("root").build()
+    return ProjectBuilder.builder().withName(name).withParent(rootProject).build()
+  }
+
+  private fun appPlatformDependency(artifactId: String): String =
+    "$APP_PLATFORM_GROUP:$artifactId:$APP_PLATFORM_VERSION"
+
+  private val agpBuiltInKotlinDebugCompilerPluginConfiguration =
+    "${PLUGIN_CLASSPATH_CONFIGURATION_NAME}Debug"
+
+  private fun Project.assertHasDependency(configurationName: String, coordinate: String) {
+    val dependencies = dependencyCoordinates(configurationName)
+    assertThat(dependencies).contains(coordinate)
+  }
+
+  private fun Project.assertDoesNotHaveDependency(configurationName: String, coordinate: String) {
+    val dependencies = dependencyCoordinates(configurationName)
+    assertThat(dependencies).doesNotContain(coordinate)
+  }
+
+  private fun Project.assertHasDependencyOnce(configurationName: String, coordinate: String) {
+    val dependencies = dependencyCoordinates(configurationName)
+    assertThat(dependencies.count { dependency -> dependency == coordinate }).isEqualTo(1)
+  }
+
+  private fun Project.dependencyCoordinates(configurationName: String): List<String> =
+    configurations
+      .getByName(configurationName)
+      .dependencies
+      .filterIsInstance<ExternalModuleDependency>()
+      .map { dependency -> "${dependency.group}:${dependency.name}:${dependency.version}" }
+
+  private fun Project.evaluate() {
+    (this as ProjectInternal).evaluate()
+  }
+}

--- a/gradle-plugin/src/test/kotlin/software/amazon/app/platform/gradle/FakePlugins.kt
+++ b/gradle-plugin/src/test/kotlin/software/amazon/app/platform/gradle/FakePlugins.kt
@@ -1,0 +1,48 @@
+package software.amazon.app.platform.gradle
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.plugin.NATIVE_COMPILER_PLUGIN_CLASSPATH_CONFIGURATION_NAME
+import org.jetbrains.kotlin.gradle.plugin.PLUGIN_CLASSPATH_CONFIGURATION_NAME
+
+public class FakeAndroidApplicationPlugin : Plugin<Project> {
+  override fun apply(target: Project) {
+    target.addSinglePlatformConfigurations()
+  }
+}
+
+public class FakeAndroidLibraryPlugin : Plugin<Project> {
+  override fun apply(target: Project) {
+    target.addSinglePlatformConfigurations()
+  }
+}
+
+public class FakeKotlinAndroidPlugin : Plugin<Project> {
+  override fun apply(target: Project) {
+    target.addSinglePlatformConfigurations()
+  }
+}
+
+public class FakeKotlinJvmPlugin : Plugin<Project> {
+  override fun apply(target: Project) {
+    target.addSinglePlatformConfigurations()
+  }
+}
+
+public class FakeMetroPlugin : Plugin<Project> {
+  override fun apply(target: Project) = Unit
+}
+
+private fun Project.addSinglePlatformConfigurations() {
+  listOf(
+      "api",
+      "implementation",
+      "testImplementation",
+      "androidTestImplementation",
+      "ksp",
+      PLUGIN_CLASSPATH_CONFIGURATION_NAME,
+      "${PLUGIN_CLASSPATH_CONFIGURATION_NAME}Debug",
+      NATIVE_COMPILER_PLUGIN_CLASSPATH_CONFIGURATION_NAME,
+    )
+    .forEach { configurationName -> configurations.maybeCreate(configurationName) }
+}

--- a/gradle-plugin/src/test/resources/META-INF/gradle-plugins/com.android.application.properties
+++ b/gradle-plugin/src/test/resources/META-INF/gradle-plugins/com.android.application.properties
@@ -1,0 +1,1 @@
+implementation-class=software.amazon.app.platform.gradle.FakeAndroidApplicationPlugin

--- a/gradle-plugin/src/test/resources/META-INF/gradle-plugins/com.android.library.properties
+++ b/gradle-plugin/src/test/resources/META-INF/gradle-plugins/com.android.library.properties
@@ -1,0 +1,1 @@
+implementation-class=software.amazon.app.platform.gradle.FakeAndroidLibraryPlugin

--- a/gradle-plugin/src/test/resources/META-INF/gradle-plugins/dev.zacsweers.metro.properties
+++ b/gradle-plugin/src/test/resources/META-INF/gradle-plugins/dev.zacsweers.metro.properties
@@ -1,0 +1,1 @@
+implementation-class=software.amazon.app.platform.gradle.FakeMetroPlugin

--- a/gradle-plugin/src/test/resources/META-INF/gradle-plugins/org.jetbrains.kotlin.android.properties
+++ b/gradle-plugin/src/test/resources/META-INF/gradle-plugins/org.jetbrains.kotlin.android.properties
@@ -1,0 +1,1 @@
+implementation-class=software.amazon.app.platform.gradle.FakeKotlinAndroidPlugin

--- a/gradle-plugin/src/test/resources/META-INF/gradle-plugins/org.jetbrains.kotlin.jvm.properties
+++ b/gradle-plugin/src/test/resources/META-INF/gradle-plugins/org.jetbrains.kotlin.jvm.properties
@@ -1,0 +1,1 @@
+implementation-class=software.amazon.app.platform.gradle.FakeKotlinJvmPlugin


### PR DESCRIPTION
AGP 9 Android modules can rely on built-in Kotlin without applying `org.jetbrains.kotlin.android`, so App Platform dependency wiring must listen to Android app/library plugins directly. This keeps `enableMetro(true)` and `addImplModuleDependencies(true)` working for AGP-only modules while preserving KMP/JVM and legacy Kotlin Android behavior.