### PR TITLE
Add release helper script

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,39 +1,70 @@
 # Production Releases
 
+Run the release helper from a clean checkout at the same commit as `origin/main`:
+
+```
+./release.sh
+```
+
+The script will:
+
+1. Fetch `origin` and verify that `HEAD` matches `origin/main`.
+2. Ask for the release version.
+3. Move the current `CHANGELOG.md` `Unreleased` section to the release version and today's date.
+4. Remove empty changelog sections, insert a fresh `Unreleased` template, and update the comparison links.
+5. Ask you to review and confirm the changelog diff.
+6. Update `VERSION_NAME` in `gradle.properties` to the release version.
+7. Commit the release, create a matching Git tag, bump `VERSION_NAME` to the next patch `-SNAPSHOT`, and commit that bump.
+
+After the script finishes, push the two commits and tag:
+
+```
+git push && git push --tags
+```
+
+Pushing the tag starts the GitHub Actions release workflow, which publishes to Maven Central and creates the GitHub release.
+
+## Manual fallback
+
+If you need to do the release without the script, use the same steps manually:
+
 1. Checkout `origin/main`.
-2. Update the `CHANGELOG.md` file with the changes of this release (the format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+2. Update `CHANGELOG.md` using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format:
    * Copy the template for the next unreleased version at the top.
-   * Delete unused section in the new release.
-   * Update the links at the bottom of the CHANGELOG.md file and don't forget to change the link for the unreleased version.
-3. Update the version in `gradle.properties` and remove the `-SNAPSHOT` suffix.
+   * Delete unused sections in the new release.
+   * Update the links at the bottom of `CHANGELOG.md`, including the `Unreleased` link.
+3. Update `VERSION_NAME` in `gradle.properties` and remove the `-SNAPSHOT` suffix.
 4. Commit the changes and create a tag:
    ```
    git commit -am "Releasing 0.1.0."
    git tag 0.1.0
    ```
-5. Update the version in `gradle.properties` and add the `-SNAPSHOT` suffix.
+5. Update `VERSION_NAME` in `gradle.properties` to the next `-SNAPSHOT` version.
 6. Commit the change:
    ```
    git commit -am "Prepare next development version."
    ```
-7. Push the two commits. This will start a Github action that publishes the release to Maven Central and creates a new release on Github.
+7. Push the two commits and tag:
    ```
    git push && git push --tags
    ```
 
 # Snapshot Releases
 
-Snapshot releases are automatically created whenever a commit to the `main` branch is pushed.
+Snapshot releases are automatically created whenever a non-documentation commit is pushed to `main`.
 
 # Manually uploading a release
 
 Depending on the version in the `gradle.properties` file it will be either a production or snapshot release.
+
 ```
 ./gradlew clean publish --no-build-cache
+./gradlew -p gradle-plugin clean publish --no-build-cache
 ```
 
 # Installing in Maven Local
 
 ```
 ./gradlew publishToMavenLocal
+./gradlew -p gradle-plugin publishToMavenLocal
 ```

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,214 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO_URL="https://github.com/vRallev/app-platform"
+UNRELEASED_TEMPLATE="## [Unreleased]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+### Other Notes & Contributions"
+
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Error: Working tree is not clean. Commit, stash, or remove local changes before releasing."
+  echo ""
+  git status --short
+  exit 1
+fi
+
+if ! grep -q '^VERSION_NAME=' gradle.properties; then
+  echo "Error: Could not find VERSION_NAME in gradle.properties."
+  exit 1
+fi
+
+if ! grep -q '^## \[Unreleased\]$' CHANGELOG.md; then
+  echo "Error: Could not find an Unreleased section in CHANGELOG.md."
+  exit 1
+fi
+
+# Ensure we're on the same commit as origin/main.
+git fetch origin
+LOCAL=$(git rev-parse HEAD)
+REMOTE=$(git rev-parse origin/main)
+if [ "$LOCAL" != "$REMOTE" ]; then
+  echo "Error: HEAD ($LOCAL) does not match origin/main ($REMOTE)."
+  echo "Please checkout origin/main before releasing."
+  exit 1
+fi
+
+# Ask for the release version.
+CURRENT_VERSION=$(sed -n 's/^VERSION_NAME=//p' gradle.properties)
+echo "Current version: $CURRENT_VERSION"
+read -rp "Enter the version of the new release: " VERSION
+if [ -z "$VERSION" ]; then
+  echo "Error: No version entered."
+  exit 1
+fi
+
+# Validate the version and warn if it doesn't look right.
+WARNINGS=()
+MAJOR=""
+MINOR=""
+PATCH=""
+
+# Check semantic versioning format (MAJOR.MINOR.PATCH).
+if [[ "$VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+  MAJOR="${BASH_REMATCH[1]}"
+  MINOR="${BASH_REMATCH[2]}"
+  PATCH="${BASH_REMATCH[3]}"
+else
+  WARNINGS+=("'$VERSION' does not follow semantic versioning (expected MAJOR.MINOR.PATCH).")
+fi
+
+# Check that the version is higher than the latest release in CHANGELOG.md.
+LATEST=$(grep -oE '## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true)
+if [ -n "$LATEST" ] && [ -n "$MAJOR" ]; then
+  version_to_num() {
+    IFS='.' read -r a b c <<< "$1"
+    echo $((a * 1000000 + b * 1000 + c))
+  }
+  if [ "$(version_to_num "$VERSION")" -le "$(version_to_num "$LATEST")" ]; then
+    WARNINGS+=("'$VERSION' is not higher than the latest release '$LATEST'.")
+  fi
+fi
+
+if [ ${#WARNINGS[@]} -gt 0 ]; then
+  echo ""
+  for w in "${WARNINGS[@]}"; do
+    echo "Warning: $w"
+  done
+  echo ""
+  read -rp "Continue anyway? [Y/n]: " CONFIRM
+  case "$CONFIRM" in
+    [Yy] | [Yy]es) ;;
+    *)
+      echo "Aborting."
+      exit 1
+      ;;
+  esac
+fi
+
+# Back up CHANGELOG.md before modifying it so we can restore the user's uncommitted
+# edits if they decline the changes.
+CHANGELOG_BACKUP=$(mktemp)
+cp CHANGELOG.md "$CHANGELOG_BACKUP"
+
+# Update CHANGELOG.md: replace [Unreleased] header with the release version and date,
+# then insert a fresh unreleased template above it.
+TODAY=$(date +%Y-%m-%d)
+CHANGELOG_TMP=$(mktemp)
+awk -v version="$VERSION" -v today="$TODAY" '
+  !done && $0 == "## [Unreleased]" {
+    print "## [" version "] - " today
+    done = 1
+    next
+  }
+  { print }
+' CHANGELOG.md > "$CHANGELOG_TMP"
+mv "$CHANGELOG_TMP" CHANGELOG.md
+
+# Remove empty ### sections from the release. A section is empty if it has only blank lines
+# before the next header (### or ##) or a link reference line.
+CHANGELOG_TMP=$(mktemp)
+awk '
+  /^###/ { pending = $0; next }
+  /^##/ || /^\[/ { pending = ""; print; next }
+  pending && /^[[:space:]]*$/ { next }
+  pending { print pending; print ""; pending = ""; print; next }
+  { print }
+' CHANGELOG.md > "$CHANGELOG_TMP"
+mv "$CHANGELOG_TMP" CHANGELOG.md
+
+# Insert a fresh unreleased template above the new release header.
+# Split the file at the first "## [" header and reassemble with the template in between.
+HEADER=$(sed -n '1,/^## \[/{ /^## \[/!p; }' CHANGELOG.md)
+REST=$(sed -n '/^## \[/,$p' CHANGELOG.md)
+printf '%s\n\n%s\n\n\n%s\n' "$HEADER" "$UNRELEASED_TEMPLATE" "$REST" > CHANGELOG.md
+
+# Update the links at the bottom of CHANGELOG.md.
+# Update the [Unreleased] link and insert the new version link after it.
+CHANGELOG_TMP=$(mktemp)
+awk -v repo_url="$REPO_URL" -v version="$VERSION" '
+  /^\[Unreleased\]: / {
+    print "[Unreleased]: " repo_url "/compare/" version "...HEAD"
+    print "[" version "]: " repo_url "/compare/" version
+    next
+  }
+  { print }
+' CHANGELOG.md > "$CHANGELOG_TMP"
+mv "$CHANGELOG_TMP" CHANGELOG.md
+
+# Show the user what changed and ask for confirmation.
+echo ""
+echo "CHANGELOG.md has been updated. Please review the changes:"
+echo ""
+git diff CHANGELOG.md
+echo ""
+read -rp "Does CHANGELOG.md contain all entries for this release? [Y/n]: " CONFIRM
+case "$CONFIRM" in
+  [Yy] | [Yy]es) ;;
+  *)
+    echo "Aborting. Restoring CHANGELOG.md to its previous state."
+    cp "$CHANGELOG_BACKUP" CHANGELOG.md
+    rm -f "$CHANGELOG_BACKUP"
+    exit 1
+    ;;
+esac
+rm -f "$CHANGELOG_BACKUP"
+
+# Compute the next snapshot version by bumping the patch number.
+if [ -z "$MAJOR" ]; then
+  read -rp "Enter the next development version: " NEXT_VERSION
+  if [ -z "$NEXT_VERSION" ]; then
+    echo "Error: No next development version entered."
+    exit 1
+  fi
+else
+  NEXT_PATCH=$((PATCH + 1))
+  NEXT_VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}-SNAPSHOT"
+fi
+
+echo ""
+echo "Release version:          $VERSION"
+echo "Next development version: $NEXT_VERSION"
+echo ""
+
+# Update gradle.properties to the release version.
+GRADLE_PROPERTIES_TMP=$(mktemp)
+awk -v version="$VERSION" '
+  /^VERSION_NAME=/ { print "VERSION_NAME=" version; next }
+  { print }
+' gradle.properties > "$GRADLE_PROPERTIES_TMP"
+mv "$GRADLE_PROPERTIES_TMP" gradle.properties
+
+# Commit and tag the release.
+git commit -am "Releasing $VERSION."
+git tag "$VERSION"
+
+# Update gradle.properties to the next snapshot version.
+GRADLE_PROPERTIES_TMP=$(mktemp)
+awk -v version="$NEXT_VERSION" '
+  /^VERSION_NAME=/ { print "VERSION_NAME=" version; next }
+  { print }
+' gradle.properties > "$GRADLE_PROPERTIES_TMP"
+mv "$GRADLE_PROPERTIES_TMP" gradle.properties
+
+# Commit the snapshot version bump.
+git commit -am "Prepare next development version."
+
+echo ""
+echo "Done! Two commits created and tag '$VERSION' applied."
+echo ""
+echo "To publish the release, push the commits and tag:"
+echo ""
+echo "   git push && git push --tags"
+echo ""


### PR DESCRIPTION
Make production releases less error-prone by codifying the changelog, version, tag, and next snapshot sequence in `release.sh`. Update `RELEASING.md` so maintainers have a script-first path while retaining the manual fallback.