### PR TITLE
Enable parallel IDE sync

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,7 @@ GROUP=software.ralf.app.platform
 org.gradle.jvmargs=-Xmx8g -Dfile.encoding=UTF-8
 org.gradle.daemon=true
 org.gradle.parallel=true
+org.gradle.tooling.parallel=true
 org.gradle.caching=true
 
 org.gradle.configuration-cache=true


### PR DESCRIPTION
Set `org.gradle.tooling.parallel` explicitly so Android Studio and other Tooling API clients can build project models concurrently, reducing sync time for this large multi-module project on Gradle 9.4 and newer.