### PR TITLE
Cancel superseded PR CI runs

### DIFF
--- a/.github/workflows/blueprints-starter-ci.yml
+++ b/.github/workflows/blueprints-starter-ci.yml
@@ -12,6 +12,10 @@ on:
       - 'blueprints/starter/**'
       - '.github/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
       - '**/*.md'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 


### PR DESCRIPTION
New pushes to the same PR should stop older in-progress CI runs to reduce runner time and status noise. The workflows now group PR runs by PR number while keeping non-PR runs on unique `github.run_id` groups, so `main` push builds continue independently.