### PR TITLE
Publish the list-detail blueprint in the wiki

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,8 +48,33 @@ jobs:
             ./sample/app/build/dist/wasmJs/productionExecutable/
             ./recipes/app/build/dist/wasmJs/productionExecutable/
 
+  build-wasm-list-detail-blueprint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup
+        uses: ./.github/actions/setup-action
+        with:
+          gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+      - name: Build list-detail blueprint wasm binary
+        working-directory: blueprints/list-detail
+        run: ./gradlew :app:web:wasmJsBrowserDistribution
+
+      - name: Upload list-detail blueprint wasm binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-list-detail-files
+          path: blueprints/list-detail/app/web/build/dist/wasmJs/productionExecutable/
+          if-no-files-found: error
+
   build-mkdocs:
-    needs: build-wasm-sample-app
+    needs:
+      - build-wasm-sample-app
+      - build-wasm-list-detail-blueprint
     runs-on: ubuntu-latest
 
     steps:
@@ -63,6 +88,11 @@ jobs:
         with:
           name: wasm-files
           path: docs/web
+      - name: Download list-detail blueprint wasm binary
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-list-detail-files
+          path: docs/web/blueprints/list-detail/app/web/build/dist/wasmJs/productionExecutable
       - run: |
           cp CHANGELOG.md docs/changelog.md
       - run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Add the advanced `blueprints/list-detail` Kotlin Multiplatform blueprint with a modular architecture, adaptive phone and tablet navigation, bundled character portraits, four platform shells, and dedicated CI.
+- Publish the list-detail blueprint as a horizontally resizable, interactive WebAssembly example in the documentation site.
 
 ### Changed
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,10 @@ writing Kotlin Multiplatform effectively.
 === "Web Recipe App"
     <iframe src="web/recipes/app/build/dist/wasmJs/productionExecutable/index.html" width="300px" height="600px" frameborder="1"></iframe>
 
+=== "Web List-Detail Blueprint"
+    <div class="blueprint-demo"><iframe src="web/blueprints/list-detail/app/web/build/dist/wasmJs/productionExecutable/index.html" title="Interactive list-detail blueprint"></iframe></div>
+    <p class="blueprint-demo__hint">Drag the bottom-right corner horizontally to switch between phone and tablet layouts.</p>
+
 ## Overview
 
 App Platform combines several features as a single framework. While all of them are optional, together they help
@@ -99,6 +103,8 @@ structure is enabled.
 ## Getting Started
 
 App Platform gives you a working Kotlin Multiplatform setup out of the box, with support for Android, iOS, Desktop, and Web (WASM). The fastest way to get started is by using the [blueprints/starter](https://github.com/vRallev/app-platform/tree/main/blueprints/starter) project — a fully functional example app that already uses App Platform and applies everything the platform provides, including the module structure, dependency injection, scopes, presenters, and renderers.
+
+For an advanced example, see the [list-detail blueprint](https://github.com/vRallev/app-platform/tree/main/blueprints/list-detail), which demonstrates adaptive phone and tablet layouts, shared presenters and renderers, Metro dependency injection, and platform-specific app shells. The **Web List-Detail Blueprint** tab above lets you run its WebAssembly app directly in the browser.
 
 ### Copy the Starter App
 

--- a/docs/stylesheets/blueprints.css
+++ b/docs/stylesheets/blueprints.css
@@ -1,0 +1,22 @@
+.blueprint-demo {
+  border: 1px solid var(--md-default-fg-color--lightest);
+  box-sizing: border-box;
+  height: 600px;
+  max-width: 100%;
+  min-width: min(300px, 100%);
+  overflow: auto;
+  resize: horizontal;
+  width: min(300px, 100%);
+}
+
+.blueprint-demo iframe {
+  border: 0;
+  display: block;
+  height: 100%;
+  width: 100%;
+}
+
+.blueprint-demo__hint {
+  color: var(--md-default-fg-color--light);
+  font-size: 0.8rem;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ theme:
     edit: material/pencil
 
 extra_css:
+  - stylesheets/blueprints.css
   - stylesheets/diagrams.css
 
 markdown_extensions:


### PR DESCRIPTION
Let readers explore the adaptive `blueprints/list-detail` app directly in the wiki and see how its phone and tablet layouts respond to available space. Build the standalone WebAssembly distribution with its own wrapper and publish all application assets alongside the existing samples so the embedded demo remains reliable.