### PR TITLE
Keep blueprint preview resizing from hijacking app clicks

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,7 @@ writing Kotlin Multiplatform effectively.
     <iframe src="web/recipes/app/build/dist/wasmJs/productionExecutable/index.html" width="300px" height="600px" frameborder="1"></iframe>
 
 === "Web List-Detail Blueprint"
-    <div class="blueprint-demo"><iframe src="web/blueprints/list-detail/app/web/build/dist/wasmJs/productionExecutable/index.html" title="Interactive list-detail blueprint"></iframe></div>
+    <div class="blueprint-demo"><iframe src="web/blueprints/list-detail/app/web/build/dist/wasmJs/productionExecutable/index.html" title="Interactive list-detail blueprint"></iframe><button class="blueprint-demo__resize-handle" type="button" aria-label="Resize app preview"></button></div>
     <p class="blueprint-demo__hint">Drag the bottom-right corner horizontally to switch between phone and tablet layouts.</p>
 
 ## Overview

--- a/docs/javascripts/blueprints.js
+++ b/docs/javascripts/blueprints.js
@@ -1,0 +1,64 @@
+document.addEventListener("pointerdown", (event) => {
+  if (!(event.target instanceof Element) || event.button !== 0) {
+    return;
+  }
+
+  const handle = event.target.closest(".blueprint-demo__resize-handle");
+  const demo = handle?.closest(".blueprint-demo");
+
+  if (!demo) {
+    return;
+  }
+
+  event.preventDefault();
+
+  const pointerId = event.pointerId;
+  const initialWidth = demo.getBoundingClientRect().width;
+  const initialX = event.clientX;
+
+  const resize = (moveEvent) => {
+    if (moveEvent.pointerId === pointerId) {
+      demo.style.width = `${Math.max(0, initialWidth + moveEvent.clientX - initialX)}px`;
+    }
+  };
+
+  const stopResizing = (stopEvent) => {
+    if (stopEvent.pointerId !== pointerId) {
+      return;
+    }
+
+    demo.classList.remove("blueprint-demo--resizing");
+    handle.removeEventListener("pointermove", resize);
+    handle.removeEventListener("pointerup", stopResizing);
+    handle.removeEventListener("pointercancel", stopResizing);
+    handle.removeEventListener("lostpointercapture", stopResizing);
+
+    if (handle.hasPointerCapture(pointerId)) {
+      handle.releasePointerCapture(pointerId);
+    }
+  };
+
+  handle.addEventListener("pointermove", resize);
+  handle.addEventListener("pointerup", stopResizing);
+  handle.addEventListener("pointercancel", stopResizing);
+  handle.addEventListener("lostpointercapture", stopResizing);
+  handle.setPointerCapture(pointerId);
+  demo.classList.add("blueprint-demo--resizing");
+});
+
+document.addEventListener("keydown", (event) => {
+  if (!(event.target instanceof Element)) {
+    return;
+  }
+
+  const handle = event.target.closest(".blueprint-demo__resize-handle");
+  const demo = handle?.closest(".blueprint-demo");
+  const direction = event.key === "ArrowRight" ? 1 : event.key === "ArrowLeft" ? -1 : 0;
+
+  if (!demo || direction === 0) {
+    return;
+  }
+
+  event.preventDefault();
+  demo.style.width = `${Math.max(0, demo.getBoundingClientRect().width + direction * 24)}px`;
+});

--- a/docs/stylesheets/blueprints.css
+++ b/docs/stylesheets/blueprints.css
@@ -4,8 +4,8 @@
   height: 600px;
   max-width: 100%;
   min-width: min(300px, 100%);
-  overflow: auto;
-  resize: horizontal;
+  overflow: hidden;
+  position: relative;
   width: min(300px, 100%);
 }
 
@@ -14,6 +14,43 @@
   display: block;
   height: 100%;
   width: 100%;
+}
+
+.blueprint-demo--resizing iframe {
+  pointer-events: none;
+}
+
+.blueprint-demo__resize-handle {
+  background: transparent;
+  border: 0;
+  bottom: 0;
+  cursor: ew-resize;
+  height: 20px;
+  padding: 0;
+  position: absolute;
+  right: 0;
+  touch-action: none;
+  width: 20px;
+}
+
+.blueprint-demo__resize-handle::after {
+  background: repeating-linear-gradient(
+    135deg,
+    transparent 0 3px,
+    var(--md-default-fg-color--light) 3px 4px
+  );
+  bottom: 3px;
+  clip-path: polygon(100% 0, 100% 100%, 0 100%);
+  content: "";
+  height: 12px;
+  position: absolute;
+  right: 3px;
+  width: 12px;
+}
+
+.blueprint-demo__resize-handle:focus-visible {
+  outline: 2px solid var(--md-accent-fg-color);
+  outline-offset: -2px;
 }
 
 .blueprint-demo__hint {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,9 @@ extra_css:
   - stylesheets/blueprints.css
   - stylesheets/diagrams.css
 
+extra_javascript:
+  - javascripts/blueprints.js
+
 markdown_extensions:
   - smarty
   - codehilite:


### PR DESCRIPTION
Native `resize: horizontal` can lose pointer-release events to the embedded iframe, making the next app click unexpectedly resize the preview. Use a dedicated pointer-captured handle that temporarily disables iframe hit-testing so phone and tablet previews remain predictable and keyboard accessible.