### PR TITLE
Remove ConstraintLayout and disable MagicNumber checks

### DIFF
--- a/gradle/detekt-config.yml
+++ b/gradle/detekt-config.yml
@@ -7,11 +7,7 @@ style:
   DataClassShouldBeImmutable:
     active: true
   MagicNumber:
-    # Magic numbers in enums should be ignored
-    ignoreEnums: true
-    # The next two parameters are recommended for Compose: https://detekt.dev/docs/introduction/compose/
-    ignorePropertyDeclaration: true
-    ignoreCompanionObjectPropertyDeclaration: true
+    active: false
   UnusedPrivateClass:
     # Recommended for Compose: https://detekt.dev/docs/introduction/compose/
     ignoreAnnotated: ['Preview']

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,8 +19,6 @@ androidx-concurrent-futures = "1.2.0"
 # Do not upgrade, which would force the higher version for consumers.
 androidx-lifecycle = "2.9.4"
 # Do not upgrade, which would force the higher version for consumers.
-androidx-constraintlayout = "2.1.4"
-# Do not upgrade, which would force the higher version for consumers.
 androidx-core = "1.10.1"
 androidx-lint-gradle = "1.0.0"
 androidx-test-espresso = "3.7.0"
@@ -73,7 +71,6 @@ androidx-activity = { module = "androidx.activity:activity", version.ref = "andr
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-annotations = { module = "androidx.annotation:annotation", version.ref = "androidx-annotations" }
 androidx-concurrent-futures = { module = "androidx.concurrent:concurrent-futures", version.ref = "androidx-concurrent-futures" }
-androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-collection = { module = "androidx.collection:collection", version.ref = "androidx-collection" }
 androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime", version.ref = "androidx-lifecycle" }

--- a/sample/templates/impl/build.gradle
+++ b/sample/templates/impl/build.gradle
@@ -13,7 +13,3 @@ appPlatform {
     enableModuleStructure true
     enableMoleculePresenters true
 }
-
-dependencies {
-    androidMainImplementation libs.androidx.constraintlayout
-}

--- a/sample/templates/impl/src/androidMain/kotlin/software/ralf/app/platform/sample/template/AndroidSampleAppTemplateRenderer.kt
+++ b/sample/templates/impl/src/androidMain/kotlin/software/ralf/app/platform/sample/template/AndroidSampleAppTemplateRenderer.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.constraintlayout.widget.ConstraintLayout
 import software.ralf.app.platform.renderer.RendererFactory
 import software.ralf.app.platform.renderer.template.AndroidTemplateRenderer
 import software.ralf.app.platform.sample.templates.impl.R
@@ -15,16 +14,9 @@ import software.ralf.app.platform.sample.templates.impl.R
 // @ContributesRenderer
 class AndroidSampleAppTemplateRenderer(rendererFactory: RendererFactory) :
   AndroidTemplateRenderer<SampleAppTemplate>(rendererFactory) {
-
-  companion object {
-    private const val ELEVATION = 24f
-  }
-
   private lateinit var fullScreenContainer: Container
   private lateinit var listContainer: Container
   private lateinit var detailContainer: Container
-
-  private lateinit var rootView: ConstraintLayout
 
   override fun inflate(
     activity: Activity,
@@ -33,13 +25,11 @@ class AndroidSampleAppTemplateRenderer(rendererFactory: RendererFactory) :
     initialModel: SampleAppTemplate,
   ): View {
     return layoutInflater.inflate(R.layout.sample_app_template_root, parent, false).also {
-      rootView = it as ConstraintLayout
-
       fullScreenContainer = Container(activity, it.findViewById(R.id.full_screen_container), null)
 
       it.findViewById<ViewGroup>(R.id.list).apply {
         this.clipToOutline = true
-        this.elevation = ELEVATION
+        this.elevation = 24f
         listContainer = Container(activity, this, null)
       }
 

--- a/sample/templates/impl/src/androidMain/res/layout/sample_app_template_root.xml
+++ b/sample/templates/impl/src/androidMain/res/layout/sample_app_template_root.xml
@@ -1,9 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:baselineAligned="false"
+        android:orientation="horizontal"
+        android:weightSum="10">
+
+        <FrameLayout
+            android:id="@+id/list"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="3" />
+
+        <FrameLayout
+            android:id="@+id/detail"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="7" />
+    </LinearLayout>
 
     <FrameLayout
         android:id="@+id/full_screen_container"
@@ -11,31 +29,4 @@
         android:layout_height="match_parent"
         android:visibility="gone" />
 
-    <FrameLayout
-        android:id="@+id/list"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="@id/list_end_guideline"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        />
-
-    <FrameLayout
-        android:id="@+id/detail"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:layout_constraintStart_toEndOf="@id/list_end_guideline"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"/>
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/list_end_guideline"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.3"
-        tools:viewBindingType="android.view.View" />
-
-</androidx.constraintlayout.widget.ConstraintLayout>
+</RelativeLayout>


### PR DESCRIPTION
**Remove ConstraintLayout from the sample template:**
Keep the sample template lightweight by preserving its 30/70 list-detail layout with platform views and eliminating the otherwise single-use `androidx.constraintlayout:constraintlayout` artifact.

**Disable Detekt's MagicNumber rule:**
Allow numeric literals to follow the project coding guidelines without forcing single-use constants or scattered suppressions by disabling `MagicNumber` in the shared Detekt configuration.
