### PR TITLE
Give structured modules unique archive names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 ### Fixed
 
+- Give module-structured projects unique default archive names based on their artifact IDs while preserving explicitly configured archive names.
+
 ### Security
 
 ### Other Notes & Contributions

--- a/docs/module-structure.md
+++ b/docs/module-structure.md
@@ -344,6 +344,7 @@ With this setting enabled, several checks and features are enabled:
 
 * App Platform ensures that the Gradle module follows the naming convention, e.g. it's named `:public` or `:impl`.
 * Default dependencies are added, e.g. an `:impl` module imports its `:public` module by default, or `:impl-robots` imports its `:impl` module by default.
+* Archive names default to `Project.artifactId()`, e.g. `:my-module:impl` produces `my-module-impl`, so modules with the same leaf name do not overwrite each other's artifacts. Explicitly configured archive names are preserved.
 * An [Android namespace](https://developer.android.com/build/configure-app-module#set-namespace) is set [automatically](https://github.com/vRallev/app-platform/blob/main/gradle-plugin/src/main/kotlin/software/ralf/app/platform/gradle/ModuleStructurePlugin.kt#L90-L110) if it hasn't been configured yet.
 * A Gradle task `:checkModuleStructureDependencies` is registered, which verifies that module structure dependency rules are followed. The `:check` Gradle task automatically depends on `:checkModuleStructureDependencies`.
 * A consistent API for an [`Project.artifactId`](https://github.com/vRallev/app-platform/blob/main/gradle-plugin/src/main/kotlin/software/ralf/app/platform/gradle/ModuleStructurePlugin.kt#L125-L135) is available, e.g. for `:my-module:public` it would return `my-module-public`.

--- a/gradle-plugin/src/main/kotlin/software/ralf/app/platform/gradle/ModuleStructurePlugin.kt
+++ b/gradle-plugin/src/main/kotlin/software/ralf/app/platform/gradle/ModuleStructurePlugin.kt
@@ -2,6 +2,7 @@ package software.ralf.app.platform.gradle
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.plugins.BasePluginExtension
 import software.ralf.app.platform.gradle.ModuleStructureDependencyCheckTask.Companion.registerModuleStructureDependencyCheckTask
 
 /** The Gradle plugin that sets up our module structure. */
@@ -9,6 +10,7 @@ public open class ModuleStructurePlugin : Plugin<Project> {
   override fun apply(target: Project) {
     target.ensureFollowsNamingConvention()
     target.addModuleStructureDependencies()
+    target.configureArtifactName()
     target.configureAndroidNamespace()
     target.registerModuleStructureDependencyCheckTask()
   }
@@ -78,6 +80,13 @@ public open class ModuleStructurePlugin : Plugin<Project> {
         publicModuleConfiguration = "api",
         implModuleConfiguration = "implementation",
       )
+    }
+  }
+
+  private fun Project.configureArtifactName() {
+    plugins.withId("base") {
+      // A convention replaces Gradle's project-name default while preserving explicit overrides.
+      extensions.getByType(BasePluginExtension::class.java).archivesName.convention(artifactId())
     }
   }
 

--- a/gradle-plugin/src/test/kotlin/software/ralf/app/platform/gradle/ModuleStructurePluginTest.kt
+++ b/gradle-plugin/src/test/kotlin/software/ralf/app/platform/gradle/ModuleStructurePluginTest.kt
@@ -2,6 +2,7 @@ package software.ralf.app.platform.gradle
 
 import assertk.assertThat
 import assertk.assertions.contains
+import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isTrue
 import kotlin.test.Test
@@ -9,11 +10,64 @@ import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.api.plugins.BasePluginExtension
+import org.gradle.api.provider.Property
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.gradle.testfixtures.ProjectBuilder
 import software.ralf.app.platform.gradle.AppPlatformExtension.Companion.appPlatform
 
 class ModuleStructurePluginTest {
+
+  @Test
+  fun `Gradle defaults archive names to the project name`() {
+    val project = createImplModule()
+
+    project.plugins.apply("base")
+
+    assertThat(project.archivesName.get()).isEqualTo("impl")
+  }
+
+  @Test
+  fun `module structure derives archive names from artifact IDs`() {
+    val project = createImplModule()
+    project.plugins.apply("base")
+
+    project.appPlatform.enableModuleStructure(true)
+
+    assertThat(project.archivesName.get()).isEqualTo("library-impl")
+  }
+
+  @Test
+  fun `module structure preserves archive names configured before it is enabled`() {
+    val project = createImplModule()
+    project.plugins.apply("base")
+    project.archivesName.set("custom-archive")
+
+    project.appPlatform.enableModuleStructure(true)
+
+    assertThat(project.archivesName.get()).isEqualTo("custom-archive")
+  }
+
+  @Test
+  fun `module structure allows archive names to be configured after it is enabled`() {
+    val project = createImplModule()
+    project.plugins.apply("base")
+    project.appPlatform.enableModuleStructure(true)
+
+    project.archivesName.set("custom-archive")
+
+    assertThat(project.archivesName.get()).isEqualTo("custom-archive")
+  }
+
+  @Test
+  fun `module structure configures archive names when the base plugin is applied later`() {
+    val project = createImplModule()
+    project.appPlatform.enableModuleStructure(true)
+
+    project.plugins.apply("base")
+
+    assertThat(project.archivesName.get()).isEqualTo("library-impl")
+  }
 
   @Test
   fun `module structure dependency checks are enabled by default`() {
@@ -105,6 +159,9 @@ class ModuleStructurePluginTest {
     project.plugins.apply(AppPlatformPlugin::class.java)
     return project
   }
+
+  private val Project.archivesName: Property<String>
+    get() = extensions.getByType(BasePluginExtension::class.java).archivesName
 
   private fun Project.dependencyCheckTask(): ModuleStructureDependencyCheckTask =
     tasks


### PR DESCRIPTION
Gradle defaults archive names to leaf project names, causing role-based modules such as `impl` to collide in distributions. Derive the archive-name convention from `artifactId()` so artifacts are distinct while explicit consumer overrides remain supported.