### PR TITLE
Upgrade Compose dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/software/amazon/app/platform/gradle/buildsrc/AppPlugin.kt
+++ b/buildSrc/src/main/kotlin/software/amazon/app/platform/gradle/buildsrc/AppPlugin.kt
@@ -27,6 +27,7 @@ public open class AppPlugin : Plugin<Project> {
     target.configureAndroidSettings()
     target.makeSingleVariant()
     target.addDependencies()
+    target.addDependencyConstraints()
     target.configureWasm()
 
     target.plugins.withId(Plugins.COMPOSE_MULTIPLATFORM) { target.configureDesktopApp() }
@@ -52,6 +53,22 @@ public open class AppPlugin : Plugin<Project> {
     allExportedDependencies().forEach { dependency ->
       kmpExtension.sourceSets.getByName("commonMain").dependencies { api(dependency) }
     }
+  }
+
+  private fun Project.addDependencyConstraints() {
+    // This is needed for Lint in app modules:
+    //
+    // Could not determine the dependencies of task
+    // ':recipes:app:generateDebugAndroidTestLintModel'.
+    //  > Could not resolve all dependencies for configuration
+    // ':recipes:app:debugAndroidTestRuntimeClasspath'.
+    //   > Could not resolve androidx.concurrent:concurrent-futures:1.2.0.
+    //
+    // TODO: Remove when upgrading AGP.
+    dependencies.constraints.add(
+      "androidMainImplementation",
+      libs.findLibrary("androidx.concurrent.futures").get().get().toString(),
+    )
   }
 
   @OptIn(ExperimentalWasmDsl::class)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ agp-gradle-plugin = "9.2.1"
 android-compileSdk = "36"
 # https://developer.android.com/jetpack/androidx/releases/compose-ui
 # https://maven.google.com/web/index.html#androidx.compose.ui:ui
-android-compose-version = "1.11.1"
+android-compose-version = "1.11.4"
 android-minSdk = "23"
 android-targetSdk = "36"
 ios-deploymentTarget = "26.0"
@@ -12,6 +12,7 @@ ios-deploymentTarget = "26.0"
 androidx-activity = "1.13.0"
 androidx-annotations = "1.9.1"
 androidx-collection = "1.5.0"
+androidx-concurrent-futures = "1.2.0"
 androidx-lifecycle = "2.9.4"
 #noinspection GradleDependency
 androidx-constraintlayout = "2.1.4"
@@ -31,7 +32,7 @@ build-config = "6.0.10"
 # https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-compatibility-and-versioning.html#kotlin-compatibility
 # https://mvnrepository.com/artifact/org.jetbrains.compose/compose-gradle-plugin
 # https://github.com/JetBrains/compose-multiplatform/releases
-compose-multiplatform = "1.11.0"
+compose-multiplatform = "1.11.1"
 coroutines = "1.11.0"
 detekt = "2.0.0-alpha.5"
 graphviz-java = "0.18.1"
@@ -67,6 +68,7 @@ android-gradle-plugin-api-gradle-plugin = { module = "com.android.tools.build:gr
 androidx-activity = { module = "androidx.activity:activity", version.ref = "androidx-activity" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-annotations = { module = "androidx.annotation:annotation", version.ref = "androidx-annotations" }
+androidx-concurrent-futures = { module = "androidx.concurrent:concurrent-futures", version.ref = "androidx-concurrent-futures" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-collection = { module = "androidx.collection:collection", version.ref = "androidx-collection" }


### PR DESCRIPTION
Adopt the latest Compose Multiplatform and AndroidX Compose patch releases so supported Android, iOS, and Wasm apps receive their runtime, text-layout, performance, keyboard-access, and accessibility fixes.

Add an `androidx.concurrent:concurrent-futures` constraint for app modules to keep Android test lint dependency resolution working until the underlying AGP issue is removed by an upgrade.