### PR TITLE
Add Compose robot tests to KMP app modules

### DIFF
--- a/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/AppPlatformExtension.kt
+++ b/gradle-plugin/src/main/kotlin/software/amazon/app/platform/gradle/AppPlatformExtension.kt
@@ -407,6 +407,9 @@ private fun Project.enableMoleculePresenterBackstack() {
 }
 
 private fun Project.enableComposeUi() {
+  val robotComposeDependency =
+    "$APP_PLATFORM_GROUP:robot-compose-multiplatform-public:$APP_PLATFORM_VERSION"
+
   plugins.withId(PluginIds.KOTLIN_MULTIPLATFORM) {
     plugins.apply(PluginIds.COMPOSE_COMPILER)
     plugins.apply(PluginIds.COMPOSE_MULTIPLATFORM)
@@ -420,9 +423,15 @@ private fun Project.enableComposeUi() {
       )
 
       if (isRobotsModule()) {
-        implementation(
-          "$APP_PLATFORM_GROUP:robot-compose-multiplatform-public:$APP_PLATFORM_VERSION"
-        )
+        implementation(robotComposeDependency)
+      }
+    }
+
+    if (isAppModule()) {
+      testingSourceSets.forEach { sourceSetName ->
+        kmpExtension.sourceSets.getByName(sourceSetName).dependencies {
+          implementation(robotComposeDependency)
+        }
       }
     }
   }
@@ -443,17 +452,11 @@ private fun Project.enableComposeUi() {
     )
 
     if (isRobotsModule()) {
-      dependencies.add(
-        "implementation",
-        "$APP_PLATFORM_GROUP:robot-compose-multiplatform-public:$APP_PLATFORM_VERSION",
-      )
+      dependencies.add("implementation", robotComposeDependency)
     }
 
     if (isAppModule()) {
-      dependencies.add(
-        "androidTestImplementation",
-        "$APP_PLATFORM_GROUP:robot-compose-multiplatform-public:$APP_PLATFORM_VERSION",
-      )
+      dependencies.add("androidTestImplementation", robotComposeDependency)
     }
   }
 }

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -42,7 +42,6 @@ dependencies {
 
     androidMainImplementation libs.androidx.activity.compose
 
-    desktopTestImplementation project(':robot-compose-multiplatform:public')
     desktopTestImplementation project(':sample:login:impl-robots')
     desktopTestImplementation project(':sample:user:impl-robots')
 


### PR DESCRIPTION
KMP app modules that enable Compose UI should not need an Android target or manual test dependency just to use App Platform Compose robots. Add the `robot-compose-multiplatform-public` artifact through KMP app test source sets while keeping the existing Android dependency path, and let the sample desktop test rely on the plugin-provided dependency.